### PR TITLE
Fix car player lyrics and add blur radius offset

### DIFF
--- a/app/src/main/java/dev/amenhancer/module/ModuleConstants.kt
+++ b/app/src/main/java/dev/amenhancer/module/ModuleConstants.kt
@@ -4,7 +4,7 @@ object ModuleConstants {
     const val MODULE_PACKAGE = "dev.amenhancer.module"
     const val TARGET_PACKAGE = "com.apple.android.music"
     const val REMOTE_PREFERENCES_GROUP = "settings"
-    const val CONFIG_SCHEMA_VERSION = 3
+    const val CONFIG_SCHEMA_VERSION = 4
 
     const val FEATURE_DUAL_PANE = "dual_pane"
     const val FEATURE_EDITORIAL_VIDEO = "editorial_video"

--- a/app/src/main/java/dev/amenhancer/module/config/ModuleSettingsSchema.kt
+++ b/app/src/main/java/dev/amenhancer/module/config/ModuleSettingsSchema.kt
@@ -15,6 +15,11 @@ internal object ModuleSettingsSchema {
             default = false,
         ),
         futureBlurEnabled = values.boolean(KEY_FUTURE_BLUR, default = true),
+        lyricBlurRadiusOffsetPx = values.number(KEY_LYRIC_BLUR_RADIUS_OFFSET)
+            ?.coerceIn(
+                ModuleSettings.MIN_LYRIC_BLUR_RADIUS_OFFSET_PX,
+                ModuleSettings.MAX_LYRIC_BLUR_RADIUS_OFFSET_PX,
+            ) ?: 0,
         schemaVersion = values.number(KEY_SCHEMA_VERSION)
             ?: ModuleConstants.CONFIG_SCHEMA_VERSION,
     )
@@ -24,6 +29,10 @@ internal object ModuleSettingsSchema {
         KEY_DISABLE_EDITORIAL_VIDEO_ON_TABLET to settings.disableEditorialVideoOnTablet,
         KEY_PHONE_LIQUID_GLASS to settings.phoneLiquidGlassEnabled,
         KEY_FUTURE_BLUR to settings.futureBlurEnabled,
+        KEY_LYRIC_BLUR_RADIUS_OFFSET to settings.lyricBlurRadiusOffsetPx.coerceIn(
+            ModuleSettings.MIN_LYRIC_BLUR_RADIUS_OFFSET_PX,
+            ModuleSettings.MAX_LYRIC_BLUR_RADIUS_OFFSET_PX,
+        ),
         KEY_SCHEMA_VERSION to ModuleConstants.CONFIG_SCHEMA_VERSION,
     )
 
@@ -49,6 +58,7 @@ internal object ModuleSettingsSchema {
         KEY_DISABLE_EDITORIAL_VIDEO_ON_TABLET,
         KEY_PHONE_LIQUID_GLASS,
         KEY_FUTURE_BLUR,
+        KEY_LYRIC_BLUR_RADIUS_OFFSET,
     )
 
     private const val KEY_DUAL_PANE = "dual_pane_enabled"
@@ -56,5 +66,6 @@ internal object ModuleSettingsSchema {
         "disable_editorial_video_on_tablet"
     private const val KEY_PHONE_LIQUID_GLASS = "phone_liquid_glass_enabled"
     private const val KEY_FUTURE_BLUR = "future_blur_enabled"
+    private const val KEY_LYRIC_BLUR_RADIUS_OFFSET = "lyric_blur_radius_offset_px"
     private const val KEY_SCHEMA_VERSION = "schema_version"
 }

--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicBidirectionalLyricBlurTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicBidirectionalLyricBlurTarget.kt
@@ -2,6 +2,7 @@ package dev.amenhancer.module.hook
 
 import android.util.Log
 import android.view.View
+import dev.amenhancer.module.config.TargetConfigClient
 import dev.amenhancer.module.hook.ModernMethodHook as XC_MethodHook
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
@@ -36,7 +37,10 @@ internal class AppleMusicBidirectionalLyricBlurTarget(
         }
 
         val targetAccess = AppleMusicLyricBlurTargetAccess(recyclerClass)
-        val runtime = OpenSourceLyricBlurPort(targetAccess)
+        val runtime = OpenSourceLyricBlurPort(
+            targetAccess = targetAccess,
+            blurRadiusOffsetPx = TargetConfigClient.currentSettings().lyricBlurRadiusOffsetPx,
+        )
         val highlights = LyricHighlightEventRouter(runtime)
 
         // Preserve the upstream installation order: recycler, session, callback, lifecycle, VM.

--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
@@ -871,6 +871,43 @@ internal object FlatLandscapeWindowPolicy {
     }
 }
 
