### PR TITLE
将相邻歌词模糊调整为 6px

### DIFF
--- a/app/src/main/java/dev/amenhancer/module/hook/BidirectionalBlurPolicy.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/BidirectionalBlurPolicy.kt
@@ -4,9 +4,8 @@ import kotlin.math.abs
 import kotlin.math.roundToInt
 
 internal object BidirectionalBlurPolicy {
-    private const val BLUR_BASE = 4f
-    private const val BLUR_STEP = 4f
     private const val BLUR_MAX = 20f
+    private val BLUR_RADII_BY_DISTANCE = floatArrayOf(0f, 6f, 8f, 12f, 16f, BLUR_MAX)
     const val TRANSITION_DURATION_MS = 300L
 
     fun resolveHighlights(current: Set<Int>, incoming: Set<Int>): Set<Int> =
@@ -26,7 +25,7 @@ internal object BidirectionalBlurPolicy {
         if (highlighted.isEmpty()) return BLUR_MAX
         if (position in highlighted) return 0f
         val distance = highlighted.minOf { abs(position - it) }
-        return (BLUR_BASE + (distance - 1) * BLUR_STEP).coerceAtMost(BLUR_MAX)
+        return BLUR_RADII_BY_DISTANCE.getOrElse(distance) { BLUR_MAX }
     }
 
     fun quantize(radius: Float): Int = radius

--- a/app/src/test/java/dev/amenhancer/module/hook/BidirectionalBlurPolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/BidirectionalBlurPolicyTest.kt
@@ -40,9 +40,9 @@ class BidirectionalBlurPolicyTest {
         assertRadius(16f, position = 6, highlighted)
         assertRadius(12f, position = 7, highlighted)
         assertRadius(8f, position = 8, highlighted)
-        assertRadius(4f, position = 9, highlighted)
+        assertRadius(6f, position = 9, highlighted)
         assertRadius(0f, position = 10, highlighted)
-        assertRadius(4f, position = 11, highlighted)
+        assertRadius(6f, position = 11, highlighted)
         assertRadius(8f, position = 12, highlighted)
         assertRadius(12f, position = 13, highlighted)
         assertRadius(16f, position = 14, highlighted)
@@ -53,12 +53,12 @@ class BidirectionalBlurPolicyTest {
     fun `nearest highlighted row determines radius when several rows are highlighted`() {
         val highlighted = setOf(3, 9)
 
-        assertRadius(4f, position = 2, highlighted)
+        assertRadius(6f, position = 2, highlighted)
         assertRadius(0f, position = 3, highlighted)
         assertRadius(8f, position = 5, highlighted)
         assertRadius(8f, position = 7, highlighted)
         assertRadius(0f, position = 9, highlighted)
-        assertRadius(4f, position = 10, highlighted)
+        assertRadius(6f, position = 10, highlighted)
     }
 
     @Test


### PR DESCRIPTION
## 修改内容

- 将距离高亮歌词第 1 行的模糊半径从 `4px` 调整为 `6px`
- 保持后续 `8/12/16/20px`、上下双向模糊和 300ms 过渡不变
- 使用显式距离表表达非线性模糊曲线

## 原因

高亮歌词附近的第一行在 4px 下仍略显清晰。真机试调 6px 后，用户确认视觉效果合适。

## 验证

- 策略测试先红后绿
- 77 项 JVM 测试通过
- Release 构建与 Release lint 通过
- 真机 QA：Future Blur 与 DualPane ACTIVE，无 FATAL
- 未重启平板