### PR TITLE
Align tablet fullscreen lyric highlight position

### DIFF
--- a/app/src/main/java/dev/amenhancer/module/hook/DualPaneFeature.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/DualPaneFeature.kt
@@ -331,14 +331,22 @@ internal class DualPaneFeature : FeatureHook {
                         ModernXposedRuntime.callMethod(fragment, "f2") as? View
                     }.getOrNull() ?: return
                     if (!TabletModeQualifier.isEligible(controls.context)) return
+                    val highlightAnchorAligned = alignSynchronizedLyricsHighlightAnchor(fragment)
                     val controlsHeight = controls.height
-                    if (controlsHeight == 0) return
-                    val updatedBothBounds = listOf("z0", "A0").all { fieldName ->
-                        subtractControlsHeightFromLyricsBoundary(fragment, fieldName, controlsHeight)
+                    val endPaddingCorrected = controlsHeight == 0 ||
+                        listOf("z0", "A0").all { fieldName ->
+                            subtractControlsHeightFromLyricsBoundary(fragment, fieldName, controlsHeight)
+                        }
+                    if (!endPaddingCorrected) return
+                    if (!highlightAnchorAligned && controlsHeight == 0) {
+                        debug("landscape lyrics metrics unchanged")
+                        return
                     }
-                    if (!updatedBothBounds) return
                     refreshLyricsRecycler(fragment)
-                    debug("corrected landscape lyrics metrics")
+                    debug(
+                        "corrected landscape lyrics metrics highlightAnchorAligned=" +
+                            highlightAnchorAligned + " controlsHeight=" + controlsHeight,
+                    )
                 }
             })
         ) {
@@ -347,6 +355,26 @@ internal class DualPaneFeature : FeatureHook {
             0
         }
     }
+
+    private fun alignSynchronizedLyricsHighlightAnchor(fragment: Any): Boolean = runCatching {
+        val binding = findField(fragment.javaClass, "i0")?.get(fragment)
+            ?: return@runCatching false
+        val container = findField(binding.javaClass, "U")?.get(binding) as? View
+            ?: return@runCatching false
+        if (container.height <= 0) return@runCatching false
+        val metrics = findField(fragment.javaClass, "z0")?.get(fragment)
+            ?: return@runCatching false
+        val highlightOffset = findField(metrics.javaClass, "a")
+            ?: return@runCatching false
+        highlightOffset.setInt(
+            metrics,
+            TabletLyricAnchorPolicy.highlightOffset(
+                currentOffset = highlightOffset.getInt(metrics),
+                containerHeight = container.height,
+            ),
+        )
+        true
+    }.getOrDefault(false)
 
     private fun subtractControlsHeightFromLyricsBoundary(
         fragment: Any,

--- a/app/src/main/java/dev/amenhancer/module/hook/TabletLyricAnchorPolicy.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/TabletLyricAnchorPolicy.kt
@@ -1,0 +1,14 @@
+package dev.amenhancer.module.hook
+
+import kotlin.math.roundToInt
+
+internal object TabletLyricAnchorPolicy {
+    fun highlightOffset(currentOffset: Int, containerHeight: Int): Int {
+        val stockAnchor = (containerHeight * STOCK_ANCHOR_FRACTION).roundToInt()
+        val targetAnchor = (containerHeight * TARGET_ANCHOR_FRACTION).roundToInt()
+        return currentOffset + targetAnchor - stockAnchor
+    }
+
+    private const val STOCK_ANCHOR_FRACTION = 0.08f
+    private const val TARGET_ANCHOR_FRACTION = 0.33f
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/DualPaneStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/DualPaneStructuralRegressionTest.kt
@@ -159,6 +159,8 @@ class DualPaneStructuralRegressionTest {
     fun `mirrors modified landscape lyrics metrics correction`() {
         assertTrue(source.contains("installLandscapeLyricsMetricsHook"))
         assertTrue(source.contains("method.name == \"j2\""))
+        assertTrue(source.contains("alignSynchronizedLyricsHighlightAnchor"))
+        assertTrue(source.contains("TabletLyricAnchorPolicy.highlightOffset"))
         assertTrue(source.contains("listOf(\"z0\", \"A0\")"))
         assertTrue(source.contains("lowerBoundary.getInt(bounds) - controlsHeight"))
         assertTrue(source.contains("ModernXposedRuntime.callMethod(recycler, \"S\")"))

--- a/app/src/test/java/dev/amenhancer/module/hook/TabletLyricAnchorPolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/TabletLyricAnchorPolicyTest.kt
@@ -1,0 +1,17 @@
+package dev.amenhancer.module.hook
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TabletLyricAnchorPolicyTest {
+    @Test
+    fun `moves the synchronized highlight anchor from stock eight percent to thirty three percent`() {
+        assertEquals(
+            787,
+            TabletLyricAnchorPolicy.highlightOffset(
+                currentOffset = 187,
+                containerHeight = 2_400,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- move the synchronized lyric highlight anchor from Apple Music's stock 8% position to 33% of the fullscreen player height
- retain Apple Music's existing top text padding when calculating the adjusted offset
- leave static lyrics, lyric blur behavior, row spacing, horizontal padding, and the established 35sp tablet typography unchanged
- scope the runtime adjustment to eligible tablet-landscape synchronized lyrics only

## Reference alignment

- physical tablet highlighted glyph top: `809/2400 = 33.71%`
- supplied reference highlighted glyph top: `281/835 = 33.65%`
- difference: approximately `0.06` percentage points

## Validation

- `test assembleDebug assembleRelease lintVitalRelease`
- Debug and Release builds and release lint completed successfully
- `git diff --check`
- physical tablet layout remained stable through two fullscreen collapse/expand cycles
- no AM++, AppleMusicEnhancer, or fatal-exception errors during visual validation
- tablet was not rebooted