+internal data class FlatPlayerBoundaryDecision(
+    val reserveNavigationSpace: Boolean,
+    val bottomMargin: Int,
+    val tabsVisible: Boolean,
+)
+
+/**
+ * Keeps the eager ultra-wide hint, but also learns from the actual flat-player
+ * geometry. Projection side rails can make a physical 17:10 display report an
+ * activity viewport below the 1.7 ratio even though its collapsed sheet still
+ * uses the no-tabs offset.
+ */
+internal object FlatPlayerBoundaryPolicy {
+    fun decide(
+        rootHeight: Int,
+        sheetTop: Int,
+        sheetBottom: Int,
+        tabsTop: Int,
+        tabsHeight: Int,
+        wasNavigationSpaceReserved: Boolean,
+    ): FlatPlayerBoundaryDecision {
+        require(rootHeight > 0) { "rootHeight must be positive" }
+        val expanded = sheetTop <= rootHeight / 2
+        val collapsedOverlap = !expanded &&
+            tabsTop > rootHeight / 2 &&
+            sheetBottom > tabsTop
+        val reserveNavigationSpace = wasNavigationSpaceReserved || collapsedOverlap
+        return FlatPlayerBoundaryDecision(
+            reserveNavigationSpace = reserveNavigationSpace,
+            bottomMargin = if (!expanded && reserveNavigationSpace) tabsHeight else 0,
+            // Before this root proves it needs compensation, remain visually
+            // inert so ordinary tablet windows keep their native tab behavior.
+            tabsVisible = !reserveNavigationSpace || !expanded,
+        )
+    }
+}
+
 internal object DualPaneShell {
     /** Mirrors the modified PlayerActivity's BaseActivity.n0() root lookup. */
     fun activityRoot(activity: Activity): View? = runCatching {
@@ -1169,16 +1206,32 @@ private object ConstraintLayoutPane {
         tabsFrame: View,
         tabsHeight: Int,
     ) {
-        if (!FlatLandscapeWindowPolicy.shouldReserveNavigationSpace(root.context)) return
         val sheetId = targetId(root.resources, PLAYER_SHEET_CONTAINER)
         val sheet = sheetId.takeIf { it != 0 }?.let { root.findViewById<View>(it) } ?: return
+        var reserveNavigationSpace =
+            FlatLandscapeWindowPolicy.shouldReserveNavigationSpace(root.context)
         var lastBottomMargin = Int.MIN_VALUE
+        val rootLocation = IntArray(2)
+        val sheetLocation = IntArray(2)
+        val tabsLocation = IntArray(2)
         fun sync() {
             val rootHeight = root.height
             if (rootHeight <= 0) return
-            val expanded = sheet.top <= rootHeight / 2
-            val desired = if (expanded) 0 else tabsHeight
-            val desiredTabsVisibility = if (expanded) View.INVISIBLE else View.VISIBLE
+            root.getLocationInWindow(rootLocation)
+            sheet.getLocationInWindow(sheetLocation)
+            tabsFrame.getLocationInWindow(tabsLocation)
+            val rootTop = rootLocation[1]
+            val decision = FlatPlayerBoundaryPolicy.decide(
+                rootHeight = rootHeight,
+                sheetTop = sheetLocation[1] - rootTop,
+                sheetBottom = sheetLocation[1] - rootTop + sheet.height,
+                tabsTop = tabsLocation[1] - rootTop,
+                tabsHeight = tabsHeight,
+                wasNavigationSpaceReserved = reserveNavigationSpace,
+            )
+            reserveNavigationSpace = decision.reserveNavigationSpace
+            val desired = decision.bottomMargin
+            val desiredTabsVisibility = if (decision.tabsVisible) View.VISIBLE else View.INVISIBLE
             val tabsVisibilityChanged = tabsFrame.visibility != desiredTabsVisibility
             if (desired == lastBottomMargin && !tabsVisibilityChanged) return
             lastBottomMargin = desired

--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
@@ -8,6 +8,7 @@ import android.os.Bundle
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewTreeObserver
 import android.widget.FrameLayout
 import dev.amenhancer.module.hook.ModernMethodHook as XC_MethodHook
 import dev.amenhancer.module.ModuleConstants
@@ -16,6 +17,8 @@ import dev.amenhancer.module.config.TargetConfigClient
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
+import java.lang.ref.WeakReference
+import java.util.WeakHashMap
 import kotlin.math.roundToInt
 
 /**
@@ -78,7 +81,6 @@ private object RightLyricsPaneLayout {
     private const val TOP_CLEAR_FRACTION = 0.075f
     private const val TOP_CLEAR_WITHIN_FADE_FRACTION = 0.25f
     private const val BOTTOM_EDGE_FRACTION = 0.15f
-    private val gradientEdgeBooleans = listOf("R", "S", "T", "U")
 
     fun apply(root: View) {
         if (!TabletModeQualifier.isEligible(root.context)) return
@@ -116,57 +118,153 @@ private object RightLyricsPaneLayout {
     /** Uses the target view's single DST_IN layer so scrolling rows fade continuously. */
     private fun configureVerticalGradientEdges(gradients: View) {
         if (gradients.javaClass.name != ALPHA_GRADIENT_FRAME_LAYOUT) return
-        val applyGradient = fun() {
-            if (gradients.height <= 0) return
-            runCatching {
-                gradientEdgeBooleans.forEach { fieldName ->
-                    val field = findField(gradients.javaClass, fieldName)
-                        ?: error("AlphaGradientFrameLayout.$fieldName was unavailable")
-                    field.setBoolean(gradients, fieldName == "R" || fieldName == "S")
-                }
-                val topFadeColors = intArrayOf(
-                    Color.TRANSPARENT,
-                    Color.TRANSPARENT,
-                    Color.BLACK,
-                )
-                val topFadePositions = floatArrayOf(
-                    0f,
-                    TOP_CLEAR_WITHIN_FADE_FRACTION,
-                    1f,
-                )
-                val topFadeColorsField = findField(gradients.javaClass, "a")
-                    ?: error("AlphaGradientFrameLayout.a was unavailable")
-                val topFadePositionsField = findField(gradients.javaClass, "e")
-                    ?: error("AlphaGradientFrameLayout.e was unavailable")
-                topFadeColorsField.set(gradients, topFadeColors)
-                topFadePositionsField.set(gradients, topFadePositions)
-                val topEdgeSize = (gradients.height * TOP_EDGE_FRACTION)
-                    .roundToInt()
-                    .coerceAtLeast(1)
-                val bottomEdgeSize = (gradients.height * BOTTOM_EDGE_FRACTION)
-                    .roundToInt()
-                    .coerceAtLeast(1)
-                val setVerticalFadeSizes = gradients.javaClass.getDeclaredMethod(
-                    "d",
-                    Int::class.javaPrimitiveType,
-                    Int::class.javaPrimitiveType,
-                ).apply { isAccessible = true }
-                setVerticalFadeSizes.invoke(gradients, topEdgeSize, bottomEdgeSize)
-                gradients.invalidate()
-            }.onFailure {
-                debug("right lyrics pane vertical gradient setup failed: $it")
+        gradients.addOnLayoutChangeListener { _, _, top, _, bottom, _, oldTop, _, oldBottom ->
+            if (bottom - top != oldBottom - oldTop) applyVerticalGradientEdges(gradients)
+        }
+        gradients.post { applyVerticalGradientEdges(gradients) }
+    }
+
+    fun reapplyVerticalGradientEdges(gradients: View) {
+        applyVerticalGradientEdges(gradients)
+    }
+
+    private fun applyVerticalGradientEdges(gradients: View) {
+        if (gradients.javaClass.name != ALPHA_GRADIENT_FRAME_LAYOUT || gradients.height <= 0) return
+        runCatching {
+            val profile = AlphaGradientEdgeFieldProfiles.resolve(gradients.javaClass)
+                ?: error("AlphaGradientFrameLayout edge profile was unavailable")
+            profile.vertical.forEach { fieldName ->
+                setGradientEdge(gradients, fieldName, enabled = true)
+            }
+            profile.horizontal.forEach { fieldName ->
+                setGradientEdge(gradients, fieldName, enabled = false)
+            }
+            val topFadeColors = intArrayOf(
+                Color.TRANSPARENT,
+                Color.TRANSPARENT,
+                Color.BLACK,
+            )
+            val topFadePositions = floatArrayOf(
+                0f,
+                TOP_CLEAR_WITHIN_FADE_FRACTION,
+                1f,
+            )
+            val topFadeColorsField = findField(gradients.javaClass, "a")
+                ?: error("AlphaGradientFrameLayout.a was unavailable")
+            val topFadePositionsField = findField(gradients.javaClass, "e")
+                ?: error("AlphaGradientFrameLayout.e was unavailable")
+            topFadeColorsField.set(gradients, topFadeColors)
+            topFadePositionsField.set(gradients, topFadePositions)
+            val topEdgeSize = (gradients.height * TOP_EDGE_FRACTION)
+                .roundToInt()
+                .coerceAtLeast(1)
+            val bottomEdgeSize = (gradients.height * BOTTOM_EDGE_FRACTION)
+                .roundToInt()
+                .coerceAtLeast(1)
+            val setVerticalFadeSizes = gradients.javaClass.getDeclaredMethod(
+                "d",
+                Int::class.javaPrimitiveType,
+                Int::class.javaPrimitiveType,
+            ).apply { isAccessible = true }
+            setVerticalFadeSizes.invoke(gradients, topEdgeSize, bottomEdgeSize)
+            gradients.invalidate()
+        }.onFailure {
+            debug("right lyrics pane vertical gradient setup failed: $it")
+        }
+    }
+
+    private fun setGradientEdge(gradients: View, fieldName: String, enabled: Boolean) {
+        val field = findField(gradients.javaClass, fieldName)
+            ?: error("AlphaGradientFrameLayout.$fieldName was unavailable")
+        field.setBoolean(gradients, enabled)
+    }
+}
+
+internal data class AlphaGradientEdgeFieldProfile(
+    val vertical: List<String>,
+    val horizontal: List<String>,
+    val requiredIntegers: List<String>,
+)
+
+/** Resolves the two Apple Music 6.5.0 AlphaGradientFrameLayout obfuscation variants. */
+internal object AlphaGradientEdgeFieldProfiles {
+    private val profiles = listOf(
+        AlphaGradientEdgeFieldProfile(
+            vertical = listOf("P", "Q"),
+            horizontal = listOf("R", "S"),
+            requiredIntegers = listOf("T", "U", "V", "W"),
+        ),
+        AlphaGradientEdgeFieldProfile(
+            vertical = listOf("R", "S"),
+            horizontal = listOf("T", "U"),
+            requiredIntegers = listOf("V", "W"),
+        ),
+    )
+
+    fun resolve(type: Class<*>): AlphaGradientEdgeFieldProfile? = resolve(
+        type.declaredFields.associate { field -> field.name to field.type },
+    )
+
+    internal fun resolve(fields: Map<String, Class<*>>): AlphaGradientEdgeFieldProfile? =
+        profiles.singleOrNull { profile ->
+            (profile.vertical + profile.horizontal).all { fieldName ->
+                fields[fieldName] == Boolean::class.javaPrimitiveType
+            } && profile.requiredIntegers.all { fieldName ->
+                fields[fieldName] == Int::class.javaPrimitiveType
             }
         }
-        gradients.addOnLayoutChangeListener { _, _, top, _, bottom, _, oldTop, _, oldBottom ->
-            if (bottom - top != oldBottom - oldTop) applyGradient()
+}
+
+internal data class LyricsLayoutFieldProfile(
+    val binding: String,
+    val container: String,
+    val recycler: String,
+    val gradients: String,
+    val synchronizedMetrics: List<String>,
+)
+
+/** Resolves PlayerLyricsViewFragment fields in official and adapted Apple Music 6.5.0 builds. */
+internal object LyricsLayoutFieldProfiles {
+    private val profiles = listOf(
+        LyricsLayoutFieldProfile(
+            binding = "g0",
+            container = "S",
+            recycler = "Y",
+            gradients = "e0",
+            synchronizedMetrics = listOf("x0", "y0"),
+        ),
+        LyricsLayoutFieldProfile(
+            binding = "i0",
+            container = "U",
+            recycler = "a0",
+            gradients = "g0",
+            synchronizedMetrics = listOf("z0", "A0"),
+        ),
+    )
+
+    fun resolve(fragmentType: Class<*>): LyricsLayoutFieldProfile? = profiles.singleOrNull { profile ->
+        val bindingType = findField(fragmentType, profile.binding)?.type
+            ?: return@singleOrNull false
+        val bindingContractPresent = listOf(
+            profile.container,
+            profile.recycler,
+            profile.gradients,
+        ).all { fieldName -> findField(bindingType, fieldName) != null }
+        bindingContractPresent && profile.synchronizedMetrics.all { fieldName ->
+            val metricsType = findField(fragmentType, fieldName)?.type
+                ?: return@all false
+            listOf("a", "b", "c").all { metricName ->
+                findField(metricsType, metricName)?.type == Int::class.javaPrimitiveType
+            }
         }
-        gradients.post(applyGradient)
     }
 }
 
 internal class AppleMusicDualPaneTarget(
     private val symbols: TargetSymbolResolver,
 ) : DualPaneTarget {
+    private val anchorResizeListeners = WeakHashMap<View, View.OnLayoutChangeListener>()
+
     override fun install(): TargetCapabilityInstall {
         val controllerResolution = symbols.resolve(AppleMusicSymbols.PlayerController)
         val controller = controllerResolution.valueOrNull()
@@ -281,7 +379,10 @@ internal class AppleMusicDualPaneTarget(
         } ?: return 0
         return if (hook(onResume, object : XC_MethodHook() {
                 override fun afterHookedMethod(param: MethodHookParam) {
-                    param.thisObject?.let(TabletLyricTypography::attach)
+                    param.thisObject?.let { fragment ->
+                        installHighlightAnchorResizeSync(fragment)
+                        TabletLyricTypography.attach(fragment)
+                    }
                 }
             })
         ) {
@@ -350,10 +451,12 @@ internal class AppleMusicDualPaneTarget(
                         ModernXposedRuntime.callMethod(fragment, "f2") as? View
                     }.getOrNull() ?: return
                     if (!TabletModeQualifier.isEligible(controls.context)) return
-                    val highlightAnchorAligned = alignSynchronizedLyricsHighlightAnchor(fragment)
+                    val profile = LyricsLayoutFieldProfiles.resolve(fragment.javaClass) ?: return
+                    installHighlightAnchorResizeSync(fragment)
+                    val highlightAnchorAligned = alignSynchronizedLyricsHighlightAnchor(fragment, profile)
                     val controlsHeight = controls.height
                     val endPaddingCorrected = controlsHeight == 0 ||
-                        listOf("z0", "A0").all { fieldName ->
+                        profile.synchronizedMetrics.all { fieldName ->
                             subtractControlsHeightFromLyricsBoundary(fragment, fieldName, controlsHeight)
                         }
                     if (!endPaddingCorrected) return
@@ -361,7 +464,8 @@ internal class AppleMusicDualPaneTarget(
                         debug("landscape lyrics metrics unchanged")
                         return
                     }
-                    refreshLyricsRecycler(fragment)
+                    refreshLyricsRecycler(fragment, profile)
+                    reapplyVerticalLyricsGradient(fragment, profile)
                     debug(
                         "corrected landscape lyrics metrics highlightAnchorAligned=" +
                             highlightAnchorAligned + " controlsHeight=" + controlsHeight,
@@ -375,13 +479,56 @@ internal class AppleMusicDualPaneTarget(
         }
     }
 
-    private fun alignSynchronizedLyricsHighlightAnchor(fragment: Any): Boolean = runCatching {
-        val binding = findField(fragment.javaClass, "i0")?.get(fragment)
+    private fun installHighlightAnchorResizeSync(fragment: Any) {
+        val profile = LyricsLayoutFieldProfiles.resolve(fragment.javaClass) ?: return
+        val binding = findField(fragment.javaClass, profile.binding)?.get(fragment) ?: return
+        val container = findField(binding.javaClass, profile.container)?.get(binding) as? View ?: return
+        synchronized(anchorResizeListeners) {
+            if (anchorResizeListeners.containsKey(container)) return
+            val fragmentReference = WeakReference(fragment)
+            val listener = View.OnLayoutChangeListener {
+                    changedView,
+                    _,
+                    top,
+                    _,
+                    bottom,
+                    _,
+                    oldTop,
+                    _,
+                    oldBottom,
+                ->
+                if (bottom - top == oldBottom - oldTop || bottom <= top) return@OnLayoutChangeListener
+                refreshHighlightAnchor(changedView, fragmentReference)
+            }
+            anchorResizeListeners[container] = listener
+            container.addOnLayoutChangeListener(listener)
+            refreshHighlightAnchor(container, fragmentReference)
+        }
+    }
+
+    private fun refreshHighlightAnchor(container: View, fragmentReference: WeakReference<Any>) {
+        container.post {
+            val currentFragment = fragmentReference.get() ?: return@post
+            if (!container.isAttachedToWindow || container.height <= 0) return@post
+            if (!TabletModeQualifier.isEligible(container.context)) return@post
+            runCatching {
+                ModernXposedRuntime.callMethod(currentFragment, "j2")
+            }.onFailure {
+                debug("lyrics anchor resize sync failed: $it")
+            }
+        }
+    }
+
+    private fun alignSynchronizedLyricsHighlightAnchor(
+        fragment: Any,
+        profile: LyricsLayoutFieldProfile,
+    ): Boolean = runCatching {
+        val binding = findField(fragment.javaClass, profile.binding)?.get(fragment)
             ?: return@runCatching false
-        val container = findField(binding.javaClass, "U")?.get(binding) as? View
+        val container = findField(binding.javaClass, profile.container)?.get(binding) as? View
             ?: return@runCatching false
         if (container.height <= 0) return@runCatching false
-        val metrics = findField(fragment.javaClass, "z0")?.get(fragment)
+        val metrics = findField(fragment.javaClass, profile.synchronizedMetrics.first())?.get(fragment)
             ?: return@runCatching false
         val highlightOffset = findField(metrics.javaClass, "a")
             ?: return@runCatching false
@@ -406,14 +553,24 @@ internal class AppleMusicDualPaneTarget(
         true
     }.getOrDefault(false)
 
-    private fun refreshLyricsRecycler(fragment: Any) {
+    private fun refreshLyricsRecycler(fragment: Any, profile: LyricsLayoutFieldProfile) {
         val recycler = runCatching {
-            val binding = findField(fragment.javaClass, "i0")?.get(fragment) ?: return@runCatching null
-            findField(binding.javaClass, "a0")?.get(binding)
+            val binding = findField(fragment.javaClass, profile.binding)?.get(fragment)
+                ?: return@runCatching null
+            findField(binding.javaClass, profile.recycler)?.get(binding)
         }.getOrNull() as? View ?: return
         if (runCatching { ModernXposedRuntime.callMethod(recycler, "S") }.isFailure) {
             recycler.requestLayout()
         }
+    }
+
+    private fun reapplyVerticalLyricsGradient(fragment: Any, profile: LyricsLayoutFieldProfile) {
+        val gradients = runCatching {
+            val binding = findField(fragment.javaClass, profile.binding)?.get(fragment)
+                ?: return@runCatching null
+            findField(binding.javaClass, profile.gradients)?.get(binding)
+        }.getOrNull() as? View ?: return
+        RightLyricsPaneLayout.reapplyVerticalGradientEdges(gradients)
     }
 
     private fun installControllerHooks(controller: Class<*>): Int {
@@ -702,6 +859,18 @@ internal object TabletModeQualifier {
         isOfficialTabletLandscape(context) && TargetConfigClient.currentSettings().dualPaneEnabled
 }
 
+internal object FlatLandscapeWindowPolicy {
+    fun shouldReserveNavigationSpace(context: Context): Boolean {
+        val configuration = context.resources.configuration
+        val width = configuration.screenWidthDp
+        val height = configuration.screenHeightDp
+        return TabletModeQualifier.isOfficialTablet(context) &&
+            configuration.orientation == Configuration.ORIENTATION_LANDSCAPE &&
+            height > 0 &&
+            width.toFloat() / height.toFloat() >= 1.7f
+    }
+}
+
 internal object DualPaneShell {
     /** Mirrors the modified PlayerActivity's BaseActivity.n0() root lookup. */
     fun activityRoot(activity: Activity): View? = runCatching {
@@ -749,6 +918,7 @@ private object ConstraintLayoutPane {
     private const val NAVIGATION_TABS_HEIGHT = "navigation_tabs_height"
     private const val STACKED_TABS_VERTICAL_INSET_DP = 8
     private const val PLAYER_CONTAINER = "player_container"
+    private const val PLAYER_SHEET_CONTAINER = "player_sheet_container"
     private const val PLAYER_CONTAINER_ELEVATION = "player_container_elevation"
     private const val PLAYER_ROOT = "player_root"
     private const val PLAYER_FRAGMENTS_HOST = "player_fragments_host"
@@ -838,7 +1008,8 @@ private object ConstraintLayoutPane {
                 configureTabsContent(bottomNavigation)
             }
             configureTabsTopShadow(topShadow)
-            configurePlayerContainer(playerContainer)
+            configurePlayerContainer(playerContainer, tabsHeight, root.context)
+            installFlatPlayerBoundarySync(root, playerContainer, tabsFrame, tabsHeight)
             installTabsDivider(tabsFrame, resources)
 
             root.setTag(R.id.am_enhancer_dual_pane_state, BottomNavigationLandscapeInstalled)
@@ -973,11 +1144,15 @@ private object ConstraintLayoutPane {
         topShadow.requestLayout()
     }
 
-    private fun configurePlayerContainer(playerContainer: View) {
+    private fun configurePlayerContainer(playerContainer: View, tabsHeight: Int, context: Context) {
         val params = constraintMarginParams(playerContainer, PLAYER_CONTAINER)
         params.width = ViewGroup.LayoutParams.MATCH_PARENT
         params.height = ViewGroup.LayoutParams.MATCH_PARENT
-        params.bottomMargin = 0
+        params.bottomMargin = if (FlatLandscapeWindowPolicy.shouldReserveNavigationSpace(context)) {
+            tabsHeight
+        } else {
+            0
+        }
         clearLegacyWidthContract(params)
         constrainFullWidth(params)
         params.setInt("topToTop", PARENT_ID)
@@ -986,6 +1161,66 @@ private object ConstraintLayoutPane {
         params.setInt("bottomToTop", -1)
         playerContainer.layoutParams = params
         playerContainer.requestLayout()
+    }
+
+    private fun installFlatPlayerBoundarySync(
+        root: ViewGroup,
+        playerContainer: View,
+        tabsFrame: View,
+        tabsHeight: Int,
+    ) {
+        if (!FlatLandscapeWindowPolicy.shouldReserveNavigationSpace(root.context)) return
+        val sheetId = targetId(root.resources, PLAYER_SHEET_CONTAINER)
+        val sheet = sheetId.takeIf { it != 0 }?.let { root.findViewById<View>(it) } ?: return
+        var lastBottomMargin = Int.MIN_VALUE
+        fun sync() {
+            val rootHeight = root.height
+            if (rootHeight <= 0) return
+            val expanded = sheet.top <= rootHeight / 2
+            val desired = if (expanded) 0 else tabsHeight
+            val desiredTabsVisibility = if (expanded) View.INVISIBLE else View.VISIBLE
+            val tabsVisibilityChanged = tabsFrame.visibility != desiredTabsVisibility
+            if (desired == lastBottomMargin && !tabsVisibilityChanged) return
+            lastBottomMargin = desired
+            val params = constraintMarginParams(playerContainer, PLAYER_CONTAINER)
+            if (params.bottomMargin != desired) {
+                params.bottomMargin = desired
+                playerContainer.layoutParams = params
+                playerContainer.requestLayout()
+            }
+            if (tabsVisibilityChanged) tabsFrame.visibility = desiredTabsVisibility
+        }
+        var observedTree: ViewTreeObserver? = null
+        val preDrawListener = ViewTreeObserver.OnPreDrawListener {
+            sync()
+            true
+        }
+        fun removePreDrawListener() {
+            observedTree?.takeIf(ViewTreeObserver::isAlive)
+                ?.removeOnPreDrawListener(preDrawListener)
+            observedTree = null
+        }
+        fun addPreDrawListener() {
+            val tree = sheet.viewTreeObserver
+            if (!tree.isAlive || tree === observedTree) return
+            removePreDrawListener()
+            sheet.viewTreeObserver.addOnPreDrawListener(preDrawListener)
+            observedTree = tree
+        }
+        sheet.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
+            override fun onViewAttachedToWindow(view: View) {
+                addPreDrawListener()
+            }
+
+            override fun onViewDetachedFromWindow(view: View) {
+                removePreDrawListener()
+            }
+        })
+        if (sheet.isAttachedToWindow) addPreDrawListener()
+        root.post {
+            if (sheet.isAttachedToWindow) addPreDrawListener()
+            sync()
+        }
     }
 
     private fun installTabsDivider(tabsFrame: FrameLayout, resources: android.content.res.Resources) {

--- a/app/src/main/java/dev/amenhancer/module/hook/BidirectionalBlurPolicy.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/BidirectionalBlurPolicy.kt
@@ -1,5 +1,6 @@
 package dev.amenhancer.module.hook
 
+import dev.amenhancer.module.model.ModuleSettings
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
@@ -36,8 +37,17 @@ internal object BidirectionalBlurPolicy {
         }
     }
 
+    fun applyRadiusOffset(radius: Float, offsetPx: Int): Float {
+        if (radius <= 0f) return 0f
+        val safeOffset = offsetPx.coerceIn(
+            ModuleSettings.MIN_LYRIC_BLUR_RADIUS_OFFSET_PX,
+            ModuleSettings.MAX_LYRIC_BLUR_RADIUS_OFFSET_PX,
+        )
+        return (radius + safeOffset).coerceIn(0f, RENDER_BLUR_MAX)
+    }
+
     fun quantize(radius: Float): Int = radius
-        .coerceIn(0f, BLUR_MAX)
+        .coerceIn(0f, RENDER_BLUR_MAX)
         .roundToInt()
 
     fun interpolate(
@@ -50,4 +60,6 @@ internal object BidirectionalBlurPolicy {
         val progress = (elapsedMs.toFloat() / durationMs).coerceIn(0f, 1f)
         return start + (target - start) * progress
     }
+
+    private const val RENDER_BLUR_MAX = 32f
 }

--- a/app/src/main/java/dev/amenhancer/module/hook/OpenSourceLyricBlurPort.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/OpenSourceLyricBlurPort.kt
@@ -23,6 +23,7 @@ import android.widget.ImageView
  */
 internal class OpenSourceLyricBlurPort(
     private val targetAccess: LyricBlurTargetAccess,
+    private val blurRadiusOffsetPx: Int = 0,
 ) : LyricBlurRuntime {
     companion object {
         private const val TAG = "AMLyricBlur"
@@ -249,7 +250,10 @@ internal class OpenSourceLyricBlurPort(
         val targets = LinkedHashMap<View, Float>(visibleRows.size)
         visibleRows.forEach { (child, adapterPos) ->
             val focusBlur = if (includeFocus) {
-                BidirectionalBlurPolicy.targetRadius(adapterPos, effectiveIds)
+                BidirectionalBlurPolicy.applyRadiusOffset(
+                    radius = BidirectionalBlurPolicy.targetRadius(adapterPos, effectiveIds),
+                    offsetPx = blurRadiusOffsetPx,
+                )
             } else {
                 0f
             }

--- a/app/src/main/java/dev/amenhancer/module/model/ModuleModels.kt
+++ b/app/src/main/java/dev/amenhancer/module/model/ModuleModels.kt
@@ -7,8 +7,14 @@ data class ModuleSettings(
     val disableEditorialVideoOnTablet: Boolean = true,
     val phoneLiquidGlassEnabled: Boolean = false,
     val futureBlurEnabled: Boolean = true,
+    val lyricBlurRadiusOffsetPx: Int = 0,
     val schemaVersion: Int = ModuleConstants.CONFIG_SCHEMA_VERSION,
-)
+) {
+    companion object {
+        const val MIN_LYRIC_BLUR_RADIUS_OFFSET_PX = -10
+        const val MAX_LYRIC_BLUR_RADIUS_OFFSET_PX = 10
+    }
+}
 
 enum class FeatureState {
     ACTIVE,

--- a/app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt
+++ b/app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt
@@ -28,6 +28,11 @@ import dev.amenhancer.module.XposedServiceSnapshot
 import dev.amenhancer.module.config.ConfigStore
 import dev.amenhancer.module.model.ModuleSettings
 
+internal object BlurRadiusSeekBarPersistencePolicy {
+    fun shouldPersistProgressChange(fromUser: Boolean, trackingTouch: Boolean): Boolean =
+        fromUser && !trackingTouch
+}
+
 class SettingsActivity : Activity() {
     private lateinit var store: ConfigStore
     private lateinit var launcherIconController: LauncherIconController
@@ -323,6 +328,7 @@ class SettingsActivity : Activity() {
             typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
             text = formatBlurRadiusOffset(safeOffset)
         }
+        var trackingTouch = false
         val seekBar = SeekBar(this@SettingsActivity).apply {
             max = ModuleSettings.MAX_LYRIC_BLUR_RADIUS_OFFSET_PX -
                 ModuleSettings.MIN_LYRIC_BLUR_RADIUS_OFFSET_PX
@@ -335,11 +341,21 @@ class SettingsActivity : Activity() {
                 override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
                     val value = progress + ModuleSettings.MIN_LYRIC_BLUR_RADIUS_OFFSET_PX
                     valueLabel.text = formatBlurRadiusOffset(value)
+                    if (BlurRadiusSeekBarPersistencePolicy.shouldPersistProgressChange(
+                            fromUser = fromUser,
+                            trackingTouch = trackingTouch,
+                        )
+                    ) {
+                        onChanged(value)
+                    }
                 }
 
-                override fun onStartTrackingTouch(seekBar: SeekBar) = Unit
+                override fun onStartTrackingTouch(seekBar: SeekBar) {
+                    trackingTouch = true
+                }
 
                 override fun onStopTrackingTouch(seekBar: SeekBar) {
+                    trackingTouch = false
                     onChanged(
                         seekBar.progress + ModuleSettings.MIN_LYRIC_BLUR_RADIUS_OFFSET_PX,
                     )

--- a/app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt
+++ b/app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt
@@ -19,6 +19,7 @@ import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.ScrollView
+import android.widget.SeekBar
 import android.widget.Switch
 import android.widget.TextView
 import dev.amenhancer.module.ModuleApplication
@@ -229,6 +230,13 @@ class SettingsActivity : Activity() {
             ) { enabled ->
                 store.saveSettings(store.settings().copy(futureBlurEnabled = enabled))
             })
+            addView(insetDivider())
+            addView(blurRadiusOffsetRow(
+                offsetPx = settings.lyricBlurRadiusOffsetPx,
+                enabled = writable,
+            ) { offsetPx ->
+                store.saveSettings(store.settings().copy(lyricBlurRadiusOffsetPx = offsetPx))
+            })
         }
 
     private fun appCard(): View = LinearLayout(this).apply {
@@ -298,6 +306,79 @@ class SettingsActivity : Activity() {
             addView(switch, LinearLayout.LayoutParams(dp(64), dp(48)))
             setOnClickListener { switch.isChecked = !switch.isChecked }
         }
+    }
+
+    private fun blurRadiusOffsetRow(
+        offsetPx: Int,
+        enabled: Boolean,
+        onChanged: (Int) -> Unit,
+    ): View {
+        val safeOffset = offsetPx.coerceIn(
+            ModuleSettings.MIN_LYRIC_BLUR_RADIUS_OFFSET_PX,
+            ModuleSettings.MAX_LYRIC_BLUR_RADIUS_OFFSET_PX,
+        )
+        val valueLabel = TextView(this).apply {
+            textSize = 16f
+            setTextColor(palette.primary)
+            typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+            text = formatBlurRadiusOffset(safeOffset)
+        }
+        val seekBar = SeekBar(this@SettingsActivity).apply {
+            max = ModuleSettings.MAX_LYRIC_BLUR_RADIUS_OFFSET_PX -
+                ModuleSettings.MIN_LYRIC_BLUR_RADIUS_OFFSET_PX
+            progress = safeOffset - ModuleSettings.MIN_LYRIC_BLUR_RADIUS_OFFSET_PX
+            isEnabled = enabled
+            contentDescription = "歌词模糊半径偏移"
+            progressTintList = ColorStateList.valueOf(palette.primary)
+            thumbTintList = ColorStateList.valueOf(palette.primary)
+            setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+                override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
+                    val value = progress + ModuleSettings.MIN_LYRIC_BLUR_RADIUS_OFFSET_PX
+                    valueLabel.text = formatBlurRadiusOffset(value)
+                }
+
+                override fun onStartTrackingTouch(seekBar: SeekBar) = Unit
+
+                override fun onStopTrackingTouch(seekBar: SeekBar) {
+                    onChanged(
+                        seekBar.progress + ModuleSettings.MIN_LYRIC_BLUR_RADIUS_OFFSET_PX,
+                    )
+                }
+            })
+        }
+        return LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            minimumHeight = dp(116)
+            isEnabled = enabled
+            alpha = if (enabled) 1f else 0.58f
+            setPadding(dp(16), dp(14), dp(16), dp(12))
+            addView(LinearLayout(this@SettingsActivity).apply {
+                orientation = LinearLayout.HORIZONTAL
+                gravity = Gravity.CENTER_VERTICAL
+                addView(TextView(this@SettingsActivity).apply {
+                    text = "歌词模糊半径偏移"
+                    textSize = 17f
+                    setTextColor(palette.onSurface)
+                    typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+                }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+                addView(valueLabel)
+            })
+            addView(TextView(this@SettingsActivity).apply {
+                text = "统一调整非高亮歌词 · 更改后需重开 Apple Music"
+                textSize = 13.5f
+                setTextColor(palette.onSurfaceVariant)
+                setPadding(0, dp(4), 0, dp(2))
+            })
+            addView(
+                seekBar,
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(40)),
+            )
+        }
+    }
+
+    private fun formatBlurRadiusOffset(offsetPx: Int): String = when {
+        offsetPx > 0 -> "+${offsetPx}px"
+        else -> "${offsetPx}px"
     }
 
     private fun badge(text: String): View = TextView(this).apply {

--- a/app/src/test/java/dev/amenhancer/module/config/ModuleSettingsSchemaTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/config/ModuleSettingsSchemaTest.kt
@@ -14,6 +14,7 @@ class ModuleSettingsSchemaTest {
                 disableEditorialVideoOnTablet = true,
                 phoneLiquidGlassEnabled = false,
                 futureBlurEnabled = true,
+                lyricBlurRadiusOffsetPx = 0,
                 schemaVersion = ModuleConstants.CONFIG_SCHEMA_VERSION,
             ),
             ModuleSettingsSchema.decode(emptyMap<String, Any?>()),
@@ -28,6 +29,7 @@ class ModuleSettingsSchemaTest {
                 disableEditorialVideoOnTablet = false,
                 phoneLiquidGlassEnabled = true,
                 futureBlurEnabled = false,
+                lyricBlurRadiusOffsetPx = 6,
                 schemaVersion = 1,
             ),
         )
@@ -38,6 +40,7 @@ class ModuleSettingsSchemaTest {
                 "disable_editorial_video_on_tablet" to false,
                 "phone_liquid_glass_enabled" to true,
                 "future_blur_enabled" to false,
+                "lyric_blur_radius_offset_px" to 6,
                 "schema_version" to ModuleConstants.CONFIG_SCHEMA_VERSION,
             ),
             encoded,
@@ -60,6 +63,7 @@ class ModuleSettingsSchemaTest {
                 "disable_editorial_video_on_tablet" to true,
                 "phone_liquid_glass_enabled" to true,
                 "future_blur_enabled" to true,
+                "lyric_blur_radius_offset_px" to 0,
                 "schema_version" to ModuleConstants.CONFIG_SCHEMA_VERSION,
             ),
             upgraded,
@@ -101,6 +105,7 @@ class ModuleSettingsSchemaTest {
                 "disable_editorial_video_on_tablet" to false,
                 "phone_liquid_glass_enabled" to 1,
                 "future_blur_enabled" to false,
+                "lyric_blur_radius_offset_px" to "too-strong",
                 "schema_version" to "three",
             ),
         )
@@ -111,6 +116,7 @@ class ModuleSettingsSchemaTest {
                 disableEditorialVideoOnTablet = false,
                 phoneLiquidGlassEnabled = false,
                 futureBlurEnabled = false,
+                lyricBlurRadiusOffsetPx = 0,
                 schemaVersion = ModuleConstants.CONFIG_SCHEMA_VERSION,
             ),
             decoded,
@@ -125,5 +131,21 @@ class ModuleSettingsSchemaTest {
         )
 
         assertEquals(null, upgraded)
+    }
+
+    @Test
+    fun `blur radius offset is clamped to the supported range`() {
+        assertEquals(
+            ModuleSettings.MAX_LYRIC_BLUR_RADIUS_OFFSET_PX,
+            ModuleSettingsSchema.decode(
+                mapOf("lyric_blur_radius_offset_px" to 99),
+            ).lyricBlurRadiusOffsetPx,
+        )
+        assertEquals(
+            ModuleSettings.MIN_LYRIC_BLUR_RADIUS_OFFSET_PX,
+            ModuleSettingsSchema.decode(
+                mapOf("lyric_blur_radius_offset_px" to -99),
+            ).lyricBlurRadiusOffsetPx,
+        )
     }
 }

--- a/app/src/test/java/dev/amenhancer/module/hook/AlphaGradientEdgeFieldProfilesTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/AlphaGradientEdgeFieldProfilesTest.kt
@@ -1,0 +1,52 @@
+package dev.amenhancer.module.hook
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AlphaGradientEdgeFieldProfilesTest {
+    @Test
+    fun `resolves official 650 edge fields`() {
+        val profile = AlphaGradientEdgeFieldProfiles.resolve(
+            mapOf(
+                "P" to Boolean::class.javaPrimitiveType!!,
+                "Q" to Boolean::class.javaPrimitiveType!!,
+                "R" to Boolean::class.javaPrimitiveType!!,
+                "S" to Boolean::class.javaPrimitiveType!!,
+                "T" to Int::class.javaPrimitiveType!!,
+                "U" to Int::class.javaPrimitiveType!!,
+                "V" to Int::class.javaPrimitiveType!!,
+                "W" to Int::class.javaPrimitiveType!!,
+            ),
+        )
+
+        assertEquals(listOf("P", "Q"), profile?.vertical)
+        assertEquals(listOf("R", "S"), profile?.horizontal)
+    }
+
+    @Test
+    fun `resolves landscape 650 edge fields`() {
+        val profile = AlphaGradientEdgeFieldProfiles.resolve(
+            mapOf(
+                "R" to Boolean::class.javaPrimitiveType!!,
+                "S" to Boolean::class.javaPrimitiveType!!,
+                "T" to Boolean::class.javaPrimitiveType!!,
+                "U" to Boolean::class.javaPrimitiveType!!,
+                "V" to Int::class.javaPrimitiveType!!,
+                "W" to Int::class.javaPrimitiveType!!,
+            ),
+        )
+
+        assertEquals(listOf("R", "S"), profile?.vertical)
+        assertEquals(listOf("T", "U"), profile?.horizontal)
+    }
+
+    @Test
+    fun `rejects unknown edge field contracts`() {
+        assertNull(
+            AlphaGradientEdgeFieldProfiles.resolve(
+                mapOf("R" to Boolean::class.javaPrimitiveType!!),
+            ),
+        )
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/BidirectionalBlurPolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/BidirectionalBlurPolicyTest.kt
@@ -76,7 +76,17 @@ class BidirectionalBlurPolicyTest {
         assertEquals(12, BidirectionalBlurPolicy.quantize(12.49f))
         assertEquals(13, BidirectionalBlurPolicy.quantize(12.5f))
         assertEquals(20, BidirectionalBlurPolicy.quantize(20f))
-        assertEquals(22, BidirectionalBlurPolicy.quantize(25f))
+        assertEquals(25, BidirectionalBlurPolicy.quantize(25f))
+        assertEquals(32, BidirectionalBlurPolicy.quantize(40f))
+    }
+
+    @Test
+    fun `global offset adjusts nonzero focus radii while highlighted rows stay clear`() {
+        assertEquals(18f, BidirectionalBlurPolicy.applyRadiusOffset(8f, 10), FLOAT_TOLERANCE)
+        assertEquals(3f, BidirectionalBlurPolicy.applyRadiusOffset(13f, -10), FLOAT_TOLERANCE)
+        assertEquals(0f, BidirectionalBlurPolicy.applyRadiusOffset(8f, -10), FLOAT_TOLERANCE)
+        assertEquals(32f, BidirectionalBlurPolicy.applyRadiusOffset(22f, 10), FLOAT_TOLERANCE)
+        assertEquals(0f, BidirectionalBlurPolicy.applyRadiusOffset(0f, 10), FLOAT_TOLERANCE)
     }
 
     @Test

--- a/app/src/test/java/dev/amenhancer/module/hook/DualPaneStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/DualPaneStructuralRegressionTest.kt
@@ -148,11 +148,14 @@ class DualPaneStructuralRegressionTest {
     }
 
     @Test
-    fun `gates flat player boundary changes through the window policy`() {
+    fun `detects flat player overlap beyond the eager window policy`() {
         assertTrue(source.contains("installFlatPlayerBoundarySync(root, playerContainer, tabsFrame, tabsHeight)"))
-        assertTrue(source.contains("if (!FlatLandscapeWindowPolicy.shouldReserveNavigationSpace(root.context)) return"))
+        assertFalse(source.contains("if (!FlatLandscapeWindowPolicy.shouldReserveNavigationSpace(root.context)) return"))
         assertTrue(source.contains("params.bottomMargin = if (FlatLandscapeWindowPolicy.shouldReserveNavigationSpace(context))"))
-        assertTrue(source.contains("val desired = if (expanded) 0 else tabsHeight"))
+        assertTrue(source.contains("FlatPlayerBoundaryPolicy.decide"))
+        assertTrue(source.contains("sheet.getLocationInWindow(sheetLocation)"))
+        assertTrue(source.contains("tabsFrame.getLocationInWindow(tabsLocation)"))
+        assertTrue(source.contains("reserveNavigationSpace = decision.reserveNavigationSpace"))
         assertTrue(source.contains("params.bottomMargin = desired"))
     }
 
@@ -163,7 +166,7 @@ class DualPaneStructuralRegressionTest {
         assertTrue(source.contains("removeOnPreDrawListener"))
         assertTrue(source.contains("sheet.addOnAttachStateChangeListener"))
         assertTrue(source.contains("installFlatPlayerBoundarySync(root, playerContainer, tabsFrame, tabsHeight)"))
-        assertTrue(source.contains("val desiredTabsVisibility = if (expanded) View.INVISIBLE else View.VISIBLE"))
+        assertTrue(source.contains("val desiredTabsVisibility = if (decision.tabsVisible) View.VISIBLE else View.INVISIBLE"))
         assertTrue(source.contains("tabsFrame.visibility = desiredTabsVisibility"))
     }
 

--- a/app/src/test/java/dev/amenhancer/module/hook/DualPaneStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/DualPaneStructuralRegressionTest.kt
@@ -69,8 +69,8 @@ class DualPaneStructuralRegressionTest {
         assertTrue(source.contains("PLAYER_CONTAINER"))
         assertTrue(source.contains("NAVIGATION_TABS_HEIGHT"))
         assertTrue(source.contains("constrainFullWidth(params)"))
-        assertTrue(source.contains("params.bottomMargin = 0"))
-        assertFalse(source.contains("params.bottomMargin = tabsHeight"))
+        assertTrue(source.contains("params.bottomMargin = if (FlatLandscapeWindowPolicy.shouldReserveNavigationSpace(context))"))
+        assertTrue(source.contains("tabsHeight"))
         assertTrue(source.contains("NAVIGATION_TABS_DIVIDER"))
         assertTrue(source.contains("clearLegacyWidthContract(params)"))
         assertTrue(source.contains("\"dimensionRatio\" to \"G\""))
@@ -133,9 +133,38 @@ class DualPaneStructuralRegressionTest {
 
     @Test
     fun `lets the native stacked holder own the collapsed player offset`() {
-        assertTrue(source.contains("configurePlayerContainer(playerContainer)"))
-        assertTrue(source.contains("params.bottomMargin = 0"))
+        assertTrue(source.contains("configurePlayerContainer(playerContainer, tabsHeight, root.context)"))
+        assertTrue(source.contains("FlatLandscapeWindowPolicy.shouldReserveNavigationSpace(context)"))
         assertFalse(source.contains("restoreStackedNavigationLayout"))
+    }
+
+    @Test
+    fun `gates flat navigation reservation to tablet landscape aspect ratio`() {
+        assertTrue(source.contains("internal object FlatLandscapeWindowPolicy"))
+        assertTrue(source.contains("TabletModeQualifier.isOfficialTablet(context)"))
+        assertTrue(source.contains("configuration.orientation == Configuration.ORIENTATION_LANDSCAPE"))
+        assertTrue(source.contains("height > 0"))
+        assertTrue(source.contains("width.toFloat() / height.toFloat() >= 1.7f"))
+    }
+
+    @Test
+    fun `gates flat player boundary changes through the window policy`() {
+        assertTrue(source.contains("installFlatPlayerBoundarySync(root, playerContainer, tabsFrame, tabsHeight)"))
+        assertTrue(source.contains("if (!FlatLandscapeWindowPolicy.shouldReserveNavigationSpace(root.context)) return"))
+        assertTrue(source.contains("params.bottomMargin = if (FlatLandscapeWindowPolicy.shouldReserveNavigationSpace(context))"))
+        assertTrue(source.contains("val desired = if (expanded) 0 else tabsHeight"))
+        assertTrue(source.contains("params.bottomMargin = desired"))
+    }
+
+    @Test
+    fun `observes delayed native sheet offsets at the pre draw boundary`() {
+        assertTrue(source.contains("ViewTreeObserver.OnPreDrawListener"))
+        assertTrue(source.contains("sheet.viewTreeObserver.addOnPreDrawListener"))
+        assertTrue(source.contains("removeOnPreDrawListener"))
+        assertTrue(source.contains("sheet.addOnAttachStateChangeListener"))
+        assertTrue(source.contains("installFlatPlayerBoundarySync(root, playerContainer, tabsFrame, tabsHeight)"))
+        assertTrue(source.contains("val desiredTabsVisibility = if (expanded) View.INVISIBLE else View.VISIBLE"))
+        assertTrue(source.contains("tabsFrame.visibility = desiredTabsVisibility"))
     }
 
     @Test
@@ -149,8 +178,9 @@ class DualPaneStructuralRegressionTest {
         assertTrue(source.contains("DualPaneShell.installImmediately(root)"))
         assertTrue(source.contains("installForControllerRoot(controllerInstance, param.result as? View, \"onCreateView\")"))
         assertFalse(source.contains("PendingDualPaneState"))
-        assertFalse(source.contains("addOnAttachStateChangeListener"))
-        assertFalse(source.contains("onViewAttachedToWindow"))
+        val synchronousInstallSource = source.substringBefore("private fun installFlatPlayerBoundarySync")
+        assertFalse(synchronousInstallSource.contains("addOnAttachStateChangeListener"))
+        assertFalse(synchronousInstallSource.contains("onViewAttachedToWindow"))
         assertTrue(source.contains("[AMENH-2]"))
     }
 

--- a/app/src/test/java/dev/amenhancer/module/hook/FlatPlayerBoundaryPolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/FlatPlayerBoundaryPolicyTest.kt
@@ -1,0 +1,88 @@
+package dev.amenhancer.module.hook
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FlatPlayerBoundaryPolicyTest {
+    @Test
+    fun `detects navigation overlap below the eager aspect ratio gate`() {
+        val decision = FlatPlayerBoundaryPolicy.decide(
+            rootHeight = 1080,
+            sheetTop = 982,
+            sheetBottom = 1080,
+            tabsTop = 954,
+            tabsHeight = 126,
+            wasNavigationSpaceReserved = false,
+        )
+
+        assertTrue(decision.reserveNavigationSpace)
+        assertEquals(126, decision.bottomMargin)
+        assertTrue(decision.tabsVisible)
+    }
+
+    @Test
+    fun `keeps detected reservation after the overlap has moved above tabs`() {
+        val decision = FlatPlayerBoundaryPolicy.decide(
+            rootHeight = 1080,
+            sheetTop = 856,
+            sheetBottom = 954,
+            tabsTop = 954,
+            tabsHeight = 126,
+            wasNavigationSpaceReserved = true,
+        )
+
+        assertTrue(decision.reserveNavigationSpace)
+        assertEquals(126, decision.bottomMargin)
+        assertTrue(decision.tabsVisible)
+    }
+
+    @Test
+    fun `leaves ordinary non-overlapping tablet geometry unchanged`() {
+        val decision = FlatPlayerBoundaryPolicy.decide(
+            rootHeight = 800,
+            sheetTop = 650,
+            sheetBottom = 744,
+            tabsTop = 744,
+            tabsHeight = 56,
+            wasNavigationSpaceReserved = false,
+        )
+
+        assertFalse(decision.reserveNavigationSpace)
+        assertEquals(0, decision.bottomMargin)
+        assertTrue(decision.tabsVisible)
+    }
+
+    @Test
+    fun `expanded sheet remains inert before an overlap has been observed`() {
+        val decision = FlatPlayerBoundaryPolicy.decide(
+            rootHeight = 1080,
+            sheetTop = 0,
+            sheetBottom = 1080,
+            tabsTop = 954,
+            tabsHeight = 126,
+            wasNavigationSpaceReserved = false,
+        )
+
+        assertFalse(decision.reserveNavigationSpace)
+        assertEquals(0, decision.bottomMargin)
+        assertTrue(decision.tabsVisible)
+    }
+
+    @Test
+    fun `expanded sheet clears margin and hides tabs after reservation`() {
+        val decision = FlatPlayerBoundaryPolicy.decide(
+            rootHeight = 1080,
+            sheetTop = 0,
+            sheetBottom = 1080,
+            tabsTop = 954,
+            tabsHeight = 126,
+            wasNavigationSpaceReserved = true,
+        )
+
+        assertTrue(decision.reserveNavigationSpace)
+        assertEquals(0, decision.bottomMargin)
+        assertFalse(decision.tabsVisible)
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/LyricBlurRadiusOffsetStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/LyricBlurRadiusOffsetStructuralRegressionTest.kt
@@ -1,0 +1,25 @@
+package dev.amenhancer.module.hook
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LyricBlurRadiusOffsetStructuralRegressionTest {
+    private fun source(fileName: String): String = sequenceOf(
+        File("src/main/java/dev/amenhancer/module/hook/$fileName"),
+        File("app/src/main/java/dev/amenhancer/module/hook/$fileName"),
+    ).firstOrNull(File::isFile)?.readText()
+        ?: error("$fileName was not found from the unit-test working directory")
+
+    @Test
+    fun `target setting is applied to directional focus blur before tablet edge blur`() {
+        val target = source("AppleMusicBidirectionalLyricBlurTarget.kt")
+        val runtime = source("OpenSourceLyricBlurPort.kt").replace(Regex("\\s+"), " ")
+
+        assertTrue(target.contains("TargetConfigClient.currentSettings().lyricBlurRadiusOffsetPx"))
+        assertTrue(runtime.contains("BidirectionalBlurPolicy.applyRadiusOffset("))
+        assertTrue(runtime.contains(
+            "TabletLyricVisualPolicy.mergeBlurRadius(focusBlur, edgeBlur)",
+        ))
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/LyricsLayoutFieldProfilesTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/LyricsLayoutFieldProfilesTest.kt
@@ -1,0 +1,68 @@
+package dev.amenhancer.module.hook
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class LyricsLayoutFieldProfilesTest {
+    @Test
+    fun `resolves official 650 lyrics fields`() {
+        val profile = LyricsLayoutFieldProfiles.resolve(OfficialFragment::class.java)
+
+        assertEquals("g0", profile?.binding)
+        assertEquals("S", profile?.container)
+        assertEquals("Y", profile?.recycler)
+        assertEquals("e0", profile?.gradients)
+        assertEquals(listOf("x0", "y0"), profile?.synchronizedMetrics)
+    }
+
+    @Test
+    fun `resolves adapted landscape 650 lyrics fields`() {
+        val profile = LyricsLayoutFieldProfiles.resolve(AdaptedFragment::class.java)
+
+        assertEquals("i0", profile?.binding)
+        assertEquals("U", profile?.container)
+        assertEquals("a0", profile?.recycler)
+        assertEquals("g0", profile?.gradients)
+        assertEquals(listOf("z0", "A0"), profile?.synchronizedMetrics)
+    }
+
+    @Test
+    fun `rejects partial lyrics field contracts`() {
+        assertNull(LyricsLayoutFieldProfiles.resolve(UnknownFragment::class.java))
+    }
+
+    private class Metrics {
+        @JvmField var a = 0
+        @JvmField var b = 0
+        @JvmField var c = 0
+    }
+
+    private class OfficialBinding {
+        @JvmField var S: Any? = null
+        @JvmField var Y: Any? = null
+        @JvmField var e0: Any? = null
+    }
+
+    private class OfficialFragment {
+        @JvmField var g0 = OfficialBinding()
+        @JvmField var x0 = Metrics()
+        @JvmField var y0 = Metrics()
+    }
+
+    private class AdaptedBinding {
+        @JvmField var U: Any? = null
+        @JvmField var a0: Any? = null
+        @JvmField var g0: Any? = null
+    }
+
+    private class AdaptedFragment {
+        @JvmField var i0 = AdaptedBinding()
+        @JvmField var z0 = Metrics()
+        @JvmField var A0 = Metrics()
+    }
+
+    private class UnknownFragment {
+        @JvmField var g0 = Any()
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/RightLyricsPaneStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/RightLyricsPaneStructuralRegressionTest.kt
@@ -39,7 +39,9 @@ class RightLyricsPaneStructuralRegressionTest {
         assertTrue(source.contains("topFadeColorsField.set(gradients, topFadeColors)"))
         assertTrue(source.contains("topFadePositionsField.set(gradients, topFadePositions)"))
         assertTrue(source.contains("setVerticalFadeSizes.invoke(gradients, topEdgeSize, bottomEdgeSize)"))
-        assertTrue(source.contains("setBoolean(gradients, fieldName == \"R\" || fieldName == \"S\")"))
+        assertTrue(source.contains("AlphaGradientEdgeFieldProfiles.resolve(gradients.javaClass)"))
+        assertTrue(source.contains("setGradientEdge(gradients, fieldName, enabled = true)"))
+        assertTrue(source.contains("setGradientEdge(gradients, fieldName, enabled = false)"))
         assertTrue(compactSource.contains("getDeclaredMethod( \"d\", Int::class.javaPrimitiveType"))
         assertFalse(source.contains("clearGradientEdges"))
     }
@@ -48,5 +50,31 @@ class RightLyricsPaneStructuralRegressionTest {
     fun `limits the resource overlay to the official tablet landscape predicate`() {
         assertTrue(source.contains("TabletModeQualifier.isEligible(root.context)"))
         assertTrue(source.contains("right lyrics pane landscape resource installed"))
+    }
+
+    @Test
+    fun `keeps vertical gradient masks through variant-aware field profiles`() {
+        assertTrue(source.contains("AlphaGradientEdgeFieldProfiles.resolve(gradients.javaClass)"))
+        assertTrue(source.contains("profile.vertical.forEach"))
+        assertTrue(source.contains("profile.horizontal.forEach"))
+        assertTrue(source.contains("field.setBoolean(gradients, enabled)"))
+        assertFalse(source.contains("disableGradientEdges(gradients)"))
+        assertTrue(source.contains("setVerticalFadeSizes.invoke(gradients, topEdgeSize, bottomEdgeSize)"))
+    }
+
+    @Test
+    fun `reapplies the tablet highlight anchor after delayed sheet expansion`() {
+        assertTrue(source.contains("installHighlightAnchorResizeSync(fragment)"))
+        assertTrue(source.contains("container.addOnLayoutChangeListener"))
+        assertTrue(source.contains("bottom - top == oldBottom - oldTop"))
+        assertTrue(source.contains("refreshHighlightAnchor(container, fragmentReference)"))
+        assertTrue(compactSource.contains(
+            "installHighlightAnchorResizeSync(fragment) TabletLyricTypography.attach(fragment)",
+        ))
+        assertTrue(source.contains("ModernXposedRuntime.callMethod(currentFragment, \"j2\")"))
+        assertTrue(source.contains("WeakReference(fragment)"))
+        assertTrue(source.contains("LyricsLayoutFieldProfiles.resolve(fragment.javaClass)"))
+        assertTrue(source.contains("profile.synchronizedMetrics.first()"))
+        assertTrue(source.contains("RightLyricsPaneLayout.reapplyVerticalGradientEdges(gradients)"))
     }
 }

--- a/app/src/test/java/dev/amenhancer/module/ui/BlurRadiusSeekBarPersistencePolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/ui/BlurRadiusSeekBarPersistencePolicyTest.kt
@@ -1,0 +1,37 @@
+package dev.amenhancer.module.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BlurRadiusSeekBarPersistencePolicyTest {
+    @Test
+    fun `persists user progress changes that are not touch tracking`() {
+        assertTrue(
+            BlurRadiusSeekBarPersistencePolicy.shouldPersistProgressChange(
+                fromUser = true,
+                trackingTouch = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `defers touch progress changes until tracking stops`() {
+        assertFalse(
+            BlurRadiusSeekBarPersistencePolicy.shouldPersistProgressChange(
+                fromUser = true,
+                trackingTouch = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `ignores programmatic progress changes`() {
+        assertFalse(
+            BlurRadiusSeekBarPersistencePolicy.shouldPersistProgressChange(
+                fromUser = false,
+                trackingTouch = false,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/ui/SettingsUiStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/ui/SettingsUiStructuralRegressionTest.kt
@@ -48,6 +48,10 @@ class SettingsUiStructuralRegressionTest {
         assertTrue(activity.contains("store.saveSettings(store.settings().copy("))
         assertTrue(activity.contains("minimumHeight = dp(84)"))
         assertTrue(activity.contains("contentDescription = title"))
+        assertTrue(activity.contains("歌词模糊半径偏移"))
+        assertTrue(activity.contains("blurRadiusOffsetRow("))
+        assertTrue(activity.contains("SeekBar(this@SettingsActivity)"))
+        assertTrue(activity.contains("lyricBlurRadiusOffsetPx = offsetPx"))
     }
 
     @Test

--- a/app/src/test/java/dev/amenhancer/module/ui/SettingsUiStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/ui/SettingsUiStructuralRegressionTest.kt
@@ -55,6 +55,18 @@ class SettingsUiStructuralRegressionTest {
     }
 
     @Test
+    fun `persists non touch blur radius changes without duplicating touch writes`() {
+        val activity = projectFile("app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt")
+
+        assertTrue(activity.contains("var trackingTouch = false"))
+        assertTrue(activity.contains("BlurRadiusSeekBarPersistencePolicy.shouldPersistProgressChange("))
+        assertTrue(activity.contains("fromUser = fromUser"))
+        assertTrue(activity.contains("trackingTouch = trackingTouch"))
+        assertTrue(activity.contains("trackingTouch = true"))
+        assertTrue(activity.contains("trackingTouch = false"))
+    }
+
+    @Test
     fun `provides a dedicated dark theme and system bar colors`() {
         val activity = projectFile("app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt")
         val darkTheme = projectFile("app/src/main/res/values-night/styles.xml")

--- a/scripts/check-car39-collapsed-geometry.ps1
+++ b/scripts/check-car39-collapsed-geometry.ps1
@@ -1,0 +1,150 @@
+param(
+    [string]$Serial = "emulator-5554",
+    [int]$StartupDelaySeconds = 5,
+    [int]$TransitionDelaySeconds = 3
+)
+
+$ErrorActionPreference = "Stop"
+
+$adbCommand = Get-Command adb -ErrorAction Stop
+$targetPackage = "com.apple.android.music"
+$deviceXml = "/sdcard/am_car39_collapsed.xml"
+$localXml = Join-Path $env:TEMP "am_car39_collapsed_$Serial.xml"
+$expandedDeviceXml = "/sdcard/am_car39_expanded.xml"
+$expandedLocalXml = Join-Path $env:TEMP "am_car39_expanded_$Serial.xml"
+
+function Invoke-Adb {
+    $output = & $adbCommand.Source -s $Serial @args
+    if ($LASTEXITCODE -ne 0) {
+        throw "adb failed ($LASTEXITCODE): adb -s $Serial $($args -join ' ')"
+    }
+    return $output
+}
+
+function Get-NodeBounds {
+    param(
+        [xml]$Hierarchy,
+        [string]$ResourceName
+    )
+
+    $resourceId = "$targetPackage`:id/$ResourceName"
+    $node = $Hierarchy.SelectSingleNode("//node[@resource-id='$resourceId']")
+    if ($null -eq $node) {
+        throw "Required UI node was missing: $resourceId"
+    }
+    $match = [regex]::Match([string]$node.bounds, '^\[(\d+),(\d+)\]\[(\d+),(\d+)\]$')
+    if (-not $match.Success) {
+        throw "Invalid bounds for ${resourceId}: $($node.bounds)"
+    }
+    return [pscustomobject]@{
+        Left = [int]$match.Groups[1].Value
+        Top = [int]$match.Groups[2].Value
+        Right = [int]$match.Groups[3].Value
+        Bottom = [int]$match.Groups[4].Value
+    }
+}
+
+$deviceLine = Invoke-Adb devices | Select-String "^$([regex]::Escape($Serial))\s+device\b"
+if ($null -eq $deviceLine) {
+    throw "ADB device is not online: $Serial"
+}
+
+$resolved = Invoke-Adb shell cmd package resolve-activity --brief `
+    -a android.intent.action.MAIN `
+    -c android.intent.category.LAUNCHER `
+    $targetPackage
+$component = $resolved | Where-Object { $_ -match '/' } | Select-Object -Last 1
+if ([string]::IsNullOrWhiteSpace($component)) {
+    throw "Could not resolve the Apple Music launcher activity"
+}
+
+Invoke-Adb shell am force-stop $targetPackage | Out-Null
+Invoke-Adb shell am start -W -n $component.Trim() | Out-Null
+Start-Sleep -Seconds $StartupDelaySeconds
+Invoke-Adb shell uiautomator dump $deviceXml | Out-Null
+Invoke-Adb pull $deviceXml $localXml | Out-Null
+
+$hierarchy = [System.Xml.XmlDocument]::new()
+$hierarchy.Load($localXml)
+$miniPlayerNode = $hierarchy.SelectSingleNode(
+    "//node[@resource-id='$targetPackage`:id/mini_player']"
+)
+if ($null -eq $miniPlayerNode) {
+    Invoke-Adb shell input keyevent KEYCODE_BACK | Out-Null
+    Start-Sleep -Seconds $TransitionDelaySeconds
+    Invoke-Adb shell uiautomator dump $deviceXml | Out-Null
+    Invoke-Adb pull $deviceXml $localXml | Out-Null
+    $hierarchy.Load($localXml)
+}
+$miniPlayer = Get-NodeBounds $hierarchy "mini_player"
+$tabsFrame = Get-NodeBounds $hierarchy "bottom_navigation_tabs_frame"
+$sheet = Get-NodeBounds $hierarchy "player_sheet_container"
+
+Write-Output (
+    "CAR39_GEOMETRY sheetTop={0} mini=[{1},{2}] tabsTop={3}" -f `
+        $sheet.Top, $miniPlayer.Top, $miniPlayer.Bottom, $tabsFrame.Top
+)
+
+if ($miniPlayer.Bottom -gt $tabsFrame.Top) {
+    Write-Error (
+        "CAR39_RED mini-player overlaps bottom tabs by {0}px" -f `
+            ($miniPlayer.Bottom - $tabsFrame.Top)
+    )
+    exit 1
+}
+
+if (($miniPlayer.Bottom - $miniPlayer.Top) -lt 48) {
+    Write-Error "CAR39_RED mini-player visible height is below 48px"
+    exit 1
+}
+
+Write-Output "CAR39_GREEN collapsed mini-player is fully above bottom tabs"
+
+$tapX = [int](($miniPlayer.Left + $miniPlayer.Right) / 2)
+$tapY = [int](($miniPlayer.Top + $miniPlayer.Bottom) / 2)
+Invoke-Adb shell input tap $tapX $tapY | Out-Null
+Start-Sleep -Seconds $TransitionDelaySeconds
+Invoke-Adb shell uiautomator dump $expandedDeviceXml | Out-Null
+Invoke-Adb pull $expandedDeviceXml $expandedLocalXml | Out-Null
+
+$expandedHierarchy = [System.Xml.XmlDocument]::new()
+$expandedHierarchy.Load($expandedLocalXml)
+$expandedSheet = Get-NodeBounds $expandedHierarchy "player_sheet_container"
+$expandedPlayer = Get-NodeBounds $expandedHierarchy "player_fragments_host"
+$expandedLyrics = Get-NodeBounds $expandedHierarchy "lyrics_main_content"
+$expandedLyricsNode = $expandedHierarchy.SelectSingleNode(
+    "//node[@resource-id='$targetPackage`:id/lyrics_main_content']"
+)
+$expandedTabsNode = $expandedHierarchy.SelectSingleNode(
+    "//node[@resource-id='$targetPackage`:id/bottom_navigation_tabs_frame']"
+)
+
+Write-Output (
+    "CAR39_EXPANDED sheet=[{0},{1}] player=[{2},{3}] lyrics=[{4},{5}] lyricsScrollable={6} tabsVisible={7}" -f `
+        $expandedSheet.Top, $expandedSheet.Bottom,
+        $expandedPlayer.Top, $expandedPlayer.Bottom,
+        $expandedLyrics.Top, $expandedLyrics.Bottom,
+        $expandedLyricsNode.scrollable,
+        ($null -ne $expandedTabsNode)
+)
+
+if ($expandedSheet.Top -gt 1 -or $expandedSheet.Bottom -lt $tabsFrame.Bottom) {
+    Write-Error "CAR39_RED expanded player sheet does not cover the full viewport"
+    exit 1
+}
+
+if ($null -ne $expandedTabsNode) {
+    Write-Error "CAR39_RED bottom tabs remain visible over the expanded player"
+    exit 1
+}
+
+if (
+    ($expandedLyrics.Bottom - $expandedLyrics.Top) -lt 600 -or
+    [string]$expandedLyricsNode.scrollable -ne "true"
+) {
+    Write-Error "CAR39_RED expanded lyrics are not full-height and scrollable"
+    exit 1
+}
+
+Write-Output "CAR39_GREEN expanded player covers tabs and lyrics are full-height/scrollable"
+exit 0

--- a/scripts/check-car39-lyrics-visibility.py
+++ b/scripts/check-car39-lyrics-visibility.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Assert that more than the highlighted lyric row is visibly rendered."""
+
+import argparse
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+import numpy as np
+from PIL import Image
+
+
+BOUNDS = re.compile(r"\[(\d+),(\d+)]\[(\d+),(\d+)]")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("xml")
+    parser.add_argument("screenshot")
+    args = parser.parse_args()
+
+    image = np.asarray(Image.open(args.screenshot).convert("L"), dtype=np.int16)
+    height, width = image.shape
+    rows: dict[tuple[int, int], list[tuple[int, int, int, int]]] = {}
+    for node in ET.parse(args.xml).iter("node"):
+        match = BOUNDS.fullmatch(node.attrib.get("bounds", ""))
+        if not match or node.attrib.get("class") != "android.widget.TextView":
+            continue
+        left, top, right, bottom = map(int, match.groups())
+        if left < width // 2 + 50 or right > width - 50 or bottom - top < 50:
+            continue
+        key = next((key for key in rows if abs(key[0] - top) <= 4), (top, bottom))
+        rows.setdefault(key, []).append((left, top, right, bottom))
+
+    visible_rows = 0
+    details = []
+    for (top, bottom), boxes in sorted(rows.items()):
+        left = max(0, min(box[0] for box in boxes) - 4)
+        right = min(width, max(box[2] for box in boxes) + 4)
+        top = max(0, top)
+        bottom = min(height, bottom)
+        crop = image[top:bottom, left:right]
+        if crop.size == 0:
+            continue
+        horizontal = np.abs(np.diff(crop, axis=1))
+        vertical = np.abs(np.diff(crop, axis=0))
+        edge_pixels = int((horizontal > 3).sum() + (vertical > 3).sum())
+        visible = edge_pixels >= 100
+        visible_rows += int(visible)
+        details.append(f"[{top},{bottom}] edges={edge_pixels} visible={str(visible).lower()}")
+
+    print(f"CAR39_LYRICS rows={len(details)} visibleRows={visible_rows}")
+    for detail in details:
+        print(f"  {detail}")
+    if visible_rows < 2:
+        print("CAR39_RED only the highlighted lyric row is visibly rendered", file=sys.stderr)
+        return 1
+    print("CAR39_GREEN multiple lyric rows are visibly rendered")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Fix low-height/ultrawide and projected-player geometry so the collapsed mini-player stays above the tabs and the expanded player hides them.
- Preserve the tablet lyric presentation on car displays with variant-safe top/bottom masks and a 33% highlighted-row anchor for official and adapted Apple Music 6.5.0.
- Add a persisted `-10px..+10px` focus-blur radius offset while keeping the highlighted lyric clear and edge masks independent.
- Add JVM and ADB regression checks for player geometry and lyric visibility.

## Root cause

The player boundary sync was gated by an effective activity-window aspect ratio of `>= 1.7`. The vehicle display is physically 17:10, but its persistent left system rail narrows the Apple Music activity below 1.7. That skipped both parts of the same sync: collapsed navigation-space reservation and expanded tab hiding. The lyric hooks use a separate tablet predicate, which is why lyrics were fixed while the mini-player and tabs still failed.

Apple Music's flat bottom sheet also settles after its initial layout callback, and official/adapted 6.5.0 builds use different obfuscated fields for lyric gradients and metrics.

## Fix

The 1.7 ratio remains an eager hint, but every eligible flat tablet root now observes the actual player/tabs geometry. Compensation latches only after a settled collapsed sheet really overlaps the tabs. Before that signal the listener is visually inert, preserving ordinary non-overlapping tablet behavior. Once latched, collapsed state reserves the tabs height and expanded state clears the margin and makes the tabs frame invisible.

## Validation

- 125 JVM tests, 0 failures/errors
- `:app:assembleRelease`
- `:app:lintVitalRelease`
- `git diff --check`
- ADB 1920×1080 baseline:
  - collapsed mini-player `[856,954]` above `tabsTop=954`
  - expanded player and lyrics `[0,1080]`, lyrics scrollable, tabs absent
- A 1760×1080 effective-window repro deterministically caught the old 126px overlap before the fix
- Real 17:10 vehicle projection confirmed:
  - collapsed mini-player visible above tabs
  - expanded bottom tabs absent
  - lyric masks, blur, and highlighted-row placement unchanged
- Visual blur regression at `-10px`, `0px`, and `+10px`; highlighted row remains clear
- Final signed APK SHA-256: `056D4E1F4B23E5274D3F1208FB68F6AE076C22D8A28495980A32C08DDBE09AF6`