### PR TITLE
feat: add launcher icon visibility toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ AM++ 是面向 libxposed API 102 的 Apple Music 增强模块。目前主要针�
 | 平板动态视频抑制 | 开启 | 平板横屏的 Editorial Video | 可用 |
 | 未来歌词模糊 | 开启 | Android 12 及以上 | 可用 |
 | 手机液态玻璃底栏 | 关闭 | Apple Music 官方 `is_tablet=false` | **WIP** |
+| 隐藏启动器图标 | 关闭 | AM++ 设置应用 | 可用 |
 
 手机液态玻璃会为底部导航栏和迷你播放器增加实时背景模糊、半透明材质与选中项胶囊。该功能仍可能在冷启动或全屏播放器收回时出现单帧闪烁，因此默认关闭并统一标记为 WIP。
 
@@ -56,9 +57,9 @@ AM++ 是面向 libxposed API 102 的 Apple Music 增强模块。目前主要针�
 2. 在 LSPosed 中启用 **AM++**。
 3. 仅选择 Apple Music（`com.apple.android.music`）作为作用域。
 4. 强制停止并重新打开 Apple Music。
-5. 从桌面打开模块设置页，根据需要调整功能。
+5. 从桌面打开模块设置页，根据需要调整功能。隐藏启动器图标后，可从 LSPosed 的模块详情重新打开设置。
 
-设置修改后需要强制停止并重新打开 Apple Music。设置页显示“已连接 LSPosed API 102”后才能写入框架托管的 remote preferences。
+Apple Music 功能修改后需要强制停止并重新打开目标应用。设置页显示“已连接 LSPosed API 102”后才能写入框架托管的 remote preferences；隐藏启动器图标是本地组件设置，不依赖该连接。
 
 ## 从源码构建
 
@@ -94,7 +95,7 @@ app/build/outputs/apk/release/app-release.apk
 
 ## 隐私与安全
 
