### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,8 +35,8 @@ android {
         applicationId = "dev.amenhancer.module"
         minSdk = 26
         targetSdk = 37
-        versionCode = 82
-        versionName = "1.0.1"
+        versionCode = 83
+        versionName = "1.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Summary

- bump the Android release version name from `1.0.1` to `1.1.0`
- increment the Android version code from `82` to `83`

## Why

This prepares the merged lyric runtime, configuration, symbol-resolution, and tablet fullscreen player improvements for the `v1.1.0` release.

## Validation

- Release APK assembled successfully
- APK manifest verified as `versionName=1.1.0` and `versionCode=83`
- `git diff --check`