-模块不请求网络、存储或通知权限，也不包含分析服务。设置保存在 Xposed 框架管理的 remote preferences 中；模块不自行暴露配置 Provider、广播接收器或跨应用写入接口。`libxposed/service` 依赖会注册其框架连接所需的 `XposedProvider`。
+模块不请求网络、存储或通知权限，也不包含分析服务。Apple Music 功能设置保存在 Xposed 框架管理的 remote preferences 中；启动器图标状态由 Android PackageManager 本地保存。模块不自行暴露配置 Provider、广播接收器或跨应用写入接口。`libxposed/service` 依赖会注册其框架连接所需的 `XposedProvider`。
 
 ## 项目结构
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,8 +35,8 @@ android {
         applicationId = "dev.amenhancer.module"
         minSdk = 26
         targetSdk = 37
-        versionCode = 80
-        versionName = "1.0.0"
+        versionCode = 82
+        versionName = "1.0.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,10 +14,27 @@
             android:name=".ui.SettingsActivity"
             android:exported="true">
             <intent-filter>
+                <action android:name="android.intent.action.APPLICATION_PREFERENCES" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.INFO" />
+            </intent-filter>
+        </activity>
+
+        <activity-alias
+            android:name=".LauncherAlias"
+            android:enabled="true"
+            android:exported="true"
+            android:icon="@drawable/ic_module"
+            android:label="@string/app_name"
+            android:targetActivity=".ui.SettingsActivity">
+            <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-        </activity>
+        </activity-alias>
 
     </application>
 

--- a/app/src/main/java/dev/amenhancer/module/ui/LauncherIconController.kt
+++ b/app/src/main/java/dev/amenhancer/module/ui/LauncherIconController.kt
@@ -1,0 +1,29 @@
+package dev.amenhancer.module.ui
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.PackageManager
+
+internal class LauncherIconController(context: Context) {
+    private val appContext = context.applicationContext
+    private val launcherComponent = ComponentName(
+        appContext,
+        "${appContext.packageName}.LauncherAlias",
+    )
+
+    fun isHidden(): Boolean =
+        appContext.packageManager.getComponentEnabledSetting(launcherComponent) ==
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+
+    fun setHidden(hidden: Boolean) {
+        appContext.packageManager.setComponentEnabledSetting(
+            launcherComponent,
+            if (hidden) {
+                PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+            } else {
+                PackageManager.COMPONENT_ENABLED_STATE_DEFAULT
+            },
+            PackageManager.DONT_KILL_APP,
+        )
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/ui/LauncherIconController.kt
+++ b/app/src/main/java/dev/amenhancer/module/ui/LauncherIconController.kt
@@ -8,7 +8,7 @@ internal class LauncherIconController(context: Context) {
     private val appContext = context.applicationContext
     private val launcherComponent = ComponentName(
         appContext,
-        "${appContext.packageName}.LauncherAlias",
+        LAUNCHER_ALIAS_CLASS,
     )
 
     fun isHidden(): Boolean =
@@ -25,5 +25,9 @@ internal class LauncherIconController(context: Context) {
             },
             PackageManager.DONT_KILL_APP,
         )
+    }
+
+    private companion object {
+        const val LAUNCHER_ALIAS_CLASS = "dev.amenhancer.module.LauncherAlias"
     }
 }

--- a/app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt
+++ b/app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt
@@ -28,6 +28,7 @@ import dev.amenhancer.module.model.ModuleSettings
 
 class SettingsActivity : Activity() {
     private lateinit var store: ConfigStore
+    private lateinit var launcherIconController: LauncherIconController
     private lateinit var content: LinearLayout
     private lateinit var palette: Palette
 
@@ -38,6 +39,7 @@ class SettingsActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         store = ConfigStore(this)
+        launcherIconController = LauncherIconController(this)
         palette = Palette.resolve(this)
         configureSystemBars()
         setContentView(buildScreen().also(::applySystemBarInsets))
@@ -140,6 +142,10 @@ class SettingsActivity : Activity() {
         content.addView(spacer(20))
         content.addView(featureCard(settings, writable))
         content.addView(spacer(24))
+        content.addView(sectionLabel("应用"))
+        content.addView(spacer(10))
+        content.addView(appCard())
+        content.addView(spacer(24))
         content.addView(sectionLabel("帮助"))
         content.addView(spacer(10))
         content.addView(helpRow())
@@ -222,6 +228,22 @@ class SettingsActivity : Activity() {
                 store.saveSettings(store.settings().copy(futureBlurEnabled = enabled))
             })
         }
+
+    private fun appCard(): View = LinearLayout(this).apply {
+        orientation = LinearLayout.VERTICAL
+        background = roundedDrawable(palette.surface, radiusDp = 20, strokeColor = palette.outline)
+        elevation = dp(2).toFloat()
+        clipToOutline = true
+
+        addView(settingRow(
+            title = "隐藏启动器图标",
+            summary = "隐藏后可从 LSPosed 模块详情重新打开设置",
+            checked = launcherIconController.isHidden(),
+            enabled = true,
+        ) { hidden ->
+            launcherIconController.setHidden(hidden)
+        })
+    }
 
     private fun settingRow(
         title: String,

--- a/app/src/test/java/dev/amenhancer/module/ui/LauncherIconVisibilityStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/ui/LauncherIconVisibilityStructuralRegressionTest.kt
@@ -1,0 +1,55 @@
+package dev.amenhancer.module.ui
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LauncherIconVisibilityStructuralRegressionTest {
+    private fun projectFile(relativePath: String): String = sequenceOf(
+        File(relativePath),
+        File("../$relativePath"),
+    ).firstOrNull(File::isFile)?.readText()
+        ?: error("$relativePath was not found from the unit-test working directory")
+
+    @Test
+    fun `launcher icon uses a disableable alias while settings activity stays available`() {
+        val manifest = projectFile("app/src/main/AndroidManifest.xml")
+
+        assertTrue(manifest.contains("<activity-alias"))
+        assertTrue(manifest.contains("android:name=\".LauncherAlias\""))
+        assertTrue(manifest.contains("android:targetActivity=\".ui.SettingsActivity\""))
+        assertTrue(manifest.contains("android.intent.action.APPLICATION_PREFERENCES"))
+        assertTrue(manifest.indexOf("<activity-alias") < manifest.indexOf("android.intent.category.LAUNCHER"))
+        val settingsDeclaration = manifest.substringBefore("<activity-alias")
+        assertTrue(settingsDeclaration.contains("android.intent.action.MAIN"))
+        assertTrue(settingsDeclaration.contains("android.intent.category.INFO"))
+        assertFalse(settingsDeclaration.contains("android.intent.category.LAUNCHER"))
+    }
+
+    @Test
+    fun `component toggle persists locally without killing the settings process`() {
+        val controller = projectFile(
+            "app/src/main/java/dev/amenhancer/module/ui/LauncherIconController.kt",
+        )
+
+        assertTrue(controller.contains("ComponentName("))
+        assertTrue(controller.contains("${'$'}{appContext.packageName}.LauncherAlias"))
+        assertTrue(controller.contains("getComponentEnabledSetting"))
+        assertTrue(controller.contains("setComponentEnabledSetting"))
+        assertTrue(controller.contains("COMPONENT_ENABLED_STATE_DISABLED"))
+        assertTrue(controller.contains("COMPONENT_ENABLED_STATE_DEFAULT"))
+        assertTrue(controller.contains("PackageManager.DONT_KILL_APP"))
+        assertFalse(controller.contains("ModuleApplication.remotePreferences"))
+    }
+
+    @Test
+    fun `settings page exposes an always available launcher visibility switch`() {
+        val activity = projectFile("app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt")
+
+        assertTrue(activity.contains("title = \"隐藏启动器图标\""))
+        assertTrue(activity.contains("checked = launcherIconController.isHidden()"))
+        assertTrue(activity.contains("launcherIconController.setHidden(hidden)"))
+        assertTrue(activity.contains("enabled = true"))
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/ui/LauncherIconVisibilityStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/ui/LauncherIconVisibilityStructuralRegressionTest.kt
@@ -34,7 +34,8 @@ class LauncherIconVisibilityStructuralRegressionTest {
         )
 
         assertTrue(controller.contains("ComponentName("))
-        assertTrue(controller.contains("${'$'}{appContext.packageName}.LauncherAlias"))
+        assertTrue(controller.contains("dev.amenhancer.module.LauncherAlias"))
+        assertFalse(controller.contains("${'$'}{appContext.packageName}.LauncherAlias"))
         assertTrue(controller.contains("getComponentEnabledSetting"))
         assertTrue(controller.contains("setComponentEnabledSetting"))
         assertTrue(controller.contains("COMPONENT_ENABLED_STATE_DISABLED"))


### PR DESCRIPTION
## What changed

- move the home-screen launcher entry to a dedicated `LauncherAlias`
- add a local setting that hides or restores that alias without killing the settings process
- keep an always-enabled `MAIN + INFO` entry so LSPosed Manager can still open AM++ while the desktop icon is hidden
- document the setting and bump the release metadata to `1.0.1` (`versionCode 82`)
- add structural regression coverage for the manifest and PackageManager contract

## Why

Disabling the only `MAIN + LAUNCHER` component successfully hid the desktop icon, but it also left LSPosed Manager without a package launch intent. The dedicated alias plus `MAIN + INFO` split preserves both behaviors.

## Validation

- 46 JVM tests passed
- `assembleRelease` passed
- `lintVitalRelease` passed
- APK v2 signature verification passed
- device regression: hidden `MAIN + LAUNCHER` remains unresolved, `MAIN + INFO` resolves to `SettingsActivity`
- user verified opening AM++ from LSPosed Manager while the desktop icon is hidden