### PR TITLE
Add custom lyrics

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,4 +81,7 @@ dependencies {
     implementation("com.github.Dimezis:BlurView:version-3.2.0")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.24")
     testImplementation("junit:junit:4.13.2")
+    // org.json is part of the Android runtime but not of the local JVM; the
+    // test-only copy keeps the NetEase response parsing unit-testable.
+    testImplementation("org.json:json:20240303")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="dev.amenhancer.module.permission.REQUEST_CURRENT_SONG_ID" />
+
+    <permission
+        android:name="dev.amenhancer.module.permission.REQUEST_CURRENT_SONG_ID"
+        android:protectionLevel="signature" />
+
     <application
         android:name=".ModuleApplication"
         android:allowBackup="false"

--- a/app/src/main/java/dev/amenhancer/module/CurrentSongIdentityProtocol.kt
+++ b/app/src/main/java/dev/amenhancer/module/CurrentSongIdentityProtocol.kt
@@ -1,0 +1,21 @@
+package dev.amenhancer.module
+
+/** Private request/reply contract between the AM++ settings and target processes. */
+internal object CurrentSongIdentityProtocol {
+    const val REQUEST_ACTION = "dev.amenhancer.module.action.REQUEST_CURRENT_SONG_ID"
+    const val REQUEST_PERMISSION = "dev.amenhancer.module.permission.REQUEST_CURRENT_SONG_ID"
+    const val EXTRA_REQUEST_TOKEN = "dev.amenhancer.module.extra.CURRENT_SONG_ID_REQUEST_TOKEN"
+    const val EXTRA_RESULT_RECEIVER = "dev.amenhancer.module.extra.CURRENT_SONG_ID_RESULT_RECEIVER"
+    const val EXTRA_APPLE_MUSIC_ID = "dev.amenhancer.module.extra.CURRENT_SONG_ID"
+    const val EXTRA_SONG_TITLE = "dev.amenhancer.module.extra.CURRENT_SONG_TITLE"
+    const val EXTRA_SONG_ARTIST = "dev.amenhancer.module.extra.CURRENT_SONG_ARTIST"
+
+    const val RESULT_UNAVAILABLE = 0
+    const val RESULT_AVAILABLE = 1
+}
+
+internal data class CurrentSongDetails(
+    val appleMusicId: Long,
+    val title: String? = null,
+    val artist: String? = null,
+)

--- a/app/src/main/java/dev/amenhancer/module/ModuleConstants.kt
+++ b/app/src/main/java/dev/amenhancer/module/ModuleConstants.kt
@@ -4,11 +4,13 @@ object ModuleConstants {
     const val MODULE_PACKAGE = "dev.amenhancer.module"
     const val TARGET_PACKAGE = "com.apple.android.music"
     const val REMOTE_PREFERENCES_GROUP = "settings"
-    const val CONFIG_SCHEMA_VERSION = 5
+    const val CONFIG_SCHEMA_VERSION = 7
 
     const val FEATURE_DUAL_PANE = "dual_pane"
     const val FEATURE_EDITORIAL_VIDEO = "editorial_video"
     const val FEATURE_PHONE_LIQUID_GLASS = "phone_liquid_glass"
     const val FEATURE_FUTURE_BLUR = "future_blur"
     const val FEATURE_LYRICS_TYPEFACE = "lyrics_typeface"
+    const val FEATURE_CUSTOM_LYRICS = "custom_lyrics"
+    const val FEATURE_CURRENT_SONG_IDENTITY = "current_song_identity"
 }

--- a/app/src/main/java/dev/amenhancer/module/config/ConfigStore.kt
+++ b/app/src/main/java/dev/amenhancer/module/config/ConfigStore.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import dev.amenhancer.module.ModuleApplication
 import dev.amenhancer.module.XposedServiceSnapshot
+import dev.amenhancer.module.model.CustomLyricsManifest
 import dev.amenhancer.module.model.LyricsFontManifest
 import dev.amenhancer.module.model.ModuleSettings
 
@@ -38,6 +39,21 @@ class ConfigStore(context: Context) {
         return writeValues(
             preferences,
             ModuleSettingsSchema.encodeFontManifest(manifest),
+            synchronous = true,
+        )
+    }
+
+    internal fun saveCustomLyricsManifest(
+        manifest: CustomLyricsManifest,
+        snapshot: XposedServiceSnapshot = ModuleApplication.serviceSnapshot,
+    ): Boolean {
+        if (!snapshot.isRemoteFileAvailable || !ModuleApplication.isCurrentSnapshot(snapshot)) {
+            return false
+        }
+        val preferences = snapshot.preferences ?: return false
+        return writeValues(
+            preferences,
+            ModuleSettingsSchema.encodeCustomLyricsManifest(manifest),
             synchronous = true,
         )
     }

--- a/app/src/main/java/dev/amenhancer/module/config/CustomLyricsManifestCodec.kt
+++ b/app/src/main/java/dev/amenhancer/module/config/CustomLyricsManifestCodec.kt
@@ -1,0 +1,63 @@
+package dev.amenhancer.module.config
+
+import dev.amenhancer.module.model.CustomLyricsEntry
+import dev.amenhancer.module.model.CustomLyricsManifest
+import org.json.JSONArray
+import org.json.JSONObject
+
+/** JSON codec for the manifest only; TTML remains in remote files. */
+internal object CustomLyricsManifestCodec {
+    fun encode(manifest: CustomLyricsManifest): String {
+        val safe = CustomLyricsManifestPolicy.sanitize(manifest)
+        return JSONObject().apply {
+            put(KEY_VERSION, VERSION)
+            put(KEY_ENTRIES, JSONArray().apply {
+                safe.entries.forEach { entry ->
+                    put(JSONObject().apply {
+                        put(KEY_APPLE_MUSIC_ID, entry.appleMusicId)
+                        put(KEY_DISPLAY_NAME, entry.displayName)
+                        put(KEY_FILE_ID, entry.fileId)
+                        put(KEY_SIZE_BYTES, entry.sizeBytes)
+                        put(KEY_SHA256, entry.sha256)
+                        put(KEY_SOURCE, entry.source)
+                        put(KEY_ENABLED, entry.enabled)
+                    })
+                }
+            })
+        }.toString()
+    }
+
+    fun decode(raw: String): CustomLyricsManifest = runCatching {
+        val root = JSONObject(raw)
+        if (root.optInt(KEY_VERSION, 0) != VERSION) return@runCatching CustomLyricsManifest.empty()
+        val entries = root.optJSONArray(KEY_ENTRIES) ?: return@runCatching CustomLyricsManifest.empty()
+        val parsed = buildList {
+            for (index in 0 until entries.length()) {
+                val entry = entries.optJSONObject(index) ?: continue
+                add(
+                    CustomLyricsEntry(
+                        appleMusicId = entry.optLong(KEY_APPLE_MUSIC_ID, 0L),
+                        displayName = entry.optString(KEY_DISPLAY_NAME),
+                        fileId = entry.optString(KEY_FILE_ID),
+                        sizeBytes = entry.optLong(KEY_SIZE_BYTES, 0L),
+                        sha256 = entry.optString(KEY_SHA256),
+                        source = entry.optString(KEY_SOURCE),
+                        enabled = entry.optBoolean(KEY_ENABLED, false),
+                    ),
+                )
+            }
+        }
+        CustomLyricsManifestPolicy.sanitize(CustomLyricsManifest(parsed))
+    }.getOrDefault(CustomLyricsManifest.empty())
+
+    private const val VERSION = 1
+    private const val KEY_VERSION = "version"
+    private const val KEY_ENTRIES = "entries"
+    private const val KEY_APPLE_MUSIC_ID = "appleMusicId"
+    private const val KEY_DISPLAY_NAME = "displayName"
+    private const val KEY_FILE_ID = "fileId"
+    private const val KEY_SIZE_BYTES = "sizeBytes"
+    private const val KEY_SHA256 = "sha256"
+    private const val KEY_SOURCE = "source"
+    private const val KEY_ENABLED = "enabled"
+}

--- a/app/src/main/java/dev/amenhancer/module/config/CustomLyricsManifestPolicy.kt
+++ b/app/src/main/java/dev/amenhancer/module/config/CustomLyricsManifestPolicy.kt
@@ -1,0 +1,51 @@
+package dev.amenhancer.module.config
+
+import dev.amenhancer.module.lyrics.TtmlInputPolicy
+import dev.amenhancer.module.model.CustomLyricsEntry
+import dev.amenhancer.module.model.CustomLyricsManifest
+import dev.amenhancer.module.model.CustomLyricsSources
+
+/** Validates the small cross-process index without trusting remote preferences. */
+internal object CustomLyricsManifestPolicy {
+    const val MAX_ENTRIES = 32
+
+    private val fileIdPattern = Regex("[A-Za-z0-9_-]{1,96}")
+    private val sha256Pattern = Regex("[0-9a-fA-F]{64}")
+    private val allowedSources = setOf(
+        CustomLyricsSources.MANUAL,
+        CustomLyricsSources.AMLL,
+        CustomLyricsSources.NETEASE,
+    )
+
+    fun sanitize(manifest: CustomLyricsManifest): CustomLyricsManifest {
+        val entries = linkedMapOf<Long, CustomLyricsEntry>()
+        manifest.entries.forEach { raw ->
+            val entry = sanitizeEntry(raw) ?: return@forEach
+            if (entries.size < MAX_ENTRIES && entry.appleMusicId !in entries) {
+                entries[entry.appleMusicId] = entry
+            }
+        }
+        return CustomLyricsManifest(entries.values.toList())
+    }
+
+    fun sanitizeDisplayName(displayName: String): String = displayName
+        .filterNot(Char::isISOControl)
+        .trim()
+        .take(120)
+        .ifBlank { "自定义歌词" }
+
+    fun isValidFileId(fileId: String): Boolean =
+        fileIdPattern.matches(fileId) && fileId.none { it == '.' || it == '/' || it == '\\' }
+
+    private fun sanitizeEntry(raw: CustomLyricsEntry): CustomLyricsEntry? {
+        if (raw.appleMusicId <= 0L) return null
+        if (!isValidFileId(raw.fileId)) return null
+        if (raw.sizeBytes !in 1L..TtmlInputPolicy.MAX_TTML_BYTES.toLong()) return null
+        if (!sha256Pattern.matches(raw.sha256)) return null
+        if (raw.source !in allowedSources) return null
+        return raw.copy(
+            displayName = sanitizeDisplayName(raw.displayName),
+            sha256 = raw.sha256.lowercase(),
+        )
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/config/ModuleSettingsSchema.kt
+++ b/app/src/main/java/dev/amenhancer/module/config/ModuleSettingsSchema.kt
@@ -1,6 +1,7 @@
 package dev.amenhancer.module.config
 
 import dev.amenhancer.module.ModuleConstants
+import dev.amenhancer.module.model.CustomLyricsManifest
 import dev.amenhancer.module.model.LyricsFontManifest
 import dev.amenhancer.module.model.ModuleSettings
 
@@ -21,18 +22,25 @@ internal object ModuleSettingsSchema {
                 ModuleSettings.MIN_LYRIC_BLUR_RADIUS_OFFSET_PX,
                 ModuleSettings.MAX_LYRIC_BLUR_RADIUS_OFFSET_PX,
             ) ?: 0,
+        customLyricsEnabled = values.boolean(
+            KEY_CUSTOM_LYRICS_ENABLED,
+            default = values.boolean(KEY_LEGACY_ONLINE_LYRIC_REPLACEMENT, default = false),
+        ),
         fontManifest = values.fontManifest(),
+        customLyricsManifest = values.customLyricsManifest(),
         schemaVersion = values.number(KEY_SCHEMA_VERSION)
             ?: ModuleConstants.CONFIG_SCHEMA_VERSION,
     )
 
     fun encode(settings: ModuleSettings): Map<String, Any> =
-        encodeOrdinarySettings(settings) + encodeFontManifest(settings.fontManifest)
+        encodeOrdinarySettings(settings) +
+            encodeFontManifest(settings.fontManifest) +
+            encodeCustomLyricsManifest(settings.customLyricsManifest)
 
     /**
      * Runtime write map for ordinary settings only. Never carries the
-     * lyrics_font_* manifest keys, so a stale ModuleSettings captured before
-     * a font import cannot overwrite a manifest that saveFontManifest
+     * lyrics_font_* or custom_lyrics_manifest keys, so a stale ModuleSettings
+     * captured before a remote-file transaction cannot overwrite a manifest
      * committed afterwards.
      */
     fun encodeOrdinarySettings(settings: ModuleSettings): Map<String, Any> {
@@ -45,6 +53,7 @@ internal object ModuleSettingsSchema {
                 ModuleSettings.MIN_LYRIC_BLUR_RADIUS_OFFSET_PX,
                 ModuleSettings.MAX_LYRIC_BLUR_RADIUS_OFFSET_PX,
             ),
+            KEY_CUSTOM_LYRICS_ENABLED to settings.customLyricsEnabled,
         )
         values[KEY_SCHEMA_VERSION] = ModuleConstants.CONFIG_SCHEMA_VERSION
         return values
@@ -61,6 +70,9 @@ internal object ModuleSettingsSchema {
         )
     }
 
+    fun encodeCustomLyricsManifest(manifest: CustomLyricsManifest): Map<String, Any> =
+        linkedMapOf(KEY_CUSTOM_LYRICS_MANIFEST to CustomLyricsManifestCodec.encode(manifest))
+
     private fun Map<String, *>.fontManifest(): LyricsFontManifest {
         val raw = LyricsFontManifest(
             enabled = boolean(KEY_FONT_ENABLED, default = false),
@@ -71,6 +83,9 @@ internal object ModuleSettingsSchema {
         )
         return FontManifestPolicy.sanitize(raw)
     }
+
+    private fun Map<String, *>.customLyricsManifest(): CustomLyricsManifest =
+        CustomLyricsManifestCodec.decode(string(KEY_CUSTOM_LYRICS_MANIFEST))
 
     private fun Map<String, *>.string(key: String): String = this[key] as? String ?: ""
 
@@ -103,11 +118,14 @@ internal object ModuleSettingsSchema {
         KEY_PHONE_LIQUID_GLASS,
         KEY_FUTURE_BLUR,
         KEY_LYRIC_BLUR_RADIUS_OFFSET,
+        KEY_CUSTOM_LYRICS_ENABLED,
+        KEY_LEGACY_ONLINE_LYRIC_REPLACEMENT,
         KEY_FONT_ENABLED,
         KEY_FONT_FILE_ID,
         KEY_FONT_DISPLAY_NAME,
         KEY_FONT_SIZE_BYTES,
         KEY_FONT_SHA256,
+        KEY_CUSTOM_LYRICS_MANIFEST,
     )
 
     private const val KEY_DUAL_PANE = "dual_pane_enabled"
@@ -116,10 +134,13 @@ internal object ModuleSettingsSchema {
     private const val KEY_PHONE_LIQUID_GLASS = "phone_liquid_glass_enabled"
     private const val KEY_FUTURE_BLUR = "future_blur_enabled"
     private const val KEY_LYRIC_BLUR_RADIUS_OFFSET = "lyric_blur_radius_offset_px"
+    private const val KEY_CUSTOM_LYRICS_ENABLED = "custom_lyrics_enabled"
+    private const val KEY_LEGACY_ONLINE_LYRIC_REPLACEMENT = "online_lyric_replacement_enabled"
     private const val KEY_FONT_ENABLED = "lyrics_font_enabled"
     private const val KEY_FONT_FILE_ID = "lyrics_font_file_id"
     private const val KEY_FONT_DISPLAY_NAME = "lyrics_font_display_name"
     private const val KEY_FONT_SIZE_BYTES = "lyrics_font_size_bytes"
     private const val KEY_FONT_SHA256 = "lyrics_font_sha256"
+    private const val KEY_CUSTOM_LYRICS_MANIFEST = "custom_lyrics_manifest"
     private const val KEY_SCHEMA_VERSION = "schema_version"
 }

--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicCurrentSongIdentityTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicCurrentSongIdentityTarget.kt
@@ -1,0 +1,184 @@
+package dev.amenhancer.module.hook
+
+import android.app.Application
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Build
+import android.os.Bundle
+import android.os.ResultReceiver
+import dev.amenhancer.module.CurrentSongDetails
+import dev.amenhancer.module.CurrentSongIdentityProtocol
+import java.util.concurrent.atomic.AtomicReference
+
+internal data class TargetCurrentSong(
+    val item: Any,
+    val details: CurrentSongDetails,
+)
+
+/** Shared target-process state from Apple's player-level metadata funnel. */
+internal class CurrentSongIdentityCache {
+    private val current = AtomicReference<TargetCurrentSong?>(null)
+
+    fun publish(item: Any?, details: CurrentSongDetails?) {
+        current.set(
+            if (item != null && details != null && details.appleMusicId > 0L) {
+                TargetCurrentSong(item, details)
+            } else {
+                null
+            },
+        )
+    }
+
+    fun current(): TargetCurrentSong? = current.get()
+}
+
+/** Responds only to the module's signature-protected, user-initiated requests. */
+internal class CurrentSongIdentityRequestResponder(
+    private val application: Application,
+    private val cache: CurrentSongIdentityCache,
+    private val logger: (String) -> Unit,
+) {
+    private val receiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            if (intent.action != CurrentSongIdentityProtocol.REQUEST_ACTION) return
+            val token = intent.getStringExtra(CurrentSongIdentityProtocol.EXTRA_REQUEST_TOKEN)
+                ?.takeIf(String::isNotBlank)
+                ?: return
+            val resultReceiver = intent.resultReceiver() ?: return
+            val details = cache.current()?.details
+            resultReceiver.send(
+                if (details == null) {
+                    CurrentSongIdentityProtocol.RESULT_UNAVAILABLE
+                } else {
+                    CurrentSongIdentityProtocol.RESULT_AVAILABLE
+                },
+                Bundle().apply {
+                    putString(CurrentSongIdentityProtocol.EXTRA_REQUEST_TOKEN, token)
+                    details?.let {
+                        putLong(CurrentSongIdentityProtocol.EXTRA_APPLE_MUSIC_ID, it.appleMusicId)
+                        it.title?.let { title ->
+                            putString(CurrentSongIdentityProtocol.EXTRA_SONG_TITLE, title)
+                        }
+                        it.artist?.let { artist ->
+                            putString(CurrentSongIdentityProtocol.EXTRA_SONG_ARTIST, artist)
+                        }
+                    }
+                },
+            )
+        }
+    }
+
+    fun register(): Boolean = runCatching {
+        val filter = IntentFilter(CurrentSongIdentityProtocol.REQUEST_ACTION)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            application.registerReceiver(
+                receiver,
+                filter,
+                CurrentSongIdentityProtocol.REQUEST_PERMISSION,
+                null,
+                Context.RECEIVER_EXPORTED,
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            application.registerReceiver(
+                receiver,
+                filter,
+                CurrentSongIdentityProtocol.REQUEST_PERMISSION,
+                null,
+            )
+        }
+        true
+    }.onFailure { error ->
+        logger("current song identity request receiver failed: $error")
+    }.getOrDefault(false)
+
+    @Suppress("DEPRECATION")
+    private fun Intent.resultReceiver(): ResultReceiver? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            getParcelableExtra(
+                CurrentSongIdentityProtocol.EXTRA_RESULT_RECEIVER,
+                ResultReceiver::class.java,
+            )
+        } else {
+            getParcelableExtra(CurrentSongIdentityProtocol.EXTRA_RESULT_RECEIVER)
+        }
+}
+
+/**
+ * Publishes the verified current-item identity for SettingsActivity requests.
+ * Reuses [CurrentItemIdentitySeam] and never falls back to title or metadata
+ * matching; the capability reports missing or ambiguous independently.
+ */
+internal class AppleMusicCurrentSongIdentityTarget(
+    private val application: Application,
+    private val symbols: TargetSymbolResolver,
+    private val cache: CurrentSongIdentityCache,
+) : CurrentSongIdentityTarget {
+    override fun install(): TargetCapabilityInstall {
+        val installMethodResolution = symbols.resolve(AppleMusicSymbols.LyricsInstallMethod)
+        val installMethod = installMethodResolution.valueOrNull()
+            ?: return TargetCapabilityInstall.Degraded(installMethodResolution.summary)
+        val metadataPublishResolution = symbols.resolve(AppleMusicSymbols.PlayerMetadataPublishMethod)
+        val metadataPublishMethod = metadataPublishResolution.valueOrNull()
+            ?: return TargetCapabilityInstall.Degraded(metadataPublishResolution.summary)
+        val converterResolution = symbols.resolve(AppleMusicSymbols.MetadataToPlaybackItemMethod)
+        val converterMethod = converterResolution.valueOrNull()
+            ?: return TargetCapabilityInstall.Degraded(converterResolution.summary)
+        if (!runCatching {
+                metadataPublishMethod.isAccessible = true
+                converterMethod.isAccessible = true
+                true
+            }.getOrDefault(false)
+        ) {
+            return TargetCapabilityInstall.Degraded(
+                "Player metadata identity surface could not be made accessible; " +
+                    listOf(metadataPublishResolution.summary, converterResolution.summary)
+                        .joinToString("; "),
+            )
+        }
+        val seam = CurrentItemIdentitySeam(symbols)
+        seam.resolve(installMethod)?.let { diagnostic ->
+            return TargetCapabilityInstall.Degraded(diagnostic)
+        }
+        val hooked = runCatching {
+            ModernXposedRuntime.hookMethod(metadataPublishMethod, object : ModernMethodHook() {
+                override fun afterHookedMethod(param: MethodHookParam) {
+                    runCatching {
+                        val item = converterMethod.invoke(null, param.args.getOrNull(0))
+                        cache.publish(item, seam.detailsOfItem(item))
+                    }.onFailure { error ->
+                        ModernXposedRuntime.log("current song identity publish failed: $error")
+                    }
+                }
+            })
+        }.isSuccess
+        if (!hooked) {
+            return TargetCapabilityInstall.Degraded(
+                "Player metadata publish method could not be hooked; ${metadataPublishResolution.summary}",
+            )
+        }
+        if (!CurrentSongIdentityRequestResponder(
+                application = application,
+                cache = cache,
+                logger = ModernXposedRuntime::log,
+            ).register()
+        ) {
+            return TargetCapabilityInstall.Degraded(
+                "Current song identity request receiver could not be registered; " +
+                    installMethodResolution.summary,
+            )
+        }
+        return TargetCapabilityInstall.Active(
+            "Current song identity request responder installed; " +
+                listOfNotNull(
+                    installMethodResolution.summary,
+                    metadataPublishResolution.summary,
+                    converterResolution.summary,
+                    seam.fieldSummary.orEmpty(),
+                    seam.metadataSummary,
+                ).joinToString("; "),
+        )
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicCustomLyricsTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicCustomLyricsTarget.kt
@@ -120,7 +120,7 @@ internal class AppleMusicCustomLyricsTarget(
                         if (nativeLyricsAvailable) return@runCatching
                         val appleMusicId = seam.detailsOfItem(param.args.getOrNull(0))?.appleMusicId
                         val replacementReady = appleMusicId != null &&
-                            session.readyReplacementFor(appleMusicId) != null
+                            session.replacementOrPrepareFor(appleMusicId) != null
                         if (
                             shouldExposeCustomLyrics(
                                 nativeLyricsAvailable = nativeLyricsAvailable,

--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicCustomLyricsTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicCustomLyricsTarget.kt
@@ -1,0 +1,174 @@
+package dev.amenhancer.module.hook
+
+import android.os.ParcelFileDescriptor
+import dev.amenhancer.module.config.TargetConfigClient
+import dev.amenhancer.module.lyrics.CustomLyricsFilePolicy
+import dev.amenhancer.module.lyrics.CustomLyricsFileReader
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+
+/** Apple Music 6.5.0 adapter for user-managed, offline ID -> TTML mappings. */
+internal class AppleMusicCustomLyricsTarget(
+    private val config: TargetConfigClient,
+    private val symbols: TargetSymbolResolver,
+) : CustomLyricsTarget {
+    override fun install(): TargetCapabilityInstall {
+        val installMethodResolution = symbols.resolve(AppleMusicSymbols.LyricsInstallMethod)
+        val installMethod = installMethodResolution.valueOrNull()
+            ?: return TargetCapabilityInstall.Degraded(installMethodResolution.summary)
+        if (!runCatching {
+                installMethod.isAccessible = true
+                true
+            }.getOrDefault(false)
+        ) {
+            return TargetCapabilityInstall.Degraded(
+                "PlayerLyricsViewFragment.I2 could not be made accessible; " +
+                    installMethodResolution.summary,
+            )
+        }
+        val ptrResolution = symbols.resolve(AppleMusicSymbols.SongInfoPtr)
+        val ptrClass = ptrResolution.valueOrNull()
+            ?: return TargetCapabilityInstall.Degraded(ptrResolution.summary)
+        val nativeResolution = symbols.resolve(AppleMusicSymbols.SongInfoNative)
+        val nativeClass = nativeResolution.valueOrNull()
+            ?: return TargetCapabilityInstall.Degraded(nativeResolution.summary)
+        val parserResolution = symbols.resolve(AppleMusicSymbols.TtmlParserNative)
+        val parserClass = parserResolution.valueOrNull()
+            ?: return TargetCapabilityInstall.Degraded(parserResolution.summary)
+        val parseMethodResolution = symbols.resolve(AppleMusicSymbols.TtmlSongInfoFromTtml)
+        val parseMethod = parseMethodResolution.valueOrNull()
+            ?: return TargetCapabilityInstall.Degraded(parseMethodResolution.summary)
+        val seam = CurrentItemIdentitySeam(symbols)
+        seam.resolve(installMethod)?.let { diagnostic ->
+            return TargetCapabilityInstall.Degraded(diagnostic)
+        }
+        val parser = TtmlNativeParser.create(
+            parserClass = parserClass,
+            parseMethod = parseMethod,
+            ptrClass = ptrClass,
+            nativeClass = nativeClass,
+        ) ?: return TargetCapabilityInstall.Degraded(
+            "TTML native parser surface was unavailable; " +
+                listOf(
+                    parserResolution.summary,
+                    parseMethodResolution.summary,
+                    ptrResolution.summary,
+                    nativeResolution.summary,
+                ).joinToString("; "),
+        )
+        val fileReader = CustomLyricsFileReader { fileId ->
+            config.openRemoteFile(fileId)?.let { descriptor ->
+                runCatching {
+                    ParcelFileDescriptor.AutoCloseInputStream(descriptor).use(
+                        CustomLyricsFilePolicy::readBounded,
+                    )
+                }.getOrNull()
+            }
+        }
+        val session = CustomLyricsReplacementSession(
+            manifestProvider = { config.settings().customLyricsManifest },
+            readTtml = fileReader::read,
+            parseTtml = parser::parse,
+            isAlive = parser::isAlive,
+            verifyPtr = parser::isValid,
+            readAdamId = parser::adamIdOf,
+            bindAdamId = parser::bindAdamId,
+            executor = ThreadPoolExecutor(
+                1,
+                1,
+                0L,
+                TimeUnit.MILLISECONDS,
+                ArrayBlockingQueue(1),
+                { runnable -> Thread(runnable, "ampp-custom-lyrics").apply { isDaemon = true } },
+                ThreadPoolExecutor.AbortPolicy(),
+            ),
+            logger = ModernXposedRuntime::log,
+        )
+        val hooked = runCatching {
+            ModernXposedRuntime.hookMethod(installMethod, object : ModernMethodHook() {
+                override fun beforeHookedMethod(param: MethodHookParam) {
+                    runCatching {
+                        if (!acceptsLyricsInstallArguments(param.args, ptrClass)) return@runCatching
+                        val original = param.args[0]
+                        val adamId = seam.currentItemAdamIdOf(param.thisObject)
+                        adamId ?: return@runCatching
+                        session.replacementFor(adamId)?.let { replacement ->
+                            if (replacement !== original) {
+                                param.args[0] = replacement
+                            }
+                        }
+                    }.onFailure { error ->
+                        ModernXposedRuntime.log("custom lyrics I2 replacement hook failed: $error")
+                    }
+                }
+            })
+        }.isSuccess
+        if (!hooked) {
+            return TargetCapabilityInstall.Degraded(
+                "PlayerLyricsViewFragment.I2 could not be hooked; ${installMethodResolution.summary}",
+            )
+        }
+        val availabilityResolution = symbols.resolve(AppleMusicSymbols.LyricsAvailabilityPredicate)
+        val availabilityMethod = availabilityResolution.valueOrNull()
+        val availabilityHooked = availabilityMethod != null && runCatching {
+            availabilityMethod.isAccessible = true
+            ModernXposedRuntime.hookMethod(availabilityMethod, object : ModernMethodHook() {
+                override fun afterHookedMethod(param: MethodHookParam) {
+                    runCatching {
+                        val nativeLyricsAvailable = param.result as? Boolean ?: return@runCatching
+                        if (nativeLyricsAvailable) return@runCatching
+                        val appleMusicId = seam.detailsOfItem(param.args.getOrNull(0))?.appleMusicId
+                        val replacementReady = appleMusicId != null &&
+                            session.readyReplacementFor(appleMusicId) != null
+                        if (
+                            shouldExposeCustomLyrics(
+                                nativeLyricsAvailable = nativeLyricsAvailable,
+                                appleMusicId = appleMusicId,
+                                replacementReady = replacementReady,
+                            )
+                        ) {
+                            param.result = true
+                        }
+                    }.onFailure { error ->
+                        ModernXposedRuntime.log("custom lyrics availability hook failed: $error")
+                    }
+                }
+            })
+        }.isSuccess
+        session.start()
+        if (!availabilityHooked) {
+            return TargetCapabilityInstall.Degraded(
+                "Custom lyric I2 replacement installed, but unavailable-lyrics entry could not be enabled; " +
+                    availabilityResolution.summary,
+            )
+        }
+        return TargetCapabilityInstall.Active(
+            "Custom lyric ID mappings installed; " +
+                listOf(
+                    installMethodResolution.summary,
+                    availabilityResolution.summary,
+                    ptrResolution.summary,
+                    nativeResolution.summary,
+                    parserResolution.summary,
+                    parseMethodResolution.summary,
+                    seam.fieldSummary.orEmpty(),
+                ).joinToString("; "),
+        )
+    }
+
+}
+
+/**
+ * Apple emits a null SongInfoPtr when a playback item has no native lyrics.
+ * That null still travels through PlayerLyricsViewFragment.I2 and is the
+ * capture point needed to refresh the fragment once a manual pointer is ready.
+ */
+internal fun acceptsLyricsInstallArguments(args: Array<Any?>, ptrClass: Class<*>): Boolean =
+    args.isNotEmpty() && (args[0] == null || ptrClass.isInstance(args[0]))
+
+internal fun shouldExposeCustomLyrics(
+    nativeLyricsAvailable: Boolean,
+    appleMusicId: Long?,
+    replacementReady: Boolean,
+): Boolean = nativeLyricsAvailable || (appleMusicId != null && appleMusicId > 0L && replacementReady)

--- a/app/src/main/java/dev/amenhancer/module/hook/CurrentItemIdentitySeam.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/CurrentItemIdentitySeam.kt
@@ -1,0 +1,105 @@
+package dev.amenhancer.module.hook
+
+import dev.amenhancer.module.CurrentSongDetails
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+
+/**
+ * The verified current lyrics item identity seam: the I2 fragment's current
+ * item field (`com.apple.android.music.player.fragment.m#c` of type
+ * `com.apple.android.music.model.BaseContentItem`) read through `getId()` and
+ * parsed with [parseCurrentItemAdamId]. The same item optionally supplies
+ * `getTitle()` and `getArtistName()` for the standalone current-song form.
+ *
+ * Lyric replacement and current-song identity capability share this exact
+ * contract; neither consumer may reinterpret the identity as a title or
+ * metadata match. Both resolve the seam through the same
+ * [AppleMusicSymbols.LyricsCurrentItemField] symbol so a version change is
+ * reported once as missing or ambiguous instead of being guessed.
+ */
+internal class CurrentItemIdentitySeam(
+    private val symbols: TargetSymbolResolver,
+) {
+    private lateinit var currentItemField: Field
+    private lateinit var currentItemGetId: Method
+    private var currentItemGetTitle: Method? = null
+    private var currentItemGetArtistName: Method? = null
+
+    /** The verified current item field resolution summary, or null before resolve. */
+    var fieldSummary: String? = null
+        private set
+
+    /** Optional metadata contracts used by the standalone current-song UI. */
+    var metadataSummary: String? = null
+        private set
+
+    /**
+     * Resolves the seam against the given I2 install entry point. Returns a
+     * diagnostic when the contract cannot be established, or null once the
+     * seam is ready to read identities.
+     */
+    fun resolve(installMethod: Method): String? {
+        val currentItemResolution = symbols.resolve(AppleMusicSymbols.LyricsCurrentItemField)
+        val currentItemFieldValue = currentItemResolution.valueOrNull()
+            ?: return currentItemResolution.summary
+        val getId = resolveCurrentItemGetId(currentItemFieldValue.type)
+            ?: return "BaseContentItem#getId() was unavailable; ${currentItemResolution.summary}"
+        if (!currentItemFieldValue.declaringClass.isAssignableFrom(installMethod.declaringClass)) {
+            return "Current lyrics item field is not in the I2 fragment hierarchy; " +
+                currentItemResolution.summary
+        }
+        currentItemField = currentItemFieldValue.apply { isAccessible = true }
+        currentItemGetId = getId
+        currentItemGetTitle = resolveStringGetter(currentItemFieldValue.type, "getTitle")
+        currentItemGetArtistName = resolveStringGetter(currentItemFieldValue.type, "getArtistName")
+        fieldSummary = currentItemResolution.summary
+        metadataSummary = buildList {
+            if (currentItemGetTitle == null) add("current-item-title-method unavailable")
+            if (currentItemGetArtistName == null) add("current-item-artist-method unavailable")
+        }.takeIf { it.isNotEmpty() }?.joinToString("; ")
+        return null
+    }
+
+    /** The current lyrics item Adam ID of an I2 fragment, or null when unavailable. */
+    fun currentItemAdamIdOf(fragment: Any?): Long? {
+        if (fragment == null) return null
+        return runCatching {
+            val item = currentItemField.get(fragment) ?: return@runCatching null
+            parseCurrentItemAdamId(currentItemGetId.invoke(item))
+        }.getOrNull()
+    }
+
+    /** Reads identity directly from a verified player item argument. */
+    fun detailsOfItem(item: Any?): CurrentSongDetails? {
+        if (item == null) return null
+        return runCatching {
+            val appleMusicId = parseCurrentItemAdamId(currentItemGetId.invoke(item))
+                ?: return@runCatching null
+            CurrentSongDetails(
+                appleMusicId = appleMusicId,
+                title = invokeStringGetter(currentItemGetTitle, item),
+                artist = invokeStringGetter(currentItemGetArtistName, item),
+            )
+        }.getOrNull()
+    }
+
+    private fun resolveCurrentItemGetId(itemType: Class<*>): Method? = resolveStringGetter(itemType, "getId")
+
+    private fun resolveStringGetter(itemType: Class<*>, name: String): Method? = runCatching {
+        itemType.getMethod(name)
+            .takeIf { method -> method.returnType == String::class.java }
+            ?.apply { isAccessible = true }
+    }.getOrNull()
+
+    private fun invokeStringGetter(method: Method?, receiver: Any): String? = method
+        ?.let { runCatching { it.invoke(receiver) as? String }.getOrNull() }
+        ?.trim()
+        ?.takeIf(String::isNotEmpty)
+}
+
+/** Parses Apple's current item identity; only a positive Adam ID is accepted. */
+internal fun parseCurrentItemAdamId(value: Any?): Long? = when (value) {
+    is String -> value.toLongOrNull()
+    is Number -> value.toLong()
+    else -> null
+}?.takeIf { it > 0L }

--- a/app/src/main/java/dev/amenhancer/module/hook/CurrentSongIdentityFeature.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/CurrentSongIdentityFeature.kt
@@ -1,0 +1,15 @@
+package dev.amenhancer.module.hook
+
+import dev.amenhancer.module.ModuleConstants
+
+/**
+ * Diagnostics capability: serves current-song identity requests from the
+ * standalone settings page. Not gated by a module setting — requests fail
+ * closed when the capability is unavailable.
+ */
+internal class CurrentSongIdentityFeature : FeatureHook {
+    override val key: String = ModuleConstants.FEATURE_CURRENT_SONG_IDENTITY
+
+    override fun install(context: HookContext): FeatureInstallResult =
+        context.target.currentSongIdentity.install().toFeatureInstallResult()
+}

--- a/app/src/main/java/dev/amenhancer/module/hook/CustomLyricsFeature.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/CustomLyricsFeature.kt
@@ -1,0 +1,15 @@
+package dev.amenhancer.module.hook
+
+import dev.amenhancer.module.ModuleConstants
+
+/** Module setting and health adapter around user-managed lyric mappings. */
+internal class CustomLyricsFeature : FeatureHook {
+    override val key: String = ModuleConstants.FEATURE_CUSTOM_LYRICS
+
+    override fun install(context: HookContext): FeatureInstallResult {
+        if (!context.config.settings().customLyricsEnabled) {
+            return FeatureInstallResult.disabled()
+        }
+        return context.target.customLyrics.install().toFeatureInstallResult()
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/hook/CustomLyricsReplacementSession.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/CustomLyricsReplacementSession.kt
@@ -63,6 +63,14 @@ internal class CustomLyricsReplacementSession(
         return null
     }
 
+    /** Returns a ready pointer or queues off-hook recovery for a known mapping. */
+    fun replacementOrPrepareFor(appleMusicId: Long): Any? {
+        if (appleMusicId <= 0L || !entriesById.containsKey(appleMusicId)) return null
+        readyReplacementFor(appleMusicId)?.let { return it }
+        queuePreload()
+        return null
+    }
+
     private fun queuePreload() {
         if (!preloadQueued.compareAndSet(false, true)) return
         try {

--- a/app/src/main/java/dev/amenhancer/module/hook/CustomLyricsReplacementSession.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/CustomLyricsReplacementSession.kt
@@ -1,0 +1,129 @@
+package dev.amenhancer.module.hook
+
+import dev.amenhancer.module.model.CustomLyricsEntry
+import dev.amenhancer.module.model.CustomLyricsManifest
+import java.util.LinkedHashMap
+import java.util.concurrent.Executor
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Resolves only user-published ID mappings. It intentionally has no metadata
+ * matching, network, or refresh behavior in the hook path. Remote
+ * files and native parsing are prepared off-hook; I2 only consumes a cache.
+ */
+internal class CustomLyricsReplacementSession(
+    private val manifestProvider: () -> CustomLyricsManifest,
+    private val readTtml: (CustomLyricsEntry) -> String?,
+    private val parseTtml: (String) -> Any?,
+    private val isAlive: (Any?) -> Boolean,
+    private val verifyPtr: (Any?) -> Boolean,
+    private val readAdamId: (Any) -> Long?,
+    private val bindAdamId: (Any, Long) -> Boolean,
+    private val executor: Executor,
+    private val logger: (String) -> Unit,
+) {
+    private data class CacheKey(
+        val appleMusicId: Long,
+        val fileId: String,
+        val sha256: String,
+    )
+
+    private val cache = object : LinkedHashMap<CacheKey, Any>(CACHE_CAPACITY, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<CacheKey, Any>?): Boolean =
+            size > CACHE_CAPACITY
+    }
+    @Volatile
+    private var entriesById: Map<Long, CustomLyricsEntry> = emptyMap()
+    private val preloadQueued = AtomicBoolean(false)
+
+    fun start() {
+        queuePreload()
+    }
+
+    fun replacementFor(appleMusicId: Long): Any? {
+        if (appleMusicId <= 0L) return null
+        readyReplacementFor(appleMusicId)?.let { return it }
+        queuePreload()
+        return null
+    }
+
+    /** Ready cache only; safe for availability predicates and other hot paths. */
+    fun readyReplacementFor(appleMusicId: Long): Any? {
+        if (appleMusicId <= 0L) return null
+        val entry = entriesById[appleMusicId]
+            ?: return null
+        val key = CacheKey(entry.appleMusicId, entry.fileId, entry.sha256)
+        synchronized(cache) {
+            cache[key]?.let { cached ->
+                if (runCatching { isAlive(cached) }.getOrDefault(false)) return cached
+                cache.remove(key)
+            }
+        }
+        return null
+    }
+
+    private fun queuePreload() {
+        if (!preloadQueued.compareAndSet(false, true)) return
+        try {
+            executor.execute {
+                try {
+                    preload()
+                } finally {
+                    preloadQueued.set(false)
+                }
+            }
+        } catch (_: RejectedExecutionException) {
+            preloadQueued.set(false)
+            logger("custom lyrics preloader rejected its task")
+        }
+    }
+
+    private fun preload() {
+        val manifest = runCatching { manifestProvider() }.getOrElse { error ->
+            logger("custom lyrics manifest read failed: $error")
+            return
+        }
+        val entries = manifest.entries
+            .filter(CustomLyricsEntry::enabled)
+            .associateBy(CustomLyricsEntry::appleMusicId)
+        entriesById = entries
+        val activeKeys = entries.values.mapTo(mutableSetOf()) { entry ->
+            CacheKey(entry.appleMusicId, entry.fileId, entry.sha256)
+        }
+        synchronized(cache) {
+            cache.keys.retainAll(activeKeys)
+        }
+        entries.values.forEach(::prepare)
+    }
+
+    private fun prepare(entry: CustomLyricsEntry) {
+        val key = CacheKey(entry.appleMusicId, entry.fileId, entry.sha256)
+        synchronized(cache) {
+            cache[key]?.let { cached ->
+                if (isPrepared(cached, entry.appleMusicId)) return
+                cache.remove(key)
+            }
+        }
+        val ttml = runCatching { readTtml(entry) }.getOrNull() ?: return
+        val replacement = runCatching { parseTtml(ttml) }.getOrNull() ?: return
+        if (!isPrepared(replacement, entry.appleMusicId) && !bindAdamId(replacement, entry.appleMusicId)) {
+            logger("custom lyrics parser returned an unusable SongInfoPtr for ${entry.appleMusicId}")
+            return
+        }
+        if (!isPrepared(replacement, entry.appleMusicId)) {
+            logger("custom lyrics SongInfoPtr Adam ID binding failed for ${entry.appleMusicId}")
+            return
+        }
+        synchronized(cache) {
+            cache[key] = replacement
+        }
+    }
+
+    private fun isPrepared(pointer: Any, appleMusicId: Long): Boolean =
+        runCatching { verifyPtr(pointer) && readAdamId(pointer) == appleMusicId }.getOrDefault(false)
+
+    private companion object {
+        const val CACHE_CAPACITY = 32
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/hook/FeatureInstallation.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/FeatureInstallation.kt
@@ -211,6 +211,8 @@ private fun productionFeatureInstallationModule(): FeatureInstallationModule {
                 feature = LyricsTypefaceFeature(),
                 registerResources = lyricsTypefaceSession::registerResources,
             ),
+            FeatureInstallationPlan(feature = CurrentSongIdentityFeature()),
+            FeatureInstallationPlan(feature = CustomLyricsFeature()),
         ),
         installLayoutInflationHooks = LayoutInflationRegistry::install,
         registerApplicationCreated = { config, targetClassLoader, onCreated ->
@@ -222,9 +224,10 @@ private fun productionFeatureInstallationModule(): FeatureInstallationModule {
                         HookContext(
                             config = config,
                             target = TargetAdaptation.appleMusic(
-                                application,
-                                targetClassLoader,
-                                lyricsTypefaceSession,
+                                config = config,
+                                application = application,
+                                classLoader = targetClassLoader,
+                                lyricsTypefaceSession = lyricsTypefaceSession,
                             ),
                         )
                     }

--- a/app/src/main/java/dev/amenhancer/module/hook/OnlineLyricClients.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/OnlineLyricClients.kt
@@ -1,0 +1,59 @@
+package dev.amenhancer.module.hook
+
+import dev.amenhancer.module.lyrics.LyricDocument
+import dev.amenhancer.module.lyrics.NeteaseEapi
+import dev.amenhancer.module.lyrics.YrcParser
+import org.json.JSONObject
+
+/**
+ * AMLL TTML DB client. Direct, fixed URL per Adam ID; a 404 (or any HTTP
+ * failure) simply falls through to the next source.
+ */
+internal class AmllTtmlClient(private val transport: LyricHttpTransport) {
+    fun fetch(adamId: Long): String? =
+        transport.get("$AMLL_TTML_DB_BASE/am-lyrics/$adamId.ttml")
+
+    companion object {
+        const val AMLL_TTML_DB_BASE =
+            "https://raw.githubusercontent.com/amll-dev/amll-ttml-db/refs/heads/main"
+    }
+}
+
+/**
+ * NetEase lyric client.
+ *
+ * The word-level YRC track is only available through the EAPI endpoint behind
+ * `/lyric/new` — the plain `GET /api/song/lyric` response carries no `yrc` —
+ * so this user-triggered import fetches an explicitly supplied NetEase song
+ * ID through a bounded EAPI POST (`/api/song/lyric/v1`, see [NeteaseEapi]).
+ * No cookies, tokens or account state are sent or persisted.
+ *
+ * A response without a usable `yrc` yields `null`; word timing is never
+ * fabricated from `lrc`.
+ */
+internal class NeteaseLyricClient(private val transport: LyricHttpTransport) {
+
+    fun fetchYrc(songId: Long): LyricDocument? {
+        val response = transport.postForm(
+            url = NeteaseEapi.LYRIC_V1_URL,
+            body = "params=${NeteaseEapi.lyricV1Params(songId)}",
+            extraHeaders = NETEASE_HEADERS,
+        ) ?: return null
+        return runCatching {
+            val root = JSONObject(response)
+            if (root.optInt("code", -1) != 200) return@runCatching null
+            val yrc = root.optJSONObject("yrc")?.optString("lyric").orEmpty()
+            YrcParser.parse(yrc)
+        }.getOrNull()
+    }
+
+    private companion object {
+        val NETEASE_HEADERS = mapOf(
+            "Origin" to "https://music.163.com",
+            "Referer" to "https://music.163.com",
+            "User-Agent" to
+                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) " +
+                "Chrome/60.0.3112.90 Safari/537.36",
+        )
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/hook/OnlineLyricHttpClient.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/OnlineLyricHttpClient.kt
@@ -1,0 +1,93 @@
+package dev.amenhancer.module.hook
+
+import java.io.ByteArrayOutputStream
+import java.net.HttpURLConnection
+import java.net.URL
+
+/** Network surface used by the lyric clients; faked in unit tests. */
+internal interface LyricHttpTransport {
+    fun get(url: String): String?
+    fun postForm(
+        url: String,
+        body: String,
+        extraHeaders: Map<String, String> = emptyMap(),
+    ): String?
+}
+
+/**
+ * Minimal HTTP transport for lyric sources. Strict timeouts, a hard response
+ * size cap and fail-open semantics: any network problem returns `null` and
+ * the caller keeps the original lyrics. Runs on the background executor only,
+ * never on the parser/I2 hook or the main thread.
+ */
+internal class HttpLyricTransport(
+    private val connectTimeoutMs: Int = DEFAULT_CONNECT_TIMEOUT_MS,
+    private val readTimeoutMs: Int = DEFAULT_READ_TIMEOUT_MS,
+    private val maxResponseBytes: Int = DEFAULT_MAX_RESPONSE_BYTES,
+) : LyricHttpTransport {
+
+    override fun get(url: String): String? = request(method = "GET", url = url, body = null)
+
+    override fun postForm(
+        url: String,
+        body: String,
+        extraHeaders: Map<String, String>,
+    ): String? = request(
+        method = "POST",
+        url = url,
+        body = body,
+        extraHeaders = extraHeaders + FORM_HEADERS,
+    )
+
+    private fun request(
+        method: String,
+        url: String,
+        body: String?,
+        extraHeaders: Map<String, String> = emptyMap(),
+    ): String? = runCatching {
+        val connection = URL(url).openConnection() as HttpURLConnection
+        try {
+            connection.requestMethod = method
+            connection.connectTimeout = connectTimeoutMs
+            connection.readTimeout = readTimeoutMs
+            connection.instanceFollowRedirects = true
+            connection.setRequestProperty("User-Agent", USER_AGENT)
+            connection.setRequestProperty("Accept", "text/plain, application/json;q=0.9, */*;q=0.5")
+            extraHeaders.forEach { (name, value) -> connection.setRequestProperty(name, value) }
+            if (body != null) {
+                connection.doOutput = true
+                connection.outputStream.use { output ->
+                    output.write(body.toByteArray(Charsets.UTF_8))
+                }
+            }
+            if (connection.responseCode != HttpURLConnection.HTTP_OK) return null
+            readBounded(connection)
+        } finally {
+            connection.disconnect()
+        }
+    }.getOrNull()
+
+    private fun readBounded(connection: HttpURLConnection): String? {
+        val buffer = java.io.ByteArrayOutputStream()
+        connection.inputStream.use { input ->
+            val chunk = ByteArray(8192)
+            while (buffer.size() < maxResponseBytes) {
+                val read = input.read(chunk)
+                if (read < 0) break
+                buffer.write(chunk, 0, read)
+            }
+        }
+        if (buffer.size() >= maxResponseBytes) return null
+        return buffer.toString(Charsets.UTF_8.name())
+    }
+
+    companion object {
+        const val DEFAULT_CONNECT_TIMEOUT_MS = 10_000
+        const val DEFAULT_READ_TIMEOUT_MS = 15_000
+        const val DEFAULT_MAX_RESPONSE_BYTES = 1 shl 20
+        private const val USER_AGENT = "AMPlusPlus/1.2.1"
+        private val FORM_HEADERS = mapOf(
+            "Content-Type" to "application/x-www-form-urlencoded; charset=UTF-8",
+        )
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/hook/TargetAdaptation.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/TargetAdaptation.kt
@@ -1,6 +1,7 @@
 package dev.amenhancer.module.hook
 
 import android.app.Application
+import dev.amenhancer.module.config.TargetConfigClient
 
 /**
  * The complete target-specific seam used by feature hooks.
@@ -16,9 +17,16 @@ internal data class TargetAdaptation(
     val lyricsTypeface: LyricsTypefaceTarget = LyricsTypefaceTarget {
         TargetCapabilityInstall.Degraded("Lyrics typeface target was not configured")
     },
+    val customLyrics: CustomLyricsTarget = CustomLyricsTarget {
+        TargetCapabilityInstall.Degraded("Custom lyrics target was not configured")
+    },
+    val currentSongIdentity: CurrentSongIdentityTarget = CurrentSongIdentityTarget {
+        TargetCapabilityInstall.Degraded("Current song identity target was not configured")
+    },
 ) {
     companion object {
         fun appleMusic(
+            config: TargetConfigClient,
             application: Application,
             classLoader: ClassLoader,
             lyricsTypefaceSession: LyricsTypefaceSession? = null,
@@ -28,6 +36,7 @@ internal data class TargetAdaptation(
                 build = build,
                 source = ApkTargetClassSource(application, classLoader),
             )
+            val currentSong = CurrentSongIdentityCache()
             return TargetAdaptation(
                 identity = build.displayName,
                 dualPane = AppleMusicDualPaneTarget(resolver),
@@ -36,6 +45,12 @@ internal data class TargetAdaptation(
                 lyricsTypeface = AppleMusicLyricsTypefaceTarget(
                     symbols = resolver,
                     session = lyricsTypefaceSession ?: LyricsTypefaceSession(),
+                ),
+                customLyrics = AppleMusicCustomLyricsTarget(config, resolver),
+                currentSongIdentity = AppleMusicCurrentSongIdentityTarget(
+                    application,
+                    resolver,
+                    currentSong,
                 ),
             )
         }
@@ -55,6 +70,14 @@ internal fun interface BidirectionalLyricBlurTarget {
 }
 
 internal fun interface LyricsTypefaceTarget {
+    fun install(): TargetCapabilityInstall
+}
+
+internal fun interface CustomLyricsTarget {
+    fun install(): TargetCapabilityInstall
+}
+
+internal fun interface CurrentSongIdentityTarget {
     fun install(): TargetCapabilityInstall
 }
 

--- a/app/src/main/java/dev/amenhancer/module/hook/TargetSymbols.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/TargetSymbols.kt
@@ -2,6 +2,7 @@ package dev.amenhancer.module.hook
 
 import android.view.View
 import dev.amenhancer.module.ModuleConstants
+import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.util.IdentityHashMap
@@ -101,6 +102,19 @@ internal class TargetClassIndex(private val source: TargetClassSource) {
             }.getOrDefault(emptyList())
         }
         .distinctBy(::methodIdentity)
+
+    fun fields(
+        namePredicate: (String) -> Boolean,
+        contract: (Field) -> Boolean,
+    ): List<Field> = classes(namePredicate) { true }
+        .flatMap { type ->
+            runCatching {
+                type.declaredFields.filter { field ->
+                    runCatching { contract(field) }.getOrDefault(false)
+                }
+            }.getOrDefault(emptyList())
+        }
+        .distinctBy(::fieldIdentity)
 }
 
 internal class TargetSymbolKey<T : Any>(
@@ -179,6 +193,13 @@ internal enum class TargetSymbolId {
     LYRICS_HIGHLIGHT_CALLBACK_OWNER,
     LYRICS_VIEW_MODEL,
     STACKED_NAVIGATION_MENU,
+    SONG_INFO_PTR,
+    SONG_INFO_NATIVE,
+    TTML_PARSER_NATIVE,
+    LYRICS_CURRENT_ITEM_FIELD,
+    PLAYER_METADATA_HUB,
+    METADATA_TO_ITEM_CONVERTER,
+    LYRICS_AVAILABILITY_OWNER,
 }
 
 private object AppleMusicProfiles {
@@ -199,6 +220,17 @@ private object AppleMusicProfiles {
             TargetSymbolId.LYRICS_VIEW_MODEL to
                 "com.apple.android.music.player.viewmodel.PlayerLyricsViewModel",
             TargetSymbolId.STACKED_NAVIGATION_MENU to "Hd.b",
+            TargetSymbolId.SONG_INFO_PTR to
+                "com.apple.android.music.ttml.javanative.model.SongInfo\$SongInfoPtr",
+            TargetSymbolId.SONG_INFO_NATIVE to
+                "com.apple.android.music.ttml.javanative.model.SongInfo\$SongInfoNative",
+            TargetSymbolId.TTML_PARSER_NATIVE to
+                "com.apple.android.music.ttml.javanative.TTMLParser\$TTMLParserNative",
+            TargetSymbolId.LYRICS_CURRENT_ITEM_FIELD to
+                "com.apple.android.music.player.fragment.m",
+            TargetSymbolId.PLAYER_METADATA_HUB to "com.apple.android.music.player.f",
+            TargetSymbolId.METADATA_TO_ITEM_CONVERTER to "com.apple.android.music.player.P",
+            TargetSymbolId.LYRICS_AVAILABILITY_OWNER to "com.apple.android.music.player.d1",
         ),
     )
 
@@ -326,6 +358,91 @@ internal object AppleMusicSymbols {
         fallbackName = { false },
         contract = { true },
     )
+
+    val SongInfoPtr = classSymbol(
+        id = "song-info-ptr",
+        profileId = TargetSymbolId.SONG_INFO_PTR,
+        stableName = "com.apple.android.music.ttml.javanative.model.SongInfo\$SongInfoPtr",
+        fallbackName = { it.endsWith(".ttml.javanative.model.SongInfo\$SongInfoPtr") },
+        contract = ::hasSongInfoPtrContract,
+    )
+
+    val SongInfoNative = classSymbol(
+        id = "song-info-native",
+        profileId = TargetSymbolId.SONG_INFO_NATIVE,
+        stableName = "com.apple.android.music.ttml.javanative.model.SongInfo\$SongInfoNative",
+        fallbackName = { it.endsWith(".ttml.javanative.model.SongInfo\$SongInfoNative") },
+        contract = ::hasSongInfoNativeContract,
+    )
+
+    val TtmlParserNative = classSymbol(
+        id = "ttml-parser-native",
+        profileId = TargetSymbolId.TTML_PARSER_NATIVE,
+        stableName = "com.apple.android.music.ttml.javanative.TTMLParser\$TTMLParserNative",
+        fallbackName = { it.endsWith(".ttml.javanative.TTMLParser\$TTMLParserNative") },
+        contract = ::hasTtmlParserNativeContract,
+    )
+
+    /**
+     * PlayerLyricsViewFragment.I2(SongInfoPtr) — the lyrics installation
+     * entry point. The contract requires the exact name "I2" plus the
+     * SongInfoPtr shape, so the same-shaped R2(SongInfoPtr) can never be
+     * selected silently: a version whose I2 is missing resolves Missing even
+     * when R2 is present.
+     */
+    val LyricsInstallMethod = methodSymbol(
+        id = "lyrics-install-method",
+        profileOwner = TargetSymbolId.LYRICS_FRAGMENT,
+        fallbackOwner = { it.endsWith(".PlayerLyricsViewFragment") },
+        contract = ::isLyricsInstallMethod,
+    )
+
+    val PlayerMetadataPublishMethod = methodSymbol(
+        id = "player-metadata-publish-method",
+        profileOwner = TargetSymbolId.PLAYER_METADATA_HUB,
+        fallbackOwner = { it == "com.apple.android.music.player.f" },
+        contract = ::isPlayerMetadataPublishMethod,
+    )
+
+    val MetadataToPlaybackItemMethod = methodSymbol(
+        id = "metadata-to-playback-item-method",
+        profileOwner = TargetSymbolId.METADATA_TO_ITEM_CONVERTER,
+        fallbackOwner = { it == "com.apple.android.music.player.P" },
+        contract = ::isMetadataToPlaybackItemMethod,
+    )
+
+    val LyricsAvailabilityPredicate = methodSymbol(
+        id = "lyrics-availability-predicate",
+        profileOwner = TargetSymbolId.LYRICS_AVAILABILITY_OWNER,
+        fallbackOwner = { it.startsWith("com.apple.android.music.player.") },
+        contract = ::isLyricsAvailabilityPredicate,
+    )
+
+    val TtmlSongInfoFromTtml = methodSymbol(
+        id = "ttml-song-info-from-ttml",
+        profileOwner = TargetSymbolId.TTML_PARSER_NATIVE,
+        fallbackOwner = { it.endsWith(".ttml.javanative.TTMLParser\$TTMLParserNative") },
+        contract = ::isTtmlSongInfoFromTtml,
+    )
+
+    /**
+     * The fragment hierarchy's current lyrics item
+     * (`com.apple.android.music.player.fragment.m#c` of type
+     * `com.apple.android.music.model.BaseContentItem`). Apple's own I2 body
+     * reads this field, calls `getId()` on the item and refuses any incoming
+     * SongInfoPtr whose Adam ID differs — so the incoming pointer can be a
+     * stale leftover from a previous song, and this field is the only
+     * authoritative song identity for every I2 entry. The contract requires
+     * the exact field name "c" plus the exact declared type, so a same-named
+     * field of another type can never be selected silently.
+     */
+    val LyricsCurrentItemField = fieldSymbol(
+        id = "lyrics-current-item-field",
+        profileOwner = TargetSymbolId.LYRICS_CURRENT_ITEM_FIELD,
+        fallbackOwner = { it.startsWith("com.apple.android.music.player.fragment.") },
+        contract = ::isLyricsCurrentItemField,
+    )
+
 }
 
 private fun classSymbol(
@@ -366,6 +483,24 @@ private fun methodSymbol(
     },
     structuralCandidates = { methods(fallbackOwner, contract) },
     identity = ::methodIdentity,
+)
+
+private fun fieldSymbol(
+    id: String,
+    profileOwner: TargetSymbolId,
+    fallbackOwner: (String) -> Boolean,
+    contract: (Field) -> Boolean,
+): TargetSymbolKey<Field> = TargetSymbolKey(
+    id = id,
+    profileCandidates = { profile ->
+        profile?.exactClasses?.get(profileOwner)
+            ?.let(::load)
+            ?.declaredFields
+            ?.filter(contract)
+            .orEmpty()
+    },
+    structuralCandidates = { fields(fallbackOwner, contract) },
+    identity = ::fieldIdentity,
 )
 
 private fun hasLyricsChromeContract(candidate: Class<*>): Boolean =
@@ -412,8 +547,78 @@ private fun isLyricsSessionProcessor(method: Method): Boolean =
         ) &&
         method.parameterTypes[1] == Long::class.javaPrimitiveType
 
+private fun isLyricsInstallMethod(method: Method): Boolean =
+    !Modifier.isStatic(method.modifiers) &&
+        method.name == "I2" &&
+        method.returnType == Void.TYPE &&
+        method.parameterTypes.size == 1 &&
+        method.parameterTypes[0].name.endsWith(
+            ".ttml.javanative.model.SongInfo\$SongInfoPtr",
+        )
+
+private fun isPlayerMetadataPublishMethod(method: Method): Boolean =
+    !Modifier.isStatic(method.modifiers) &&
+        method.name == "g" &&
+        method.returnType == Void.TYPE &&
+        method.parameterTypes.singleOrNull()?.name == "v3.v"
+
+private fun isMetadataToPlaybackItemMethod(method: Method): Boolean =
+    Modifier.isStatic(method.modifiers) &&
+        method.name == "b" &&
+        method.parameterTypes.singleOrNull()?.name == "v3.v" &&
+        method.returnType.name == "com.apple.android.music.model.PlaybackItem"
+
+private fun isLyricsAvailabilityPredicate(method: Method): Boolean =
+    Modifier.isStatic(method.modifiers) &&
+        method.name == "i" &&
+        method.returnType == Boolean::class.javaPrimitiveType &&
+        method.parameterTypes.singleOrNull()?.name == "com.apple.android.music.model.PlaybackItem"
+
+private fun isTtmlSongInfoFromTtml(method: Method): Boolean =
+    !Modifier.isStatic(method.modifiers) &&
+        method.name == "songInfoFromTTML" &&
+        method.parameterTypes.contentEquals(arrayOf(String::class.java)) &&
+        method.returnType.name.endsWith(".ttml.javanative.model.SongInfo\$SongInfoPtr")
+
+private fun isLyricsCurrentItemField(field: Field): Boolean =
+    !Modifier.isStatic(field.modifiers) &&
+        field.name == "c" &&
+        field.type.name == "com.apple.android.music.model.BaseContentItem"
+
+private fun hasSongInfoPtrContract(candidate: Class<*>): Boolean =
+    candidate.declaredMethods.any { method ->
+        method.name == "get" &&
+            method.parameterCount == 0 &&
+            method.returnType.name.endsWith(".ttml.javanative.model.SongInfo\$SongInfoNative")
+    }
+
+private fun hasSongInfoNativeContract(candidate: Class<*>): Boolean =
+    candidate.declaredMethods.any { method ->
+        method.name == "getSections" &&
+            method.parameterCount == 0 &&
+            method.returnType.name.endsWith(".ttml.javanative.model.LyricsSectionVector")
+    } && candidate.declaredMethods.any { method ->
+        method.name == "getAdamId" &&
+            method.parameterCount == 0 &&
+            method.returnType == Long::class.javaPrimitiveType
+    } && candidate.declaredMethods.any { method ->
+        method.name == "setAdamId" &&
+            method.parameterCount == 1 &&
+            method.parameterTypes[0] == Long::class.javaPrimitiveType
+    }
+
+private fun hasTtmlParserNativeContract(candidate: Class<*>): Boolean =
+    candidate.declaredConstructors.any { constructor ->
+        constructor.parameterCount == 0 && !Modifier.isPrivate(constructor.modifiers)
+    } && candidate.declaredMethods.any(::isTtmlSongInfoFromTtml)
+
 private fun methodIdentity(method: Method): String = buildString {
     append(method.declaringClass.name).append('#').append(method.name).append('(')
     append(method.parameterTypes.joinToString(",") { it.name })
     append("):").append(method.returnType.name)
+}
+
+private fun fieldIdentity(field: Field): String = buildString {
+    append(field.declaringClass.name).append('#').append(field.name).append(':')
+        .append(field.type.name)
 }

--- a/app/src/main/java/dev/amenhancer/module/hook/TtmlNativeParser.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/TtmlNativeParser.kt
@@ -1,0 +1,119 @@
+package dev.amenhancer.module.hook
+
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+
+/**
+ * Wraps Apple Music's native TTML parser surface with the version-exact
+ * classes and methods resolved through [TargetSymbolResolver]:
+ *
+ * `TTMLParser$TTMLParserNative#songInfoFromTTML(String)` → `SongInfo$SongInfoPtr`
+ * → `SongInfoPtr#get()` → `SongInfo$SongInfoNative` (sections / Adam ID).
+ *
+ * Native pointer lifetime: Apple Music calls `Pointer.deallocate()` on
+ * lyrics pointers (PlayerLyricsViewFragment.onDestroyView does), which zeroes
+ * the native address while Java wrappers may still be referenced. Every entry
+ * point therefore checks pointer liveness (address field / `Pointer.isNull`)
+ * before any native call, and a dead cached pointer is dropped by the caller
+ * instead of being used. This is a best-effort Java-layer guard, not a full
+ * use-after-free guarantee — that still needs real-device verification.
+ *
+ * The single parser instance is kept as a strong reference for its whole
+ * native lifetime; every call is cheap and runs on the background executor,
+ * never on the I2 hook or the main thread.
+ */
+internal class TtmlNativeParser private constructor(
+    private val parserClass: Class<*>,
+    private val parseMethod: Method,
+    private val ptrClass: Class<*>,
+    private val nativeClass: Class<*>,
+    private val aliveCheck: (Any) -> Boolean,
+) {
+    private val parser: Any by lazy {
+        parserClass.getDeclaredConstructor().newInstance()
+    }
+
+    private val ptrGet: Method = ptrClass.getMethod("get")
+    private val sectionsMethod: Method = nativeClass.getMethod("getSections")
+    private val sectionsSizeMethod: Method = sectionsMethod.returnType.getMethod("size")
+    private val adamIdGet: Method = nativeClass.getMethod("getAdamId")
+    private val adamIdSet: Method = nativeClass.getMethod("setAdamId", Long::class.javaPrimitiveType)
+
+    /** True while the JavaCPP wrapper still owns a native address. */
+    fun isAlive(ptr: Any?): Boolean = runCatching {
+        ptr != null && ptrClass.isInstance(ptr) && aliveCheck(ptr)
+    }.getOrDefault(false)
+
+    /** Parses Word-TTML into a SongInfoPtr, or `null` when parsing failed. */
+    fun parse(ttml: String): Any? = runCatching {
+        parseMethod.invoke(parser, ttml)
+    }.getOrNull()
+
+    /** True when the pointer is alive and holds at least one section. */
+    fun isValid(ptr: Any?): Boolean = runCatching {
+        if (!isAlive(ptr)) return@runCatching false
+        val native = ptrGet.invoke(ptr) ?: return@runCatching false
+        if (!nativeClass.isInstance(native)) return@runCatching false
+        val sections = sectionsMethod.invoke(native) ?: return@runCatching false
+        val size = sectionsSizeMethod.invoke(sections) as? Number ?: return@runCatching false
+        size.toLong() > 0L
+    }.getOrDefault(false)
+
+    /** The SongInfo's Adam ID, or `null` when unavailable or deallocated. */
+    fun adamIdOf(ptr: Any): Long? = runCatching {
+        if (!isAlive(ptr)) return@runCatching null
+        val native = ptrGet.invoke(ptr) ?: return@runCatching null
+        (adamIdGet.invoke(native) as? Number)?.toLong()
+    }.getOrNull()
+
+    /**
+     * Sets the replacement's Adam ID so Apple's own identity checks (I2's
+     * incoming-id vs current item) pass, then verifies the value stuck.
+     */
+    fun bindAdamId(ptr: Any, adamId: Long): Boolean = runCatching {
+        if (!isAlive(ptr)) return@runCatching false
+        val native = ptrGet.invoke(ptr) ?: return@runCatching false
+        adamIdSet.invoke(native, adamId)
+        (adamIdGet.invoke(native) as? Number)?.toLong() == adamId
+    }.getOrDefault(false)
+
+    companion object {
+        private const val JAVACPP_POINTER_NAME = "org.bytedeco.javacpp.Pointer"
+
+        /**
+         * Builds the wrapper, resolving the JavaCPP liveness surface up
+     * front. Returns `null` when the method or liveness surface is unavailable
+     * so the caller can report a targeted degraded state instead of risking a
+     * released native pointer.
+         */
+        fun create(
+            parserClass: Class<*>,
+            parseMethod: Method,
+            ptrClass: Class<*>,
+            nativeClass: Class<*>,
+        ): TtmlNativeParser? = runCatching {
+            val pointerBase = generateSequence(ptrClass as Class<*>) { type -> type.superclass }
+                .firstOrNull { type -> type.name == JAVACPP_POINTER_NAME }
+            val addressField: Field? = pointerBase
+                ?.getDeclaredField("address")
+                ?.apply { isAccessible = true }
+            val isNullMethod: Method? = pointerBase?.let { type ->
+                runCatching { type.getMethod("isNull", type) }.getOrNull()
+            }
+            val aliveCheck: (Any) -> Boolean = when {
+                addressField != null -> { ptr -> addressField.getLong(ptr) != 0L }
+                isNullMethod != null -> { ptr ->
+                    !((isNullMethod.invoke(null, ptr) as? Boolean) ?: false)
+                }
+                else -> return@runCatching null
+            }
+            TtmlNativeParser(
+                parserClass = parserClass,
+                parseMethod = parseMethod,
+                ptrClass = ptrClass,
+                nativeClass = nativeClass,
+                aliveCheck = aliveCheck,
+            )
+        }.getOrNull()
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsFilePolicy.kt
+++ b/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsFilePolicy.kt
@@ -1,0 +1,50 @@
+package dev.amenhancer.module.lyrics
+
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.security.MessageDigest
+
+internal sealed interface CustomLyricsInspection {
+    data class Accepted(
+        val ttml: String,
+        val bytes: ByteArray,
+        val sha256: String,
+    ) : CustomLyricsInspection
+
+    data class Rejected(val message: String) : CustomLyricsInspection
+}
+
+/** Applies the same input bounds to pasted, imported, and target-side TTML. */
+internal object CustomLyricsFilePolicy {
+    fun inspect(ttml: String): CustomLyricsInspection {
+        val bytes = ttml.toByteArray(Charsets.UTF_8)
+        if (!TtmlInputPolicy.isAcceptable(ttml)) {
+            return CustomLyricsInspection.Rejected("TTML 必须是有效且不超过 512 KiB 的歌词文档")
+        }
+        return CustomLyricsInspection.Accepted(
+            ttml = ttml,
+            bytes = bytes,
+            sha256 = sha256(bytes),
+        )
+    }
+
+    fun readBounded(input: InputStream): ByteArray {
+        val output = ByteArrayOutputStream()
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        while (true) {
+            val count = input.read(buffer)
+            if (count < 0) break
+            if (output.size() + count > TtmlInputPolicy.MAX_TTML_BYTES) {
+                throw SizeLimitExceeded()
+            }
+            output.write(buffer, 0, count)
+        }
+        return output.toByteArray()
+    }
+
+    fun sha256(bytes: ByteArray): String = MessageDigest.getInstance("SHA-256")
+        .digest(bytes)
+        .joinToString(separator = "") { byte -> "%02x".format(byte) }
+
+    class SizeLimitExceeded : Exception()
+}

--- a/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsFileReader.kt
+++ b/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsFileReader.kt
@@ -1,0 +1,16 @@
+package dev.amenhancer.module.lyrics
+
+import dev.amenhancer.module.model.CustomLyricsEntry
+
+/** Verifies a remote TTML file against its manifest before native parsing. */
+internal class CustomLyricsFileReader(
+    private val readBytes: (String) -> ByteArray?,
+) {
+    fun read(entry: CustomLyricsEntry): String? {
+        val bytes = runCatching { readBytes(entry.fileId) }.getOrNull() ?: return null
+        if (bytes.size.toLong() != entry.sizeBytes) return null
+        if (!CustomLyricsFilePolicy.sha256(bytes).equals(entry.sha256, ignoreCase = true)) return null
+        val ttml = bytes.toString(Charsets.UTF_8)
+        return ttml.takeIf { CustomLyricsFilePolicy.inspect(it) is CustomLyricsInspection.Accepted }
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsImportTransaction.kt
+++ b/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsImportTransaction.kt
@@ -1,0 +1,80 @@
+package dev.amenhancer.module.lyrics
+
+import dev.amenhancer.module.config.CustomLyricsManifestPolicy
+import dev.amenhancer.module.model.CustomLyricsEntry
+import dev.amenhancer.module.model.CustomLyricsManifest
+import dev.amenhancer.module.model.CustomLyricsSources
+
+internal data class CustomLyricsDraft(
+    val appleMusicId: Long,
+    val displayName: String,
+    val ttml: String,
+    val source: String = CustomLyricsSources.MANUAL,
+    val enabled: Boolean = true,
+)
+
+internal sealed interface CustomLyricsSaveResult {
+    data class Saved(
+        val manifest: CustomLyricsManifest,
+        val entry: CustomLyricsEntry,
+    ) : CustomLyricsSaveResult
+
+    data class Failed(val message: String) : CustomLyricsSaveResult
+}
+
+/** Writes a new TTML file before publishing the replacement manifest. */
+internal class CustomLyricsImportTransaction(
+    private val fileIdFactory: () -> String,
+    private val writeRemoteFile: (String, ByteArray) -> Boolean,
+    private val publishManifest: (CustomLyricsManifest) -> Boolean,
+    private val deleteRemoteFile: (String) -> Unit,
+) {
+    fun upsert(
+        oldManifest: CustomLyricsManifest,
+        draft: CustomLyricsDraft,
+    ): CustomLyricsSaveResult {
+        if (draft.appleMusicId <= 0L) {
+            return CustomLyricsSaveResult.Failed("Apple Music ID 必须是正整数")
+        }
+        val inspection = CustomLyricsFilePolicy.inspect(draft.ttml)
+        if (inspection is CustomLyricsInspection.Rejected) {
+            return CustomLyricsSaveResult.Failed(inspection.message)
+        }
+        val accepted = inspection as CustomLyricsInspection.Accepted
+        val fileId = runCatching(fileIdFactory).getOrNull()
+            ?: return CustomLyricsSaveResult.Failed("无法生成歌词文件 ID")
+        if (!CustomLyricsManifestPolicy.isValidFileId(fileId)) {
+            return CustomLyricsSaveResult.Failed("生成的歌词文件 ID 无效")
+        }
+        val entry = CustomLyricsEntry(
+            appleMusicId = draft.appleMusicId,
+            displayName = CustomLyricsManifestPolicy.sanitizeDisplayName(draft.displayName),
+            fileId = fileId,
+            sizeBytes = accepted.bytes.size.toLong(),
+            sha256 = accepted.sha256,
+            source = draft.source,
+            enabled = draft.enabled,
+        )
+        val manifest = CustomLyricsManifestPolicy.sanitize(
+            CustomLyricsManifest(
+                oldManifest.entries.filterNot { it.appleMusicId == draft.appleMusicId } + entry,
+            ),
+        )
+        if (manifest.entries.none { it.appleMusicId == entry.appleMusicId && it.fileId == entry.fileId }) {
+            return CustomLyricsSaveResult.Failed("歌词映射无效")
+        }
+        if (!runCatching { writeRemoteFile(fileId, accepted.bytes) }.getOrDefault(false)) {
+            runCatching { deleteRemoteFile(fileId) }
+            return CustomLyricsSaveResult.Failed("无法写入共享歌词文件")
+        }
+        if (!runCatching { publishManifest(manifest) }.getOrDefault(false)) {
+            runCatching { deleteRemoteFile(fileId) }
+            return CustomLyricsSaveResult.Failed("无法发布歌词映射")
+        }
+        oldManifest.entries.firstOrNull { it.appleMusicId == entry.appleMusicId }
+            ?.fileId
+            ?.takeIf { it != entry.fileId }
+            ?.let { oldFileId -> runCatching { deleteRemoteFile(oldFileId) } }
+        return CustomLyricsSaveResult.Saved(manifest, entry)
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsImportTransaction.kt
+++ b/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsImportTransaction.kt
@@ -32,9 +32,24 @@ internal class CustomLyricsImportTransaction(
     fun upsert(
         oldManifest: CustomLyricsManifest,
         draft: CustomLyricsDraft,
+        replacingAppleMusicId: Long? = null,
     ): CustomLyricsSaveResult {
         if (draft.appleMusicId <= 0L) {
             return CustomLyricsSaveResult.Failed("Apple Music ID 必须是正整数")
+        }
+        val replacedAppleMusicId = replacingAppleMusicId ?: draft.appleMusicId
+        val replacedEntry = oldManifest.entries.firstOrNull {
+            it.appleMusicId == replacedAppleMusicId
+        }
+        if (replacingAppleMusicId != null && replacedEntry == null) {
+            return CustomLyricsSaveResult.Failed("原歌词映射不存在")
+        }
+        if (
+            replacingAppleMusicId != null &&
+            replacingAppleMusicId != draft.appleMusicId &&
+            oldManifest.entries.any { it.appleMusicId == draft.appleMusicId }
+        ) {
+            return CustomLyricsSaveResult.Failed("目标 Apple Music ID 已存在")
         }
         val inspection = CustomLyricsFilePolicy.inspect(draft.ttml)
         if (inspection is CustomLyricsInspection.Rejected) {
@@ -57,7 +72,9 @@ internal class CustomLyricsImportTransaction(
         )
         val manifest = CustomLyricsManifestPolicy.sanitize(
             CustomLyricsManifest(
-                oldManifest.entries.filterNot { it.appleMusicId == draft.appleMusicId } + entry,
+                oldManifest.entries.filterNot {
+                    it.appleMusicId == replacedAppleMusicId || it.appleMusicId == draft.appleMusicId
+                } + entry,
             ),
         )
         if (manifest.entries.none { it.appleMusicId == entry.appleMusicId && it.fileId == entry.fileId }) {
@@ -71,8 +88,7 @@ internal class CustomLyricsImportTransaction(
             runCatching { deleteRemoteFile(fileId) }
             return CustomLyricsSaveResult.Failed("无法发布歌词映射")
         }
-        oldManifest.entries.firstOrNull { it.appleMusicId == entry.appleMusicId }
-            ?.fileId
+        replacedEntry?.fileId
             ?.takeIf { it != entry.fileId }
             ?.let { oldFileId -> runCatching { deleteRemoteFile(oldFileId) } }
         return CustomLyricsSaveResult.Saved(manifest, entry)

--- a/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsManager.kt
+++ b/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsManager.kt
@@ -18,7 +18,10 @@ internal class CustomLyricsManager(
     private val snapshot: XposedServiceSnapshot,
     private val configStore: ConfigStore,
 ) {
-    fun save(draft: CustomLyricsDraft): CustomLyricsSaveResult = synchronized(mutationLock) {
+    fun save(
+        draft: CustomLyricsDraft,
+        replacingAppleMusicId: Long? = null,
+    ): CustomLyricsSaveResult = synchronized(mutationLock) {
         if (!isWritable()) return CustomLyricsSaveResult.Failed("libxposed remote file 服务不可用")
         val oldManifest = configStore.settings(snapshot).customLyricsManifest
         return CustomLyricsImportTransaction(
@@ -30,7 +33,7 @@ internal class CustomLyricsManager(
             deleteRemoteFile = { fileId ->
                 if (ModuleApplication.isCurrentSnapshot(snapshot)) snapshot.deleteRemoteFile(fileId)
             },
-        ).upsert(oldManifest, draft)
+        ).upsert(oldManifest, draft, replacingAppleMusicId)
     }
 
     fun setEnabled(appleMusicId: Long, enabled: Boolean): CustomLyricsMutationResult = synchronized(mutationLock) {

--- a/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsManager.kt
+++ b/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsManager.kt
@@ -1,0 +1,101 @@
+package dev.amenhancer.module.lyrics
+
+import android.os.ParcelFileDescriptor
+import dev.amenhancer.module.ModuleApplication
+import dev.amenhancer.module.XposedServiceSnapshot
+import dev.amenhancer.module.config.ConfigStore
+import dev.amenhancer.module.config.CustomLyricsManifestPolicy
+import dev.amenhancer.module.model.CustomLyricsManifest
+import java.util.UUID
+
+internal sealed interface CustomLyricsMutationResult {
+    data class Updated(val manifest: CustomLyricsManifest) : CustomLyricsMutationResult
+    data class Failed(val message: String) : CustomLyricsMutationResult
+}
+
+/** Settings-process facade for atomic custom-lyrics file and manifest changes. */
+internal class CustomLyricsManager(
+    private val snapshot: XposedServiceSnapshot,
+    private val configStore: ConfigStore,
+) {
+    fun save(draft: CustomLyricsDraft): CustomLyricsSaveResult = synchronized(mutationLock) {
+        if (!isWritable()) return CustomLyricsSaveResult.Failed("libxposed remote file 服务不可用")
+        val oldManifest = configStore.settings(snapshot).customLyricsManifest
+        return CustomLyricsImportTransaction(
+            fileIdFactory = ::newFileId,
+            writeRemoteFile = ::writeRemoteFile,
+            publishManifest = { manifest ->
+                isWritable() && configStore.saveCustomLyricsManifest(manifest, snapshot)
+            },
+            deleteRemoteFile = { fileId ->
+                if (ModuleApplication.isCurrentSnapshot(snapshot)) snapshot.deleteRemoteFile(fileId)
+            },
+        ).upsert(oldManifest, draft)
+    }
+
+    fun setEnabled(appleMusicId: Long, enabled: Boolean): CustomLyricsMutationResult = synchronized(mutationLock) {
+        mutate { manifest ->
+        var found = false
+        val entries = manifest.entries.map { entry ->
+            if (entry.appleMusicId == appleMusicId) {
+                found = true
+                entry.copy(enabled = enabled)
+            } else {
+                entry
+            }
+        }
+            if (!found) null else CustomLyricsManifest(entries)
+        }
+    }
+
+    fun delete(appleMusicId: Long): CustomLyricsMutationResult = synchronized(mutationLock) {
+        if (!isWritable()) return CustomLyricsMutationResult.Failed("libxposed remote file 服务不可用")
+        val oldManifest = configStore.settings(snapshot).customLyricsManifest
+        val removed = oldManifest.entries.singleOrNull { it.appleMusicId == appleMusicId }
+            ?: return CustomLyricsMutationResult.Failed("歌词映射不存在")
+        val next = CustomLyricsManifestPolicy.sanitize(
+            CustomLyricsManifest(oldManifest.entries.filterNot { it.appleMusicId == appleMusicId }),
+        )
+        if (!configStore.saveCustomLyricsManifest(next, snapshot)) {
+            return CustomLyricsMutationResult.Failed("无法发布歌词映射")
+        }
+        if (ModuleApplication.isCurrentSnapshot(snapshot)) {
+            runCatching { snapshot.deleteRemoteFile(removed.fileId) }
+        }
+        return CustomLyricsMutationResult.Updated(next)
+    }
+
+    private fun mutate(
+        transform: (CustomLyricsManifest) -> CustomLyricsManifest?,
+    ): CustomLyricsMutationResult {
+        if (!isWritable()) return CustomLyricsMutationResult.Failed("libxposed remote file 服务不可用")
+        val oldManifest = configStore.settings(snapshot).customLyricsManifest
+        val candidate = transform(oldManifest) ?: return CustomLyricsMutationResult.Failed("歌词映射不存在")
+        val next = CustomLyricsManifestPolicy.sanitize(candidate)
+        if (!configStore.saveCustomLyricsManifest(next, snapshot)) {
+            return CustomLyricsMutationResult.Failed("无法发布歌词映射")
+        }
+        return CustomLyricsMutationResult.Updated(next)
+    }
+
+    private fun isWritable(): Boolean =
+        snapshot.isRemoteFileAvailable && ModuleApplication.isCurrentSnapshot(snapshot)
+
+    private fun writeRemoteFile(fileId: String, bytes: ByteArray): Boolean {
+        if (!isWritable()) return false
+        val descriptor = snapshot.openRemoteFile(fileId) ?: return false
+        return runCatching {
+            ParcelFileDescriptor.AutoCloseOutputStream(descriptor).use { output ->
+                output.write(bytes)
+                output.flush()
+            }
+            true
+        }.getOrDefault(false)
+    }
+
+    private fun newFileId(): String = "lyrics_" + UUID.randomUUID().toString().replace("-", "")
+
+    private companion object {
+        val mutationLock = Any()
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsOnlineImporter.kt
+++ b/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsOnlineImporter.kt
@@ -1,0 +1,39 @@
+package dev.amenhancer.module.lyrics
+
+import dev.amenhancer.module.model.CustomLyricsSources
+
+internal sealed interface CustomLyricsOnlineImportResult {
+    data class Imported(
+        val ttml: String,
+        val source: String,
+    ) : CustomLyricsOnlineImportResult
+
+    data class Failed(val message: String) : CustomLyricsOnlineImportResult
+}
+
+/** User-triggered online imports. Playback hooks never call this class. */
+internal class CustomLyricsOnlineImporter(
+    private val fetchAmll: (Long) -> String?,
+    private val fetchNeteaseYrc: (Long) -> LyricDocument?,
+) {
+    fun importAmll(appleMusicId: Long): CustomLyricsOnlineImportResult {
+        if (appleMusicId <= 0L) return CustomLyricsOnlineImportResult.Failed("Apple Music ID 必须是正整数")
+        val ttml = runCatching { fetchAmll(appleMusicId) }.getOrNull()
+            ?.takeIf(TtmlInputPolicy::isAcceptable)
+            ?: return CustomLyricsOnlineImportResult.Failed("AMLL 未找到可用 TTML")
+        return CustomLyricsOnlineImportResult.Imported(ttml, CustomLyricsSources.AMLL)
+    }
+
+    fun importNetease(
+        neteaseSongId: Long,
+        title: String,
+    ): CustomLyricsOnlineImportResult {
+        if (neteaseSongId <= 0L) return CustomLyricsOnlineImportResult.Failed("网易云歌曲 ID 必须是正整数")
+        val document = runCatching { fetchNeteaseYrc(neteaseSongId) }.getOrNull()
+            ?: return CustomLyricsOnlineImportResult.Failed("网易云未找到逐字歌词")
+        val ttml = WordTtmlSerializer.serialize(document, title.takeIf(String::isNotBlank))
+            ?.takeIf(TtmlInputPolicy::isAcceptable)
+            ?: return CustomLyricsOnlineImportResult.Failed("网易云歌词无法转换为有效 TTML")
+        return CustomLyricsOnlineImportResult.Imported(ttml, CustomLyricsSources.NETEASE)
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/lyrics/LyricDocument.kt
+++ b/app/src/main/java/dev/amenhancer/module/lyrics/LyricDocument.kt
@@ -1,0 +1,24 @@
+package dev.amenhancer.module.lyrics
+
+/** One timed word inside a lyric line. Timing is in milliseconds. */
+data class LyricWord(
+    val text: String,
+    val startMs: Long,
+    val endMs: Long,
+)
+
+/** One lyric line with its word-level timing. Timing is in milliseconds. */
+data class LyricLine(
+    val startMs: Long,
+    val endMs: Long,
+    val words: List<LyricWord>,
+)
+
+/**
+ * Unified, Android-free lyric document produced from every online source.
+ * Only the main word track is kept; translations and transliterations are
+ * deliberately discarded because they cannot be aligned to words reliably.
+ */
+data class LyricDocument(
+    val lines: List<LyricLine>,
+)

--- a/app/src/main/java/dev/amenhancer/module/lyrics/NeteaseEapi.kt
+++ b/app/src/main/java/dev/amenhancer/module/lyrics/NeteaseEapi.kt
@@ -1,0 +1,96 @@
+package dev.amenhancer.module.lyrics
+
+import java.security.MessageDigest
+import javax.crypto.Cipher
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Minimal NetEase EAPI encoding for the `/api/song/lyric/v1` endpoint.
+ *
+ * Algorithm verified against NeteaseCloudMusicApi (Binaryify JS original and
+ * the wwh1004 C# port) and lx-music-desktop's `wy/lyric.js`:
+ * - `json` is the exact request object in fixed key order;
+ * - `digest = md5("nobody" + path + "use" + json + "md5forencrypt")` (lower hex);
+ * - `message = path + "-36cd479b6b5-" + json + "-36cd479b6b5-" + digest`;
+ * - `params = AES-128-ECB(message, key "e82ckenh8dichen8", PKCS5 padding)`
+ *   as uppercase hex; the body is `params=<uppercase hex>`.
+ *
+ * Pure Kotlin (no Android state) so the encoding is deterministically
+ * unit-testable without network access.
+ */
+object NeteaseEapi {
+
+    const val LYRIC_V1_PATH = "/api/song/lyric/v1"
+    const val LYRIC_V1_URL = "https://interface3.music.163.com/eapi/song/lyric/v1"
+
+    private const val AES_KEY = "e82ckenh8dichen8"
+    private const val MAGIC = "36cd479b6b5"
+    private const val PREFIX = "nobody"
+    private const val SUFFIX = "md5forencrypt"
+    private const val TRANSFORMATION = "AES/ECB/PKCS5Padding"
+
+    /** The `params` form value for a lyric request; body is `params=<value>`. */
+    fun lyricV1Params(songId: Long): String {
+        val json = lyricV1Json(songId)
+        val message = buildString {
+            append(PREFIX)
+            append(LYRIC_V1_PATH)
+            append("use")
+            append(json)
+            append(SUFFIX)
+        }
+        val digest = md5Hex(message)
+        val data = buildString {
+            append(LYRIC_V1_PATH)
+            append('-').append(MAGIC).append('-')
+            append(json)
+            append('-').append(MAGIC).append('-')
+            append(digest)
+        }
+        return aesEcbEncryptHex(data)
+    }
+
+    /** Exact request JSON, key order fixed by the upstream implementation. */
+    internal fun lyricV1Json(songId: Long): String = buildString {
+        append("{\"id\":").append(songId)
+        append(",\"cp\":false")
+        append(",\"tv\":0")
+        append(",\"lv\":0")
+        append(",\"rv\":0")
+        append(",\"kv\":0")
+        append(",\"yv\":0")
+        append(",\"ytv\":0")
+        append(",\"yrv\":0}")
+    }
+
+    internal fun md5Hex(message: String): String {
+        val digest = MessageDigest.getInstance("MD5")
+            .digest(message.toByteArray(Charsets.UTF_8))
+        return buildString(digest.size * 2) {
+            digest.forEach { byte ->
+                val value = byte.toInt() and 0xFF
+                append(HEX_LOWER[value ushr 4])
+                append(HEX_LOWER[value and 0x0F])
+            }
+        }
+    }
+
+    internal fun aesEcbEncryptHex(data: String): String {
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(
+            Cipher.ENCRYPT_MODE,
+            SecretKeySpec(AES_KEY.toByteArray(Charsets.UTF_8), "AES"),
+        )
+        val encrypted = cipher.doFinal(data.toByteArray(Charsets.UTF_8))
+        return buildString(encrypted.size * 2) {
+            encrypted.forEach { byte ->
+                val value = byte.toInt() and 0xFF
+                append(HEX_UPPER[value ushr 4])
+                append(HEX_UPPER[value and 0x0F])
+            }
+        }
+    }
+
+    private const val HEX_LOWER = "0123456789abcdef"
+    private const val HEX_UPPER = "0123456789ABCDEF"
+}

--- a/app/src/main/java/dev/amenhancer/module/lyrics/TtmlInputPolicy.kt
+++ b/app/src/main/java/dev/amenhancer/module/lyrics/TtmlInputPolicy.kt
@@ -1,0 +1,43 @@
+package dev.amenhancer.module.lyrics
+
+import java.util.Locale
+
+/**
+ * Acceptance policy for third-party TTML before it ever reaches Apple's
+ * native parser. All limits are structural: UTF-8 byte size, required root
+ * markers, and bounded counts of line/word tags. Anything violating the
+ * policy is rejected and the original lyrics stay in place.
+ */
+object TtmlInputPolicy {
+
+    const val MAX_TTML_BYTES = 512 * 1024
+    const val MAX_LINES = 4096
+    const val MAX_WORDS = 65536
+
+    fun isAcceptable(ttml: String): Boolean {
+        if (ttml.isEmpty()) return false
+        if (ttml.toByteArray(Charsets.UTF_8).size > MAX_TTML_BYTES) return false
+        val lower = ttml.lowercase(Locale.ROOT)
+        if (!lower.contains("<tt") || !lower.contains("<body")) return false
+        if (countTag(lower, "<p") > MAX_LINES) return false
+        if (countTag(lower, "<span") > MAX_WORDS) return false
+        return true
+    }
+
+    private fun countTag(text: String, tag: String): Int {
+        var count = 0
+        var index = 0
+        while (true) {
+            index = text.indexOf(tag, index)
+            if (index < 0) break
+            val next = index + tag.length
+            if (next >= text.length || text[next] == ' ' || text[next] == '>' ||
+                text[next] == '\t' || text[next] == '\n'
+            ) {
+                count += 1
+            }
+            index = next
+        }
+        return count
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/lyrics/WordTtmlSerializer.kt
+++ b/app/src/main/java/dev/amenhancer/module/lyrics/WordTtmlSerializer.kt
@@ -1,0 +1,75 @@
+package dev.amenhancer.module.lyrics
+
+import java.util.Locale
+
+/**
+ * The single serializer that converts the unified [LyricDocument] into the
+ * Apple Music Word-TTML accepted by `TTMLParser$TTMLParserNative.songInfoFromTTML`.
+ *
+ * The emitted structure mirrors the amll-ttml-db files that Apple Music
+ * already renders: seconds-based `begin`/`end` on `p` and `span`, the
+ * `itunes:timing="Word"` attribute, `itunes:key` line ids, and literal
+ * whitespace spans between words.
+ *
+ * Every text node is XML-escaped; a document without lines serializes to
+ * `null` so the caller fails open to the original lyrics.
+ */
+object WordTtmlSerializer {
+
+    fun serialize(
+        document: LyricDocument,
+        title: String? = null,
+        artist: String? = null,
+    ): String? {
+        val lines = document.lines
+        if (lines.isEmpty()) return null
+        val totalEndMs = lines.maxOf { it.endMs }
+
+        return buildString {
+            append("<tt xmlns=\"http://www.w3.org/ns/ttml\" ")
+            append("xmlns:amll=\"http://www.example.com/ns/amll\" ")
+            append("xmlns:itunes=\"http://music.apple.com/lyric-ttml-internal\" ")
+            append("xmlns:ttm=\"http://www.w3.org/ns/ttml#metadata\" ")
+            append("itunes:timing=\"Word\">")
+            append("<head><metadata>")
+            append("<ttm:agent type=\"person\" xml:id=\"v1\"/>")
+            if (!title.isNullOrBlank()) {
+                append("<amll:meta key=\"musicName\" value=\"").append(escape(title)).append("\"/>")
+            }
+            if (!artist.isNullOrBlank()) {
+                append("<amll:meta key=\"artists\" value=\"").append(escape(artist)).append("\"/>")
+            }
+            append("</metadata></head>")
+            append("<body dur=\"").append(seconds(totalEndMs)).append("\">")
+            append("<div begin=\"0.000\" end=\"").append(seconds(totalEndMs)).append("\">")
+            lines.forEachIndexed { index, line ->
+                append("<p begin=\"").append(seconds(line.startMs)).append("\" ")
+                append("end=\"").append(seconds(line.endMs)).append("\" ")
+                append("itunes:key=\"L").append(index + 1).append("\" ttm:agent=\"v1\">")
+                line.words.forEach { word ->
+                    append("<span begin=\"").append(seconds(word.startMs)).append("\" ")
+                    append("end=\"").append(seconds(word.endMs)).append("\">")
+                    append(escape(word.text))
+                    append("</span>")
+                }
+                append("</p>")
+            }
+            append("</div></body></tt>")
+        }
+    }
+
+    internal fun seconds(ms: Long): String = String.format(Locale.US, "%.3f", ms / 1000.0)
+
+    internal fun escape(value: String): String = buildString(value.length) {
+        value.forEach { character ->
+            when (character) {
+                '&' -> append("&amp;")
+                '<' -> append("&lt;")
+                '>' -> append("&gt;")
+                '"' -> append("&quot;")
+                '\'' -> append("&apos;")
+                else -> append(character)
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/lyrics/YrcParser.kt
+++ b/app/src/main/java/dev/amenhancer/module/lyrics/YrcParser.kt
@@ -1,0 +1,126 @@
+package dev.amenhancer.module.lyrics
+
+/**
+ * Parses NetEase YRC word-level lyric text into the unified [LyricDocument].
+ *
+ * Real YRC line shape (verified against amll-ttml-db `.yrc` files and the
+ * NetEase `/api/song/lyric/v1` response):
+ *
+ *   `[lineStartMs,lineDurationMs](wordStartMs,wordDurationMs,flag)text...`
+ *
+ * - The bracketed header carries the absolute line start and line duration
+ *   in milliseconds.
+ * - Each parenthesised word marker carries the ABSOLUTE word start (ms), the
+ *   explicit word duration (ms), and a flag that is ignored here.
+ * - A word's text runs from its closing `)` to the next `(` (or line end) and
+ *   is kept verbatim, including its own trailing space, as one span.
+ *
+ * Contract:
+ * - Returns `null` when the text carries no usable word timing at all, so the
+ *   caller can never fabricate word timing from line-level content alone.
+ * - Lines without timed word markers are skipped; malformed lines are
+ *   isolated and never fail the document.
+ * - Words outside the line range are dropped (never clamped — clamping would
+ *   fabricate timing).
+ * - Zero-duration markers such as `(0,0,0) ` are NetEase's untimed space
+ *   placeholders: their text merges into the next word (leading) or the
+ *   previous word (trailing), preserving the original text without inventing
+ *   timing for it.
+ */
+object YrcParser {
+
+    private val LINE_HEADER = Regex("""^\[(\d+),(\d+)\]""")
+    private val WORD_MARKER = Regex("""\((\d+),(\d+)(?:,\d+)?\)""")
+
+    fun parse(raw: String): LyricDocument? {
+        if (raw.isBlank()) return null
+        val lines = raw.lineSequence()
+            .map(::parseLine)
+            .filterNotNull()
+            .toList()
+        if (lines.isEmpty()) return null
+
+        val timedLines = mutableListOf<LyricLine>()
+        lines.forEach { (startMs, endMs, words) ->
+            if (words.isEmpty()) return@forEach
+            timedLines += LyricLine(startMs = startMs, endMs = endMs, words = words)
+        }
+        if (timedLines.isEmpty()) return null
+        return LyricDocument(lines = timedLines)
+    }
+
+    private fun parseLine(raw: String): ParsedLine? {
+        val header = LINE_HEADER.find(raw) ?: return null
+        val lineStartMs = header.groupValues[1].toLongOrNull() ?: return null
+        val lineDurationMs = header.groupValues[2].toLongOrNull() ?: return null
+        if (lineStartMs < 0 || lineDurationMs <= 0) return null
+        val lineEndMs = lineStartMs + lineDurationMs
+
+        val body = raw.substring(header.range.last + 1)
+        val markers = WORD_MARKER.findAll(body).toList()
+        if (markers.isEmpty()) return null
+
+        data class Marker(
+            val startMs: Long,
+            val durationMs: Long,
+            val text: String,
+            val timeless: Boolean,
+        )
+
+        val parsedMarkers = markers.mapIndexed { index, marker ->
+            val startMs = marker.groupValues[1].toLongOrNull() ?: -1L
+            val durationMs = marker.groupValues[2].toLongOrNull() ?: -1L
+            val textStart = marker.range.last + 1
+            val textEnd = markers.getOrNull(index + 1)?.range?.first ?: body.length
+            Marker(
+                startMs = startMs,
+                durationMs = durationMs,
+                text = body.substring(textStart, textEnd),
+                timeless = durationMs <= 0,
+            )
+        }
+
+        // Zero-duration markers are untimed placeholders (typically spaces):
+        // their text merges as leading text into the next timed word, or as
+        // trailing text into the last timed word when nothing follows.
+        val timed = mutableListOf<Marker>()
+        var pendingLeadingText = ""
+        for (marker in parsedMarkers) {
+            if (marker.timeless) {
+                if (marker.text.isNotEmpty()) pendingLeadingText += marker.text
+                continue
+            }
+            timed += marker.copy(text = pendingLeadingText + marker.text)
+            pendingLeadingText = ""
+        }
+        if (pendingLeadingText.isNotEmpty() && timed.isNotEmpty()) {
+            val last = timed[timed.lastIndex]
+            timed[timed.lastIndex] = last.copy(text = last.text + pendingLeadingText)
+        }
+
+        val words = mutableListOf<LyricWord>()
+        timed.forEach { marker ->
+            if (marker.text.isEmpty()) return@forEach
+            val wordStartMs = marker.startMs
+            val wordEndMs = wordStartMs + marker.durationMs
+            if (wordStartMs < lineStartMs || wordEndMs > lineEndMs) return@forEach
+            words += LyricWord(
+                text = marker.text,
+                startMs = wordStartMs,
+                endMs = wordEndMs,
+            )
+        }
+        if (words.isEmpty()) return null
+        return ParsedLine(
+            startMs = lineStartMs,
+            endMs = lineEndMs,
+            words = words,
+        )
+    }
+
+    private data class ParsedLine(
+        val startMs: Long,
+        val endMs: Long,
+        val words: List<LyricWord>,
+    )
+}

--- a/app/src/main/java/dev/amenhancer/module/model/ModuleModels.kt
+++ b/app/src/main/java/dev/amenhancer/module/model/ModuleModels.kt
@@ -8,7 +8,9 @@ data class ModuleSettings(
     val phoneLiquidGlassEnabled: Boolean = false,
     val futureBlurEnabled: Boolean = true,
     val lyricBlurRadiusOffsetPx: Int = 0,
+    val customLyricsEnabled: Boolean = false,
     val fontManifest: LyricsFontManifest = LyricsFontManifest.disabled(),
+    val customLyricsManifest: CustomLyricsManifest = CustomLyricsManifest.empty(),
     val schemaVersion: Int = ModuleConstants.CONFIG_SCHEMA_VERSION,
 ) {
     companion object {
@@ -28,6 +30,32 @@ data class LyricsFontManifest(
     companion object {
         fun disabled(): LyricsFontManifest = LyricsFontManifest()
     }
+}
+
+/** One user-managed Apple Music ID -> TTML file mapping. */
+data class CustomLyricsEntry(
+    val appleMusicId: Long,
+    val displayName: String,
+    val fileId: String,
+    val sizeBytes: Long,
+    val sha256: String,
+    val source: String,
+    val enabled: Boolean = true,
+)
+
+/** Small index shared through remote preferences; TTML bodies stay in remote files. */
+data class CustomLyricsManifest(
+    val entries: List<CustomLyricsEntry> = emptyList(),
+) {
+    companion object {
+        fun empty(): CustomLyricsManifest = CustomLyricsManifest()
+    }
+}
+
+object CustomLyricsSources {
+    const val MANUAL = "manual"
+    const val AMLL = "amll-ttml-db"
+    const val NETEASE = "netease-yrc"
 }
 
 enum class FeatureState {

--- a/app/src/main/java/dev/amenhancer/module/ui/CurrentSongIdentityRequester.kt
+++ b/app/src/main/java/dev/amenhancer/module/ui/CurrentSongIdentityRequester.kt
@@ -1,0 +1,83 @@
+package dev.amenhancer.module.ui
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.os.ResultReceiver
+import dev.amenhancer.module.CurrentSongIdentityProtocol
+import dev.amenhancer.module.CurrentSongDetails
+import dev.amenhancer.module.ModuleConstants
+import java.util.UUID
+
+/** Issues one user-initiated request for the latest current-song details observed by the target hook. */
+internal class CurrentSongIdentityRequester(
+    context: Context,
+    private val handler: Handler = Handler(Looper.getMainLooper()),
+) {
+    private val applicationContext = context.applicationContext
+    private var activeRequest: ActiveRequest? = null
+    private val timeout = Runnable {
+        activeRequest?.let { request -> complete(request.token, null) }
+    }
+    private val resultReceiver = object : ResultReceiver(handler) {
+        override fun onReceiveResult(resultCode: Int, resultData: Bundle?) {
+            val token = resultData?.getString(CurrentSongIdentityProtocol.EXTRA_REQUEST_TOKEN) ?: return
+            val appleMusicId = resultData
+                ?.getLong(CurrentSongIdentityProtocol.EXTRA_APPLE_MUSIC_ID, 0L)
+                ?.takeIf { resultCode == CurrentSongIdentityProtocol.RESULT_AVAILABLE && it > 0L }
+            complete(
+                token,
+                appleMusicId?.let {
+                    CurrentSongDetails(
+                        appleMusicId = it,
+                        title = resultData.stringOrNull(CurrentSongIdentityProtocol.EXTRA_SONG_TITLE),
+                        artist = resultData.stringOrNull(CurrentSongIdentityProtocol.EXTRA_SONG_ARTIST),
+                    )
+                },
+            )
+        }
+    }
+
+    fun request(onResult: (CurrentSongDetails?) -> Unit): Boolean {
+        if (activeRequest != null) return false
+
+        val request = ActiveRequest(UUID.randomUUID().toString(), onResult)
+        activeRequest = request
+        handler.postDelayed(timeout, TIMEOUT_MILLIS)
+        applicationContext.sendBroadcast(
+            Intent(CurrentSongIdentityProtocol.REQUEST_ACTION)
+                .setPackage(ModuleConstants.TARGET_PACKAGE)
+                .putExtra(CurrentSongIdentityProtocol.EXTRA_REQUEST_TOKEN, request.token)
+                .putExtra(CurrentSongIdentityProtocol.EXTRA_RESULT_RECEIVER, resultReceiver),
+        )
+        return true
+    }
+
+    fun cancel() {
+        handler.removeCallbacks(timeout)
+        activeRequest = null
+    }
+
+    private fun complete(token: String, details: CurrentSongDetails?) {
+        val request = activeRequest?.takeIf { it.token == token } ?: return
+        handler.removeCallbacks(timeout)
+        activeRequest = null
+        request.onResult(details)
+    }
+
+    private fun Bundle?.stringOrNull(key: String): String? = this
+        ?.getString(key)
+        ?.trim()
+        ?.takeIf(String::isNotEmpty)
+
+    private data class ActiveRequest(
+        val token: String,
+        val onResult: (CurrentSongDetails?) -> Unit,
+    )
+
+    private companion object {
+        const val TIMEOUT_MILLIS = 1_500L
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt
+++ b/app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt
@@ -763,14 +763,15 @@ class SettingsActivity : Activity() {
                     return@save
                 }
                 saveCustomLyrics(
-                    CustomLyricsDraft(
+                    draft = CustomLyricsDraft(
                         appleMusicId = id,
                         displayName = displayName.text.toString(),
                         ttml = rawTtml,
                         source = source,
                         enabled = existing?.enabled ?: true,
                     ),
-                    dialog,
+                    replacingAppleMusicId = existing?.appleMusicId,
+                    dialog = dialog,
                 )
             })
         }
@@ -946,14 +947,18 @@ class SettingsActivity : Activity() {
         }
     }
 
-    private fun saveCustomLyrics(draft: CustomLyricsDraft, dialog: AlertDialog) {
+    private fun saveCustomLyrics(
+        draft: CustomLyricsDraft,
+        replacingAppleMusicId: Long?,
+        dialog: AlertDialog,
+    ) {
         val snapshot = ModuleApplication.serviceSnapshot
         if (!snapshot.isRemoteFileAvailable) {
             toast("libxposed remote file 服务不可用")
             return
         }
         backgroundExecutor.execute {
-            val result = CustomLyricsManager(snapshot, store).save(draft)
+            val result = CustomLyricsManager(snapshot, store).save(draft, replacingAppleMusicId)
             runOnUiThread {
                 if (isFinishing || isDestroyed) return@runOnUiThread
                 when (result) {

--- a/app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt
+++ b/app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt
@@ -10,6 +10,7 @@ import android.graphics.Color
 import android.graphics.Typeface
 import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.RippleDrawable
+import android.text.InputType
 import android.os.Build
 import android.os.Bundle
 import android.view.Gravity
@@ -20,6 +21,7 @@ import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.Button
+import android.widget.EditText
 import android.widget.ScrollView
 import android.widget.SeekBar
 import android.widget.Switch
@@ -31,6 +33,21 @@ import dev.amenhancer.module.XposedServiceSnapshot
 import dev.amenhancer.module.config.ConfigStore
 import dev.amenhancer.module.font.FontImportResult
 import dev.amenhancer.module.font.SafFontImporter
+import dev.amenhancer.module.hook.AmllTtmlClient
+import dev.amenhancer.module.hook.HttpLyricTransport
+import dev.amenhancer.module.hook.NeteaseLyricClient
+import dev.amenhancer.module.lyrics.CustomLyricsDraft
+import dev.amenhancer.module.lyrics.CustomLyricsFilePolicy
+import dev.amenhancer.module.lyrics.CustomLyricsFileReader
+import dev.amenhancer.module.lyrics.CustomLyricsInspection
+import dev.amenhancer.module.lyrics.CustomLyricsManager
+import dev.amenhancer.module.lyrics.CustomLyricsMutationResult
+import dev.amenhancer.module.lyrics.CustomLyricsOnlineImportResult
+import dev.amenhancer.module.lyrics.CustomLyricsOnlineImporter
+import dev.amenhancer.module.lyrics.CustomLyricsSaveResult
+import dev.amenhancer.module.model.CustomLyricsEntry
+import dev.amenhancer.module.model.CustomLyricsManifest
+import dev.amenhancer.module.model.CustomLyricsSources
 import dev.amenhancer.module.model.LyricsFontManifest
 import dev.amenhancer.module.model.ModuleSettings
 import java.util.concurrent.ExecutorService
@@ -41,12 +58,24 @@ internal object BlurRadiusSeekBarPersistencePolicy {
         fromUser && !trackingTouch
 }
 
+private enum class SettingsPage {
+    MAIN,
+    CUSTOM_LYRICS,
+}
+
 class SettingsActivity : Activity() {
     private lateinit var store: ConfigStore
     private lateinit var launcherIconController: LauncherIconController
     private lateinit var content: LinearLayout
+    private lateinit var settingsScroll: ScrollView
     private lateinit var palette: Palette
-    private val backgroundExecutor: ExecutorService = Executors.newSingleThreadExecutor()
+    private lateinit var currentSongIdentityRequester: CurrentSongIdentityRequester
+    private lateinit var topBarTitle: TextView
+    private lateinit var topBarBackButton: ImageView
+    private val backgroundExecutor: ExecutorService get() = settingsExecutor
+    private var pendingCustomTtmlImport: ((String) -> Unit)? = null
+    private var awaitingCustomTtmlPickerResult = false
+    private var currentPage = SettingsPage.MAIN
 
     private val serviceListener: (XposedServiceSnapshot) -> Unit = { snapshot ->
         runOnUiThread { if (::content.isInitialized) render(snapshot) }
@@ -56,7 +85,15 @@ class SettingsActivity : Activity() {
         super.onCreate(savedInstanceState)
         store = ConfigStore(this)
         launcherIconController = LauncherIconController(this)
+        currentSongIdentityRequester = CurrentSongIdentityRequester(this)
         palette = Palette.resolve(this)
+        awaitingCustomTtmlPickerResult = savedInstanceState?.getBoolean(
+            STATE_AWAITING_CUSTOM_TTML_PICKER,
+            false,
+        ) == true
+        currentPage = savedInstanceState?.getString(STATE_SETTINGS_PAGE)
+            ?.let { saved -> runCatching { SettingsPage.valueOf(saved) }.getOrNull() }
+            ?: SettingsPage.MAIN
         configureSystemBars()
         setContentView(buildScreen().also(::applySystemBarInsets))
         render()
@@ -74,18 +111,46 @@ class SettingsActivity : Activity() {
     }
 
     override fun onDestroy() {
-        // Let an in-flight remote-file transaction finish so it cannot leave a
-        // partially written shared font when the Activity is recreated.
-        backgroundExecutor.shutdown()
+        if (::currentSongIdentityRequester.isInitialized) currentSongIdentityRequester.cancel()
         super.onDestroy()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putBoolean(STATE_AWAITING_CUSTOM_TTML_PICKER, awaitingCustomTtmlPickerResult)
+        outState.putString(STATE_SETTINGS_PAGE, currentPage.name)
+        super.onSaveInstanceState(outState)
+    }
+
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+    override fun onBackPressed() {
+        if (currentPage == SettingsPage.CUSTOM_LYRICS) {
+            showPage(SettingsPage.MAIN)
+        } else {
+            super.onBackPressed()
+        }
     }
 
     @Suppress("DEPRECATION")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
-        if (requestCode != FONT_PICKER_REQUEST_CODE || resultCode != RESULT_OK) return
-        val uri = data?.data ?: return
-        importFont(uri)
+        when (requestCode) {
+            FONT_PICKER_REQUEST_CODE -> {
+                if (resultCode == RESULT_OK) data?.data?.let(::importFont)
+            }
+            CUSTOM_TTML_PICKER_REQUEST_CODE -> {
+                val onImported = pendingCustomTtmlImport
+                val restoreEditor = onImported == null && awaitingCustomTtmlPickerResult
+                pendingCustomTtmlImport = null
+                awaitingCustomTtmlPickerResult = false
+                if (resultCode == RESULT_OK) data?.data?.let { uri ->
+                    importCustomTtml(uri) { ttml ->
+                        if (onImported != null) onImported(ttml) else if (restoreEditor) {
+                            showCustomLyricsEditor(initialTtml = ttml)
+                        }
+                    }
+                }
+            }
+        }
     }
 
     private fun configureSystemBars() {
@@ -132,7 +197,7 @@ class SettingsActivity : Activity() {
             LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(56)),
         )
         addView(divider())
-        addView(ScrollView(this@SettingsActivity).apply {
+        settingsScroll = ScrollView(this@SettingsActivity).apply {
             isFillViewport = true
             clipToPadding = false
             content = LinearLayout(this@SettingsActivity).apply {
@@ -146,27 +211,48 @@ class SettingsActivity : Activity() {
                     ViewGroup.LayoutParams.WRAP_CONTENT,
                 ),
             )
-        }, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f))
+        }
+        addView(settingsScroll, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f))
     }
 
     private fun buildTopBar(): View = FrameLayout(this).apply {
-        setPadding(dp(24), 0, dp(24), 0)
-        addView(TextView(this@SettingsActivity).apply {
-            text = "AM++"
+        setPadding(dp(12), 0, dp(24), 0)
+        topBarBackButton = ImageView(this@SettingsActivity).apply {
+            setImageResource(R.drawable.ic_arrow_back)
+            imageTintList = ColorStateList.valueOf(palette.onSurface)
+            contentDescription = "返回"
+            setPadding(dp(12), dp(12), dp(12), dp(12))
+            background = rippleDrawable()
+            setOnClickListener { showPage(SettingsPage.MAIN) }
+        }
+        addView(
+            topBarBackButton,
+            FrameLayout.LayoutParams(dp(48), dp(48), Gravity.START or Gravity.CENTER_VERTICAL),
+        )
+        topBarTitle = TextView(this@SettingsActivity).apply {
             textSize = 20f
             setTextColor(palette.onSurface)
             gravity = Gravity.START or Gravity.CENTER_VERTICAL
             typeface = Typeface.create(Typeface.DEFAULT, Typeface.NORMAL)
-        }, FrameLayout.LayoutParams(
+        }
+        addView(topBarTitle, FrameLayout.LayoutParams(
             ViewGroup.LayoutParams.MATCH_PARENT,
             ViewGroup.LayoutParams.WRAP_CONTENT,
             Gravity.CENTER_VERTICAL,
-        ))
+        ).apply { marginStart = dp(12) })
     }
 
     private fun render(snapshot: XposedServiceSnapshot = ModuleApplication.serviceSnapshot) {
         content.removeAllViews()
         val settings = store.settings(snapshot)
+        updateTopBar()
+        when (currentPage) {
+            SettingsPage.MAIN -> renderMainPage(settings, snapshot)
+            SettingsPage.CUSTOM_LYRICS -> renderCustomLyricsPage(settings, snapshot)
+        }
+    }
+
+    private fun renderMainPage(settings: ModuleSettings, snapshot: XposedServiceSnapshot) {
         val writable = snapshot.isRemoteAvailable
 
         content.addView(statusCard(snapshot))
@@ -182,6 +268,32 @@ class SettingsActivity : Activity() {
         content.addView(sectionLabel("帮助"))
         content.addView(spacer(10))
         content.addView(helpRow())
+    }
+
+    private fun renderCustomLyricsPage(settings: ModuleSettings, snapshot: XposedServiceSnapshot) {
+        content.addView(customLyricsSettingsCard(settings, snapshot.isRemoteAvailable))
+        content.addView(spacer(20))
+        content.addView(
+            customLyricsCard(settings.customLyricsManifest, snapshot.isRemoteFileAvailable),
+        )
+    }
+
+    private fun showPage(page: SettingsPage) {
+        if (currentPage == page) return
+        if (page == SettingsPage.MAIN) currentSongIdentityRequester.cancel()
+        currentPage = page
+        render()
+        settingsScroll.post { settingsScroll.scrollTo(0, 0) }
+    }
+
+    private fun updateTopBar() {
+        val customLyrics = currentPage == SettingsPage.CUSTOM_LYRICS
+        topBarTitle.text = if (customLyrics) "自定义歌词" else "AM++"
+        topBarBackButton.visibility = if (customLyrics) View.VISIBLE else View.GONE
+        (topBarTitle.layoutParams as? FrameLayout.LayoutParams)?.let { params ->
+            params.marginStart = dp(if (customLyrics) 52 else 12)
+            topBarTitle.layoutParams = params
+        }
     }
 
     private fun statusCard(snapshot: XposedServiceSnapshot): View = LinearLayout(this).apply {
@@ -267,6 +379,61 @@ class SettingsActivity : Activity() {
                 enabled = writable,
             ) { offsetPx ->
                 store.saveSettings(store.settings().copy(lyricBlurRadiusOffsetPx = offsetPx))
+            })
+            addView(insetDivider())
+            addView(customLyricsNavigationRow(settings.customLyricsManifest))
+        }
+
+    private fun customLyricsNavigationRow(manifest: CustomLyricsManifest): View =
+        LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            minimumHeight = dp(84)
+            isClickable = true
+            isFocusable = true
+            contentDescription = "自定义歌词"
+            background = rippleDrawable()
+            setPadding(dp(16), dp(12), dp(14), dp(12))
+            addView(LinearLayout(this@SettingsActivity).apply {
+                orientation = LinearLayout.VERTICAL
+                addView(TextView(this@SettingsActivity).apply {
+                    text = "自定义歌词"
+                    textSize = 17f
+                    setTextColor(palette.onSurface)
+                    typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+                })
+                addView(TextView(this@SettingsActivity).apply {
+                    text = if (manifest.entries.isEmpty()) {
+                        "添加和管理 Apple Music ID 歌词映射"
+                    } else {
+                        "已配置 ${manifest.entries.size} 首歌词"
+                    }
+                    textSize = 13.5f
+                    setTextColor(palette.onSurfaceVariant)
+                    setPadding(0, dp(4), dp(8), 0)
+                })
+            }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+            addView(ImageView(this@SettingsActivity).apply {
+                setImageResource(R.drawable.ic_chevron_right)
+                imageTintList = ColorStateList.valueOf(palette.onSurfaceVariant)
+                contentDescription = null
+            }, LinearLayout.LayoutParams(dp(24), dp(24)))
+            setOnClickListener { showPage(SettingsPage.CUSTOM_LYRICS) }
+        }
+
+    private fun customLyricsSettingsCard(settings: ModuleSettings, writable: Boolean): View =
+        LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            background = roundedDrawable(palette.surface, radiusDp = 20, strokeColor = palette.outline)
+            elevation = dp(2).toFloat()
+            clipToOutline = true
+            addView(settingRow(
+                title = "自定义歌词替换",
+                summary = "按 Apple Music ID 注入 · 更改后重开 Apple Music 生效",
+                checked = settings.customLyricsEnabled,
+                enabled = writable,
+            ) { enabled ->
+                store.saveSettings(store.settings().copy(customLyricsEnabled = enabled))
             })
         }
 
@@ -389,6 +556,458 @@ class SettingsActivity : Activity() {
                 }
             }
         }
+    }
+
+    private fun customLyricsCard(manifest: CustomLyricsManifest, writable: Boolean): View =
+        LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            background = roundedDrawable(palette.surface, radiusDp = 20, strokeColor = palette.outline)
+            elevation = dp(2).toFloat()
+            clipToOutline = true
+
+            addView(sectionLabel("自定义歌词").apply {
+                setPadding(dp(16), dp(18), dp(16), dp(8))
+            })
+            addView(TextView(this@SettingsActivity).apply {
+                text = when {
+                    !writable -> "需要 libxposed API 102 remote file 服务"
+                    manifest.entries.isEmpty() -> "按 Apple Music ID 手动添加 TTML；不会在播放时联网识歌"
+                    else -> "已配置 ${manifest.entries.size} 首；更改后重开 Apple Music 生效"
+                }
+                textSize = 13.5f
+                setTextColor(palette.onSurfaceVariant)
+                setPadding(dp(16), dp(4), dp(16), dp(12))
+            })
+            manifest.entries.forEach { entry ->
+                addView(customLyricsEntryRow(entry, writable))
+                addView(insetDivider())
+            }
+            addView(LinearLayout(this@SettingsActivity).apply {
+                orientation = LinearLayout.HORIZONTAL
+                setPadding(dp(12), 0, dp(12), dp(12))
+                addView(
+                    fontActionButton("添加歌词", writable) { showCustomLyricsEditor() },
+                    LinearLayout.LayoutParams(0, dp(48), 1f),
+                )
+            })
+        }
+
+    private fun requestCurrentSongId(appleMusicId: EditText, displayName: EditText) {
+        if (!currentSongIdentityRequester.request { currentSong ->
+                if (currentSong == null) {
+                    toast("未获取到当前歌曲信息，请先在 Apple Music 播放一首歌")
+                    return@request
+                }
+                appleMusicId.setText(currentSong.appleMusicId.toString())
+                appleMusicId.setSelection(appleMusicId.length())
+                formatCurrentSongDisplayName(currentSong.title, currentSong.artist)?.let {
+                    displayName.setText(it)
+                    displayName.setSelection(displayName.length())
+                }
+                toast("已获取当前歌曲信息")
+            }
+        ) {
+            toast("正在获取当前歌曲信息")
+            return
+        }
+        toast("正在获取当前歌曲信息…")
+    }
+
+    private fun formatCurrentSongDisplayName(title: String?, artist: String?): String? = listOfNotNull(
+        title?.takeIf(String::isNotBlank),
+        artist?.takeIf(String::isNotBlank),
+    ).joinToString(" - ").takeIf(String::isNotBlank)
+
+    private fun customLyricsEntryRow(entry: CustomLyricsEntry, writable: Boolean): View =
+        LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(16), dp(12), dp(12), dp(12))
+            alpha = if (writable) 1f else 0.58f
+            addView(LinearLayout(this@SettingsActivity).apply {
+                orientation = LinearLayout.HORIZONTAL
+                gravity = Gravity.CENTER_VERTICAL
+                addView(LinearLayout(this@SettingsActivity).apply {
+                    orientation = LinearLayout.VERTICAL
+                    addView(TextView(this@SettingsActivity).apply {
+                        text = entry.displayName
+                        textSize = 16f
+                        setTextColor(palette.onSurface)
+                        typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+                    })
+                    addView(TextView(this@SettingsActivity).apply {
+                        text = "${entry.appleMusicId} · ${customLyricsSourceName(entry.source)}"
+                        textSize = 13f
+                        setTextColor(palette.onSurfaceVariant)
+                        setPadding(0, dp(3), 0, 0)
+                    })
+                }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+                addView(Switch(this@SettingsActivity).apply {
+                    isChecked = entry.enabled
+                    isEnabled = writable
+                    contentDescription = "${entry.displayName} 自定义歌词开关"
+                    thumbTintList = switchThumbColors()
+                    trackTintList = switchTrackColors()
+                    setOnCheckedChangeListener { _, checked ->
+                        setCustomLyricsEnabled(entry.appleMusicId, checked)
+                    }
+                }, LinearLayout.LayoutParams(dp(64), dp(48)))
+            })
+            addView(LinearLayout(this@SettingsActivity).apply {
+                orientation = LinearLayout.HORIZONTAL
+                setPadding(0, dp(8), 0, 0)
+                addView(
+                    fontActionButton("编辑", writable) { showCustomLyricsEditor(entry) },
+                    LinearLayout.LayoutParams(0, dp(44), 1f),
+                )
+                addView(spacer(8), LinearLayout.LayoutParams(dp(8), dp(1)))
+                addView(
+                    fontActionButton("删除", writable) { confirmDeleteCustomLyrics(entry) },
+                    LinearLayout.LayoutParams(0, dp(44), 1f),
+                )
+            })
+        }
+
+    private fun showCustomLyricsEditor(
+        existing: CustomLyricsEntry? = null,
+        initialTtml: String = "",
+    ) {
+        var source = existing?.source ?: CustomLyricsSources.MANUAL
+        val form = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(20), dp(8), dp(20), 0)
+        }
+        val appleMusicId = lyricEditorInput(
+            hint = "Apple Music ID",
+            initial = existing?.appleMusicId?.toString().orEmpty(),
+            numeric = true,
+        )
+        val displayName = lyricEditorInput(
+            hint = "显示名称（可选）",
+            initial = existing?.displayName.orEmpty(),
+        )
+        val neteaseId = lyricEditorInput(hint = "网易云歌曲 ID（仅网易云导入时需要）", numeric = true)
+        val ttml = lyricEditorInput(
+            hint = "TTML 内容",
+            initial = initialTtml,
+            multiLine = true,
+        )
+        val sourceLabel = TextView(this).apply {
+            textSize = 13f
+            setTextColor(palette.onSurfaceVariant)
+            setPadding(0, dp(8), 0, dp(8))
+        }
+        fun updateSourceLabel() {
+            sourceLabel.text = "当前来源：${customLyricsSourceName(source)}"
+        }
+        updateSourceLabel()
+        form.addView(appleMusicId)
+        form.addView(displayName)
+        form.addView(neteaseId)
+        form.addView(sourceLabel)
+        form.addView(LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            addView(
+                fontActionButton("从 AMLL 导入", true) {
+                    importFromAmll(appleMusicId, ttml) { importedSource ->
+                        source = importedSource
+                        updateSourceLabel()
+                    }
+                },
+                LinearLayout.LayoutParams(0, dp(44), 1f),
+            )
+            addView(spacer(8), LinearLayout.LayoutParams(dp(8), dp(1)))
+            addView(
+                fontActionButton("从网易云导入", true) {
+                    importFromNetease(neteaseId, displayName, ttml) { importedSource ->
+                        source = importedSource
+                        updateSourceLabel()
+                    }
+                },
+                LinearLayout.LayoutParams(0, dp(44), 1f),
+            )
+        })
+        form.addView(ttml, LinearLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+        ).apply { topMargin = dp(8) })
+        val dialogContent = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            minimumHeight = (resources.displayMetrics.heightPixels * 0.65f).toInt()
+            addView(
+                ScrollView(this@SettingsActivity).apply { addView(form) },
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f),
+            )
+        }
+        lateinit var dialog: AlertDialog
+        val actionBar = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            addView(dialogActionButton("导入 TTML") {
+                chooseCustomTtml { imported ->
+                    ttml.setText(imported)
+                    source = CustomLyricsSources.MANUAL
+                    updateSourceLabel()
+                }
+            })
+            addView(dialogActionButton("获取 ID") { requestCurrentSongId(appleMusicId, displayName) })
+            addView(dialogActionButton("取消") { dialog.dismiss() })
+            addView(dialogActionButton("保存") save@{
+                val id = parsePositiveId(appleMusicId.text.toString())
+                if (id == null) {
+                    appleMusicId.error = "请输入正整数 Apple Music ID"
+                    return@save
+                }
+                val rawTtml = ttml.text.toString()
+                if (rawTtml.isBlank()) {
+                    ttml.error = "请输入或导入 TTML"
+                    return@save
+                }
+                saveCustomLyrics(
+                    CustomLyricsDraft(
+                        appleMusicId = id,
+                        displayName = displayName.text.toString(),
+                        ttml = rawTtml,
+                        source = source,
+                        enabled = existing?.enabled ?: true,
+                    ),
+                    dialog,
+                )
+            })
+        }
+        dialogContent.addView(
+            actionBar,
+            LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(56)),
+        )
+        dialog = AlertDialog.Builder(this)
+            .setTitle(if (existing == null) "添加自定义歌词" else "编辑自定义歌词")
+            .setView(dialogContent)
+            .create()
+        dialog.setOnShowListener {
+            existing?.let { entry -> loadExistingCustomTtml(entry, ttml) }
+        }
+        dialog.setOnDismissListener { currentSongIdentityRequester.cancel() }
+        dialog.show()
+    }
+
+    private fun LinearLayout.dialogActionButton(label: String, onClick: () -> Unit): Button =
+        Button(this@SettingsActivity).apply {
+            text = label
+            isAllCaps = false
+            textSize = 13f
+            minimumWidth = 0
+            minWidth = 0
+            setPadding(0, 0, 0, 0)
+            setTextColor(palette.primary)
+            background = rippleDrawable(roundedDrawable(Color.TRANSPARENT, radiusDp = 0))
+            setOnClickListener { onClick() }
+            layoutParams = LinearLayout.LayoutParams(0, dp(56), 1f)
+        }
+
+    private fun lyricEditorInput(
+        hint: String,
+        initial: String = "",
+        numeric: Boolean = false,
+        multiLine: Boolean = false,
+    ): EditText = EditText(this).apply {
+        this.hint = hint
+        setText(initial)
+        textSize = 15f
+        setTextColor(palette.onSurface)
+        setHintTextColor(palette.onSurfaceVariant)
+        inputType = when {
+            numeric -> InputType.TYPE_CLASS_NUMBER
+            multiLine -> InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE or
+                InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
+            else -> InputType.TYPE_CLASS_TEXT
+        }
+        if (multiLine) {
+            minLines = 8
+            maxLines = 14
+            gravity = Gravity.TOP or Gravity.START
+            typeface = Typeface.MONOSPACE
+        } else {
+            isSingleLine = true
+        }
+    }
+
+    private fun importFromAmll(
+        appleMusicIdInput: EditText,
+        ttmlInput: EditText,
+        onImported: (String) -> Unit,
+    ) {
+        val appleMusicId = parsePositiveId(appleMusicIdInput.text.toString())
+        if (appleMusicId == null) {
+            appleMusicIdInput.error = "请输入正整数 Apple Music ID"
+            return
+        }
+        backgroundExecutor.execute {
+            val result = CustomLyricsOnlineImporter(
+                fetchAmll = AmllTtmlClient(HttpLyricTransport())::fetch,
+                fetchNeteaseYrc = NeteaseLyricClient(HttpLyricTransport())::fetchYrc,
+            ).importAmll(appleMusicId)
+            showOnlineImportResult(result, ttmlInput, onImported)
+        }
+    }
+
+    private fun importFromNetease(
+        neteaseIdInput: EditText,
+        displayNameInput: EditText,
+        ttmlInput: EditText,
+        onImported: (String) -> Unit,
+    ) {
+        val neteaseSongId = parsePositiveId(neteaseIdInput.text.toString())
+        if (neteaseSongId == null) {
+            neteaseIdInput.error = "请输入正整数网易云歌曲 ID"
+            return
+        }
+        backgroundExecutor.execute {
+            val result = CustomLyricsOnlineImporter(
+                fetchAmll = AmllTtmlClient(HttpLyricTransport())::fetch,
+                fetchNeteaseYrc = NeteaseLyricClient(HttpLyricTransport())::fetchYrc,
+            ).importNetease(neteaseSongId, displayNameInput.text.toString())
+            showOnlineImportResult(result, ttmlInput, onImported)
+        }
+    }
+
+    private fun showOnlineImportResult(
+        result: CustomLyricsOnlineImportResult,
+        ttmlInput: EditText,
+        onImported: (String) -> Unit,
+    ) {
+        runOnUiThread {
+            if (isFinishing || isDestroyed) return@runOnUiThread
+            when (result) {
+                is CustomLyricsOnlineImportResult.Imported -> {
+                    ttmlInput.setText(result.ttml)
+                    onImported(result.source)
+                    toast("已导入 ${customLyricsSourceName(result.source)} 歌词，请确认后保存")
+                }
+                is CustomLyricsOnlineImportResult.Failed -> toast(result.message)
+            }
+        }
+    }
+
+    private fun chooseCustomTtml(onImported: (String) -> Unit) {
+        pendingCustomTtmlImport = onImported
+        awaitingCustomTtmlPickerResult = true
+        startActivityForResult(Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+            addCategory(Intent.CATEGORY_OPENABLE)
+            type = "application/xml"
+            putExtra(
+                Intent.EXTRA_MIME_TYPES,
+                arrayOf("application/ttml+xml", "application/xml", "text/xml", "text/plain"),
+            )
+        }, CUSTOM_TTML_PICKER_REQUEST_CODE)
+    }
+
+    private fun importCustomTtml(uri: android.net.Uri, onImported: (String) -> Unit) {
+        backgroundExecutor.execute {
+            val result = runCatching {
+                val bytes = contentResolver.openInputStream(uri)?.use(CustomLyricsFilePolicy::readBounded)
+                    ?: return@runCatching null
+                bytes.toString(Charsets.UTF_8).takeIf {
+                    CustomLyricsFilePolicy.inspect(it) is CustomLyricsInspection.Accepted
+                }
+            }.getOrNull()
+            runOnUiThread {
+                if (isFinishing || isDestroyed) return@runOnUiThread
+                if (result == null) {
+                    toast("所选文件不是有效且不超过 512 KiB 的 TTML")
+                } else {
+                    onImported(result)
+                    toast("TTML 已导入，请确认后保存")
+                }
+            }
+        }
+    }
+
+    private fun loadExistingCustomTtml(entry: CustomLyricsEntry, ttmlInput: EditText) {
+        val snapshot = ModuleApplication.serviceSnapshot
+        if (!snapshot.isRemoteFileAvailable) return
+        backgroundExecutor.execute {
+            val reader = CustomLyricsFileReader { fileId ->
+                snapshot.openRemoteFile(fileId)?.let { descriptor ->
+                    runCatching {
+                        android.os.ParcelFileDescriptor.AutoCloseInputStream(descriptor).use(
+                            CustomLyricsFilePolicy::readBounded,
+                        )
+                    }.getOrNull()
+                }
+            }
+            val ttml = reader.read(entry)
+            runOnUiThread {
+                if (isFinishing || isDestroyed) return@runOnUiThread
+                if (ttml == null) {
+                    toast("无法读取已保存的 TTML，请重新导入后保存")
+                } else if (ttmlInput.text.isNullOrBlank()) {
+                    ttmlInput.setText(ttml)
+                }
+            }
+        }
+    }
+
+    private fun saveCustomLyrics(draft: CustomLyricsDraft, dialog: AlertDialog) {
+        val snapshot = ModuleApplication.serviceSnapshot
+        if (!snapshot.isRemoteFileAvailable) {
+            toast("libxposed remote file 服务不可用")
+            return
+        }
+        backgroundExecutor.execute {
+            val result = CustomLyricsManager(snapshot, store).save(draft)
+            runOnUiThread {
+                if (isFinishing || isDestroyed) return@runOnUiThread
+                when (result) {
+                    is CustomLyricsSaveResult.Saved -> {
+                        dialog.dismiss()
+                        render()
+                        toast("歌词映射已保存，重开 Apple Music 后生效")
+                    }
+                    is CustomLyricsSaveResult.Failed -> toast(result.message)
+                }
+            }
+        }
+    }
+
+    private fun setCustomLyricsEnabled(appleMusicId: Long, enabled: Boolean) {
+        val snapshot = ModuleApplication.serviceSnapshot
+        backgroundExecutor.execute {
+            val result = CustomLyricsManager(snapshot, store).setEnabled(appleMusicId, enabled)
+            runOnUiThread {
+                if (isFinishing || isDestroyed) return@runOnUiThread
+                render()
+                if (result is CustomLyricsMutationResult.Failed) toast(result.message)
+            }
+        }
+    }
+
+    private fun confirmDeleteCustomLyrics(entry: CustomLyricsEntry) {
+        AlertDialog.Builder(this)
+            .setTitle("删除自定义歌词")
+            .setMessage("删除“${entry.displayName}”的 TTML 映射？")
+            .setNegativeButton("取消", null)
+            .setPositiveButton("删除") { _, _ ->
+                val snapshot = ModuleApplication.serviceSnapshot
+                backgroundExecutor.execute {
+                    val result = CustomLyricsManager(snapshot, store).delete(entry.appleMusicId)
+                    runOnUiThread {
+                        if (isFinishing || isDestroyed) return@runOnUiThread
+                        render()
+                        when (result) {
+                            is CustomLyricsMutationResult.Updated -> toast("已删除歌词映射")
+                            is CustomLyricsMutationResult.Failed -> toast(result.message)
+                        }
+                    }
+                }
+            }
+            .show()
+    }
+
+    private fun parsePositiveId(value: String): Long? = value.trim().toLongOrNull()?.takeIf { it > 0L }
+
+    private fun customLyricsSourceName(source: String): String = when (source) {
+        CustomLyricsSources.AMLL -> "AMLL"
+        CustomLyricsSources.NETEASE -> "网易云 YRC"
+        else -> "手动 TTML"
     }
 
     private fun toast(message: String) {
@@ -672,6 +1291,10 @@ class SettingsActivity : Activity() {
 
     private companion object {
         const val FONT_PICKER_REQUEST_CODE = 4401
+        const val CUSTOM_TTML_PICKER_REQUEST_CODE = 4402
+        const val STATE_AWAITING_CUSTOM_TTML_PICKER = "awaiting_custom_ttml_picker"
+        const val STATE_SETTINGS_PAGE = "settings_page"
+        val settingsExecutor: ExecutorService = Executors.newSingleThreadExecutor()
     }
 
     private data class Palette(

--- a/app/src/main/res/drawable/ic_arrow_back.xml
+++ b/app/src/main/res/drawable/ic_arrow_back.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.42,-1.41L7.83,13H20v-2z" />
+</vector>

--- a/app/src/test/java/com/apple/android/music/model/BaseContentItem.kt
+++ b/app/src/test/java/com/apple/android/music/model/BaseContentItem.kt
@@ -1,0 +1,16 @@
+package com.apple.android.music.model
+
+/**
+ * JVM stand-in for Apple Music's current lyrics item base class, matching the
+ * real binary name so the current-item field contract (`getId()`) can be
+ * exercised in unit tests.
+ */
+open class BaseContentItem(
+    private val id: String = "0",
+    private val title: String = "",
+    private val artistName: String = "",
+) {
+    fun getId(): String = id
+    fun getTitle(): String = title
+    fun getArtistName(): String = artistName
+}

--- a/app/src/test/java/com/apple/android/music/model/PlaybackItem.kt
+++ b/app/src/test/java/com/apple/android/music/model/PlaybackItem.kt
@@ -1,0 +1,3 @@
+package com.apple.android.music.model
+
+class PlaybackItem : BaseContentItem()

--- a/app/src/test/java/com/apple/android/music/player/fragment/CurrentItemFieldOwners.kt
+++ b/app/src/test/java/com/apple/android/music/player/fragment/CurrentItemFieldOwners.kt
@@ -1,0 +1,38 @@
+package com.apple.android.music.player.fragment
+
+import com.apple.android.music.model.BaseContentItem
+
+class e {
+    class c
+}
+
+/**
+ * JVM stand-ins for the player fragment hierarchy that owns the current
+ * lyrics item field (`c`). `m` mirrors the verified 6.5.0/1580 owner with the
+ * exact public non-static field of type `BaseContentItem`; `n` is a
+ * same-contract neighbor used for ambiguity fixtures; the `m*` variants must
+ * never satisfy the field contract.
+ */
+class m {
+    @JvmField
+    var c: BaseContentItem = BaseContentItem()
+}
+
+class n {
+    @JvmField
+    var c: BaseContentItem = BaseContentItem()
+}
+
+/** Same field name but static — must never satisfy the field contract. */
+class mStatic {
+    companion object {
+        @JvmField
+        var c: BaseContentItem? = null
+    }
+}
+
+/** Same field name but wrong type — must never satisfy the field contract. */
+class mWrongType {
+    @JvmField
+    var c: String = ""
+}

--- a/app/src/test/java/com/apple/android/music/ttml/javanative/model/SongInfo.kt
+++ b/app/src/test/java/com/apple/android/music/ttml/javanative/model/SongInfo.kt
@@ -1,5 +1,25 @@
 package com.apple.android.music.ttml.javanative.model
 
+import org.bytedeco.javacpp.Pointer
+
+/**
+ * JVM stand-ins for the native model classes, matching the real binary names
+ * (`...SongInfo$SongInfoPtr`, `...SongInfo$SongInfoNative`,
+ * `...LyricsSectionVector`) so target-symbol contracts can be exercised in
+ * unit tests.
+ */
 class SongInfo {
-    class SongInfoPtr
+    class SongInfoPtr : Pointer() {
+        fun get(): SongInfoNative = SongInfoNative()
+    }
+
+    class SongInfoNative {
+        fun getSections(): LyricsSectionVector = LyricsSectionVector()
+        fun getAdamId(): Long = 0L
+        fun setAdamId(adamId: Long) = Unit
+    }
+}
+
+class LyricsSectionVector {
+    fun size(): Long = 0L
 }

--- a/app/src/test/java/dev/amenhancer/module/config/CustomLyricsManifestCodecTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/config/CustomLyricsManifestCodecTest.kt
@@ -1,0 +1,43 @@
+package dev.amenhancer.module.config
+
+import dev.amenhancer.module.model.CustomLyricsEntry
+import dev.amenhancer.module.model.CustomLyricsManifest
+import dev.amenhancer.module.model.CustomLyricsSources
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CustomLyricsManifestCodecTest {
+    private val entry = CustomLyricsEntry(
+        appleMusicId = 123456789L,
+        displayName = "Song",
+        fileId = "lyrics_abc123",
+        sizeBytes = 42L,
+        sha256 = "0cba697d61a21fb62408b2411aa2152d1bc24cc2414d2bd162f70e04d20c5e53",
+        source = CustomLyricsSources.AMLL,
+    )
+
+    @Test
+    fun `manifest round trips through one remote preference string`() {
+        val manifest = CustomLyricsManifest(listOf(entry))
+
+        assertEquals(manifest, CustomLyricsManifestCodec.decode(CustomLyricsManifestCodec.encode(manifest)))
+    }
+
+    @Test
+    fun `malformed or untrusted entries fail closed`() {
+        assertEquals(CustomLyricsManifest.empty(), CustomLyricsManifestCodec.decode("not json"))
+        assertEquals(
+            CustomLyricsManifest.empty(),
+            CustomLyricsManifestCodec.decode(
+                """{"version":1,"entries":[{"appleMusicId":0,"fileId":"../bad"}]}""",
+            ),
+        )
+    }
+
+    @Test
+    fun `duplicate ids never leave an ambiguous target mapping`() {
+        val manifest = CustomLyricsManifest(listOf(entry, entry.copy(fileId = "lyrics_other")))
+
+        assertEquals(listOf(entry), CustomLyricsManifestPolicy.sanitize(manifest).entries)
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/config/ModuleSettingsSchemaTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/config/ModuleSettingsSchemaTest.kt
@@ -1,6 +1,7 @@
 package dev.amenhancer.module.config
 
 import dev.amenhancer.module.ModuleConstants
+import dev.amenhancer.module.model.CustomLyricsManifest
 import dev.amenhancer.module.model.ModuleSettings
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -41,11 +42,13 @@ class ModuleSettingsSchemaTest {
                 "phone_liquid_glass_enabled" to true,
                 "future_blur_enabled" to false,
                 "lyric_blur_radius_offset_px" to 6,
+                "custom_lyrics_enabled" to false,
                 "lyrics_font_enabled" to false,
                 "lyrics_font_file_id" to "",
                 "lyrics_font_display_name" to "",
                 "lyrics_font_size_bytes" to 0L,
                 "lyrics_font_sha256" to "",
+                "custom_lyrics_manifest" to CustomLyricsManifestCodec.encode(CustomLyricsManifest.empty()),
                 "schema_version" to ModuleConstants.CONFIG_SCHEMA_VERSION,
             ),
             encoded,
@@ -69,11 +72,13 @@ class ModuleSettingsSchemaTest {
                 "phone_liquid_glass_enabled" to true,
                 "future_blur_enabled" to true,
                 "lyric_blur_radius_offset_px" to 0,
+                "custom_lyrics_enabled" to false,
                 "lyrics_font_enabled" to false,
                 "lyrics_font_file_id" to "",
                 "lyrics_font_display_name" to "",
                 "lyrics_font_size_bytes" to 0L,
                 "lyrics_font_sha256" to "",
+                "custom_lyrics_manifest" to CustomLyricsManifestCodec.encode(CustomLyricsManifest.empty()),
                 "schema_version" to ModuleConstants.CONFIG_SCHEMA_VERSION,
             ),
             upgraded,
@@ -157,5 +162,42 @@ class ModuleSettingsSchemaTest {
                 mapOf("lyric_blur_radius_offset_px" to -99),
             ).lyricBlurRadiusOffsetPx,
         )
+    }
+
+    @Test
+    fun `custom lyrics defaults to disabled and round trips`() {
+        assertEquals(
+            false,
+            ModuleSettingsSchema.decode(emptyMap<String, Any?>()).customLyricsEnabled,
+        )
+        assertEquals(
+            false,
+            ModuleSettingsSchema.decode(
+                mapOf("custom_lyrics_enabled" to "not-a-boolean"),
+            ).customLyricsEnabled,
+        )
+
+        val encoded = ModuleSettingsSchema.encodeOrdinarySettings(
+            ModuleSettings(customLyricsEnabled = true),
+        )
+        assertEquals(true, encoded["custom_lyrics_enabled"])
+        assertEquals(
+            true,
+            ModuleSettingsSchema.decode(encoded).customLyricsEnabled,
+        )
+    }
+
+    @Test
+    fun `an old online lyric setting migrates to the custom lyrics gate`() {
+        val upgraded = ModuleSettingsSchema.upgrade(
+            storedValues = mapOf(
+                "schema_version" to 5,
+                "online_lyric_replacement_enabled" to true,
+            ),
+            legacyValues = emptyMap<String, Any?>(),
+        )
+
+        assertEquals(true, upgraded?.get("custom_lyrics_enabled"))
+        assertEquals(ModuleConstants.CONFIG_SCHEMA_VERSION, upgraded?.get("schema_version"))
     }
 }

--- a/app/src/test/java/dev/amenhancer/module/config/OrdinarySettingsWritePolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/config/OrdinarySettingsWritePolicyTest.kt
@@ -1,6 +1,9 @@
 package dev.amenhancer.module.config
 
 import dev.amenhancer.module.ModuleConstants
+import dev.amenhancer.module.model.CustomLyricsEntry
+import dev.amenhancer.module.model.CustomLyricsManifest
+import dev.amenhancer.module.model.CustomLyricsSources
 import dev.amenhancer.module.model.LyricsFontManifest
 import dev.amenhancer.module.model.ModuleSettings
 import org.junit.Assert.assertEquals
@@ -10,11 +13,8 @@ import org.junit.Test
 
 /**
  * Guards ConfigStore.saveSettings' write contract: an ordinary runtime write
- * must never carry any of the five lyrics_font_* manifest keys, so a stale
- * ModuleSettings (captured before a font import) cannot overwrite a manifest
- * that saveFontManifest committed afterwards. Merging the ordinary write into
- * the current preferences must leave the committed manifest byte-for-byte
- * intact; saveFontManifest stays the only runtime writer of font keys.
+ * must never carry a remote-file manifest key, so a stale ModuleSettings
+ * cannot overwrite a manifest committed by a file transaction afterwards.
  */
 class OrdinarySettingsWritePolicyTest {
     private val committedManifest = LyricsFontManifest(
@@ -39,12 +39,25 @@ class OrdinarySettingsWritePolicyTest {
         "lyrics_font_size_bytes",
         "lyrics_font_sha256",
     )
+    private val customLyricsManifest = CustomLyricsManifest(
+        entries = listOf(
+            CustomLyricsEntry(
+                appleMusicId = 42L,
+                displayName = "Example",
+                fileId = "lyrics_abc123",
+                sizeBytes = 42L,
+                sha256 = "0cba697d61a21fb62408b2411aa2152d1bc24cc2414d2bd162f70e04d20c5e53",
+                source = CustomLyricsSources.MANUAL,
+            ),
+        ),
+    )
 
     @Test
     fun `stale ordinary settings write after a new manifest commit leaves the manifest unchanged`() {
         val currentPreferences = mutableMapOf<String, Any>().apply {
             putAll(ModuleSettingsSchema.encodeOrdinarySettings(ModuleSettings()))
             putAll(ModuleSettingsSchema.encodeFontManifest(committedManifest))
+            putAll(ModuleSettingsSchema.encodeCustomLyricsManifest(customLyricsManifest))
         }
 
         val ordinaryWrite = ModuleSettingsSchema.encodeOrdinarySettings(staleSettings)
@@ -58,6 +71,7 @@ class OrdinarySettingsWritePolicyTest {
         assertEquals(committedManifest, decoded.fontManifest)
         assertEquals(false, decoded.dualPaneEnabled)
         assertEquals(false, decoded.futureBlurEnabled)
+        assertEquals(customLyricsManifest, decoded.customLyricsManifest)
     }
 
     @Test
@@ -80,11 +94,13 @@ class OrdinarySettingsWritePolicyTest {
                 "phone_liquid_glass_enabled" to true,
                 "future_blur_enabled" to false,
                 "lyric_blur_radius_offset_px" to 6,
+                "custom_lyrics_enabled" to false,
                 "schema_version" to ModuleConstants.CONFIG_SCHEMA_VERSION,
             ),
             encoded,
         )
         assertFalse(encoded.keys.any(fontKeys::contains))
+        assertFalse(encoded.containsKey("custom_lyrics_manifest"))
     }
 
     @Test
@@ -95,5 +111,9 @@ class OrdinarySettingsWritePolicyTest {
 
         fontKeys.forEach { key -> assertTrue("full encode must keep $key", encoded.containsKey(key)) }
         assertEquals(committedManifest, ModuleSettingsSchema.decode(encoded).fontManifest)
+        assertEquals(
+            CustomLyricsManifest.empty(),
+            ModuleSettingsSchema.decode(encoded).customLyricsManifest,
+        )
     }
 }

--- a/app/src/test/java/dev/amenhancer/module/hook/CurrentItemAdamIdTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CurrentItemAdamIdTest.kt
@@ -1,0 +1,22 @@
+package dev.amenhancer.module.hook
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CurrentItemAdamIdTest {
+
+    @Test
+    fun `apple current item string id is parsed`() {
+        assertEquals(42L, parseCurrentItemAdamId("42"))
+    }
+
+    @Test
+    fun `invalid current item ids fail open`() {
+        assertNull(parseCurrentItemAdamId(null))
+        assertNull(parseCurrentItemAdamId(""))
+        assertNull(parseCurrentItemAdamId("not-a-number"))
+        assertNull(parseCurrentItemAdamId("0"))
+        assertNull(parseCurrentItemAdamId("-1"))
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/CurrentSongIdentityStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CurrentSongIdentityStructuralRegressionTest.kt
@@ -1,0 +1,109 @@
+package dev.amenhancer.module.hook
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CurrentSongIdentityStructuralRegressionTest {
+    private fun projectFile(relativePath: String): String = sequenceOf(
+        File(relativePath),
+        File("../$relativePath"),
+    ).firstOrNull(File::isFile)?.readText()
+        ?: error("$relativePath was not found from the unit-test working directory")
+
+    @Test
+    fun `caches the identity in memory without storage or network on the hook path`() {
+        val target = projectFile(
+            "app/src/main/java/dev/amenhancer/module/hook/AppleMusicCurrentSongIdentityTarget.kt",
+        )
+        val feature = projectFile(
+            "app/src/main/java/dev/amenhancer/module/hook/CurrentSongIdentityFeature.kt",
+        )
+
+        assertTrue(target.contains("CurrentItemIdentitySeam(symbols)"))
+        assertTrue(target.contains("private val cache: CurrentSongIdentityCache"))
+        assertTrue(target.contains("PlayerMetadataPublishMethod"))
+        assertTrue(target.contains("MetadataToPlaybackItemMethod"))
+        assertTrue(target.contains("cache.publish(item, seam.detailsOfItem(item))"))
+        assertFalse(target.contains("SharedPreferences"))
+        assertFalse(target.contains("openRemoteFile"))
+        assertFalse(target.contains("HttpLyricTransport"))
+        assertFalse(target.contains("java.io.File"))
+        assertFalse(target.contains("embedded-payload"))
+        assertFalse(target.contains("com.apple.android.music.amplus"))
+        assertFalse(feature.contains("config.settings()"))
+    }
+
+    @Test
+    fun `reuses the verified current item seam instead of duplicating it`() {
+        val target = projectFile(
+            "app/src/main/java/dev/amenhancer/module/hook/AppleMusicCustomLyricsTarget.kt",
+        )
+
+        assertTrue(target.contains("val seam = CurrentItemIdentitySeam(symbols)"))
+        assertTrue(target.contains("seam.currentItemAdamIdOf(param.thisObject)"))
+        assertFalse(target.contains("private fun currentItemAdamIdOf"))
+        assertFalse(target.contains("private fun resolveGetIdMethod"))
+    }
+
+    @Test
+    fun `opens unavailable lyrics only after an exact replacement is ready`() {
+        val target = projectFile(
+            "app/src/main/java/dev/amenhancer/module/hook/AppleMusicCustomLyricsTarget.kt",
+        )
+
+        assertTrue(target.contains("AppleMusicSymbols.LyricsAvailabilityPredicate"))
+        assertTrue(target.contains("override fun afterHookedMethod(param: MethodHookParam)"))
+        assertTrue(target.contains("seam.detailsOfItem(param.args.getOrNull(0))"))
+        assertTrue(target.contains("session.readyReplacementFor(appleMusicId)"))
+        assertTrue(target.contains("shouldExposeCustomLyrics("))
+        assertFalse(target.contains("LyricsResultField"))
+        assertFalse(target.contains("LyricsLoadMethod"))
+        assertFalse(target.contains("LyricsResumeMethod"))
+        assertFalse(target.contains("installMethod.invoke"))
+    }
+
+    @Test
+    fun `registers the capability in adaptation and the feature in installation`() {
+        val adaptation = projectFile(
+            "app/src/main/java/dev/amenhancer/module/hook/TargetAdaptation.kt",
+        )
+        val installation = projectFile(
+            "app/src/main/java/dev/amenhancer/module/hook/FeatureInstallation.kt",
+        )
+        val constants = projectFile("app/src/main/java/dev/amenhancer/module/ModuleConstants.kt")
+
+        assertTrue(adaptation.contains("val currentSong = CurrentSongIdentityCache()"))
+        assertTrue(adaptation.contains("currentSongIdentity = AppleMusicCurrentSongIdentityTarget("))
+        assertTrue(adaptation.contains("customLyrics = AppleMusicCustomLyricsTarget(config, resolver)"))
+        assertTrue(adaptation.contains("internal fun interface CurrentSongIdentityTarget"))
+        assertTrue(installation.contains("FeatureInstallationPlan(feature = CurrentSongIdentityFeature())"))
+        assertTrue(
+            installation.indexOf("FeatureInstallationPlan(feature = CurrentSongIdentityFeature())") <
+                installation.indexOf("FeatureInstallationPlan(feature = CustomLyricsFeature())"),
+        )
+        assertTrue(constants.contains("FEATURE_CURRENT_SONG_IDENTITY = \"current_song_identity\""))
+    }
+
+    @Test
+    fun `uses a signature-protected request responder instead of an embedded holder`() {
+        val target = projectFile(
+            "app/src/main/java/dev/amenhancer/module/hook/AppleMusicCurrentSongIdentityTarget.kt",
+        )
+        val protocol = projectFile(
+            "app/src/main/java/dev/amenhancer/module/CurrentSongIdentityProtocol.kt",
+        )
+        val manifest = projectFile("app/src/main/AndroidManifest.xml")
+
+        assertTrue(target.contains("CurrentSongIdentityRequestResponder"))
+        assertTrue(target.contains("ResultReceiver"))
+        assertTrue(target.contains("Context.RECEIVER_EXPORTED"))
+        assertTrue(target.contains("CurrentSongIdentityProtocol.REQUEST_PERMISSION"))
+        assertTrue(protocol.contains("REQUEST_CURRENT_SONG_ID"))
+        assertTrue(protocol.contains("EXTRA_SONG_TITLE"))
+        assertTrue(protocol.contains("EXTRA_SONG_ARTIST"))
+        assertTrue(manifest.contains("android:protectionLevel=\"signature\""))
+        assertTrue(manifest.contains("permission.REQUEST_CURRENT_SONG_ID"))
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/CurrentSongIdentityStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CurrentSongIdentityStructuralRegressionTest.kt
@@ -56,7 +56,7 @@ class CurrentSongIdentityStructuralRegressionTest {
         assertTrue(target.contains("AppleMusicSymbols.LyricsAvailabilityPredicate"))
         assertTrue(target.contains("override fun afterHookedMethod(param: MethodHookParam)"))
         assertTrue(target.contains("seam.detailsOfItem(param.args.getOrNull(0))"))
-        assertTrue(target.contains("session.readyReplacementFor(appleMusicId)"))
+        assertTrue(target.contains("session.replacementOrPrepareFor(appleMusicId)"))
         assertTrue(target.contains("shouldExposeCustomLyrics("))
         assertFalse(target.contains("LyricsResultField"))
         assertFalse(target.contains("LyricsLoadMethod"))

--- a/app/src/test/java/dev/amenhancer/module/hook/CurrentSongIdentityTargetTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CurrentSongIdentityTargetTest.kt
@@ -1,0 +1,252 @@
+package dev.amenhancer.module.hook
+
+import android.content.SharedPreferences
+import dev.amenhancer.module.CurrentSongDetails
+import dev.amenhancer.module.config.TargetConfigClient
+import dev.amenhancer.module.model.FeatureState
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CurrentSongIdentityTargetTest {
+
+    @Test
+    fun `seam resolves and reads the exact current item adam id`() {
+        val seam = CurrentItemIdentitySeam(resolver(SongFragment::class.java))
+        assertNull(seam.resolve(SongFragment.installMethod()))
+        assertNotNull(seam.fieldSummary)
+
+        assertEquals(12345L, seam.currentItemAdamIdOf(SongFragment(SongItem("12345"))))
+    }
+
+    @Test
+    fun `seam reads item update argument without depending on I2`() {
+        val seam = CurrentItemIdentitySeam(resolver(SongFragment::class.java))
+        assertNull(seam.resolve(SongFragment.installMethod()))
+
+        assertEquals(
+            CurrentSongDetails(67890L, "No lyrics", "Artist"),
+            seam.detailsOfItem(SongItem("67890", "No lyrics", "Artist")),
+        )
+    }
+
+    @Test
+    fun `seam reads fail closed when the current item is unavailable`() {
+        val seam = CurrentItemIdentitySeam(resolver(SongFragment::class.java))
+        seam.resolve(SongFragment.installMethod())
+
+        assertNull(seam.currentItemAdamIdOf(null))
+        assertNull(seam.currentItemAdamIdOf(SongFragment(null)))
+        assertNull(seam.currentItemAdamIdOf(SongFragment(SongItem("0"))))
+        assertNull(seam.currentItemAdamIdOf(SongFragment(SongItem("not-a-number"))))
+    }
+
+    @Test
+    fun `seam reports a missing current item field`() {
+        val seam = CurrentItemIdentitySeam(FakeIdentityResolver(field = null))
+        val diagnostic = seam.resolve(SongFragment.installMethod())
+
+        assertNotNull(diagnostic)
+        assertTrue(diagnostic!!.contains("lyrics-current-item-field"))
+        assertTrue(diagnostic.contains("was not found"))
+    }
+
+    @Test
+    fun `seam reports an item type without the getId contract`() {
+        val seam = CurrentItemIdentitySeam(resolver(WrongTypeFragment::class.java))
+        val diagnostic = seam.resolve(WrongTypeFragment.installMethod())
+
+        assertNotNull(diagnostic)
+        assertTrue(diagnostic!!.contains("getId() was unavailable"))
+    }
+
+    @Test
+    fun `seam rejects a field outside the I2 fragment hierarchy`() {
+        val seam = CurrentItemIdentitySeam(
+            resolver(owner = ForeignFieldOwner::class.java, installMethod = ForeignFragment.installMethod()),
+        )
+        val diagnostic = seam.resolve(ForeignFragment.installMethod())
+
+        assertNotNull(diagnostic)
+        assertTrue(diagnostic!!.contains("not in the I2 fragment hierarchy"))
+    }
+
+    @Test
+    fun `cache stores the exact adam id`() {
+        val cache = CurrentSongIdentityCache()
+        val item = Any()
+
+        cache.publish(item, CurrentSongDetails(12345L, "Song title", "Artist name"))
+
+        assertEquals(
+            CurrentSongDetails(12345L, "Song title", "Artist name"),
+            cache.current()?.details,
+        )
+        assertTrue(cache.current()?.item === item)
+    }
+
+    @Test
+    fun `cache fails closed for unavailable identities`() {
+        val cache = CurrentSongIdentityCache()
+        cache.publish(Any(), CurrentSongDetails(12345L))
+
+        cache.publish(null, null)
+        assertNull(cache.current())
+        cache.publish(Any(), CurrentSongDetails(0L))
+        assertNull(cache.current())
+        cache.publish(Any(), CurrentSongDetails(-7L))
+        assertNull(cache.current())
+    }
+
+    @Test
+    fun `feature installs unconditionally and maps the capability result`() {
+        val target = TargetAdaptation(
+            identity = "test",
+            dualPane = DualPaneTarget { TargetCapabilityInstall.Active("unused") },
+            editorialVideo = EditorialVideoTarget { TargetCapabilityInstall.Active("unused") },
+            bidirectionalLyricBlur = BidirectionalLyricBlurTarget {
+                TargetCapabilityInstall.Active("unused")
+            },
+            currentSongIdentity = CurrentSongIdentityTarget {
+                TargetCapabilityInstall.Active("identity published")
+            },
+        )
+
+        val result = CurrentSongIdentityFeature().install(
+            HookContext(config(), target),
+        )
+
+        assertEquals(FeatureState.ACTIVE, result.state)
+        assertTrue(result.message.contains("identity published"))
+    }
+
+    @Test
+    fun `feature maps a degraded capability as degraded without a settings gate`() {
+        val target = TargetAdaptation(
+            identity = "test",
+            dualPane = DualPaneTarget { TargetCapabilityInstall.Active("unused") },
+            editorialVideo = EditorialVideoTarget { TargetCapabilityInstall.Active("unused") },
+            bidirectionalLyricBlur = BidirectionalLyricBlurTarget {
+                TargetCapabilityInstall.Active("unused")
+            },
+            currentSongIdentity = CurrentSongIdentityTarget {
+                TargetCapabilityInstall.Degraded("holder missing")
+            },
+        )
+
+        val result = CurrentSongIdentityFeature().install(
+            HookContext(config(), target),
+        )
+
+        assertEquals(FeatureState.DEGRADED, result.state)
+        assertTrue(result.message.contains("holder missing"))
+    }
+
+    private fun resolver(
+        owner: Class<*>,
+        installMethod: Method = owner.getDeclaredMethod("I2", Any::class.java),
+    ): TargetSymbolResolver = FakeIdentityResolver(
+        field = owner.getDeclaredField("c"),
+        installMethod = installMethod,
+    )
+
+    private fun config(): TargetConfigClient = TargetConfigClient(
+        Proxy.newProxyInstance(
+            SharedPreferences::class.java.classLoader,
+            arrayOf(SharedPreferences::class.java),
+        ) { _, method, _ ->
+            when (method.name) {
+                "getAll" -> emptyMap<String, Any>()
+                "toString" -> "current-song-identity-test-preferences"
+                "hashCode" -> 1
+                "equals" -> false
+                else -> null
+            }
+        } as SharedPreferences,
+    )
+}
+
+private class FakeIdentityResolver(
+    private val field: Field?,
+    private val installMethod: Method? = null,
+) : TargetSymbolResolver {
+    override fun <T : Any> resolve(symbol: TargetSymbolKey<T>): TargetResolution<T> {
+        @Suppress("UNCHECKED_CAST")
+        return when (symbol.id) {
+            AppleMusicSymbols.LyricsCurrentItemField.id ->
+                if (field != null) {
+                    TargetResolution.Found(symbol.id, field, SymbolMatch.VERSION_PROFILE, "test")
+                } else {
+                    TargetResolution.Missing(symbol.id, "test")
+                }
+            AppleMusicSymbols.LyricsInstallMethod.id ->
+                if (installMethod != null) {
+                    TargetResolution.Found(
+                        symbol.id,
+                        installMethod,
+                        SymbolMatch.VERSION_PROFILE,
+                        "test",
+                    )
+                } else {
+                    TargetResolution.Missing(symbol.id, "test")
+                }
+            else -> TargetResolution.Missing(symbol.id, "test")
+        } as TargetResolution<T>
+    }
+}
+
+private class SongItem(
+    private val id: String,
+    private val title: String = "Song title",
+    private val artistName: String = "Artist name",
+) {
+    fun getId(): String = id
+    fun getTitle(): String = title
+    fun getArtistName(): String = artistName
+}
+
+private class SongFragment(item: SongItem?) {
+    @JvmField
+    var c: SongItem? = item
+
+    @Suppress("UNUSED_PARAMETER")
+    fun I2(ptr: Any) = Unit
+
+    companion object {
+        fun installMethod(): Method =
+            SongFragment::class.java.getDeclaredMethod("I2", Any::class.java)
+    }
+}
+
+private class WrongTypeFragment {
+    @JvmField
+    var c: String = ""
+
+    @Suppress("UNUSED_PARAMETER")
+    fun I2(ptr: Any) = Unit
+
+    companion object {
+        fun installMethod(): Method =
+            WrongTypeFragment::class.java.getDeclaredMethod("I2", Any::class.java)
+    }
+}
+
+private class ForeignFieldOwner {
+    @JvmField
+    var c: SongItem? = null
+}
+
+private class ForeignFragment {
+    @Suppress("UNUSED_PARAMETER")
+    fun I2(ptr: Any) = Unit
+
+    companion object {
+        fun installMethod(): Method =
+            ForeignFragment::class.java.getDeclaredMethod("I2", Any::class.java)
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsAvailabilityPolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsAvailabilityPolicyTest.kt
@@ -1,0 +1,21 @@
+package dev.amenhancer.module.hook
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CustomLyricsAvailabilityPolicyTest {
+    @Test
+    fun `native lyrics availability is never overridden`() {
+        assertTrue(shouldExposeCustomLyrics(true, 42L, replacementReady = false))
+        assertTrue(shouldExposeCustomLyrics(true, 42L, replacementReady = true))
+    }
+
+    @Test
+    fun `unavailable lyrics stay closed until an exact replacement is ready`() {
+        assertFalse(shouldExposeCustomLyrics(false, null, replacementReady = true))
+        assertFalse(shouldExposeCustomLyrics(false, 0L, replacementReady = true))
+        assertFalse(shouldExposeCustomLyrics(false, 42L, replacementReady = false))
+        assertTrue(shouldExposeCustomLyrics(false, 42L, replacementReady = true))
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsFeatureTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsFeatureTest.kt
@@ -1,0 +1,100 @@
+package dev.amenhancer.module.hook
+
+import android.content.SharedPreferences
+import dev.amenhancer.module.config.TargetConfigClient
+import dev.amenhancer.module.model.FeatureState
+import java.lang.reflect.Proxy
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CustomLyricsFeatureTest {
+
+    @Test
+    fun `disabled setting reports disabled and never touches the capability`() {
+        var capabilityCalled = false
+        val target = TargetAdaptation(
+            identity = "test",
+            dualPane = DualPaneTarget { TargetCapabilityInstall.Active("unused") },
+            editorialVideo = EditorialVideoTarget { TargetCapabilityInstall.Active("unused") },
+            bidirectionalLyricBlur = BidirectionalLyricBlurTarget {
+                TargetCapabilityInstall.Active("unused")
+            },
+            customLyrics = CustomLyricsTarget {
+                capabilityCalled = true
+                TargetCapabilityInstall.Active("installed")
+            },
+        )
+
+        val result = CustomLyricsFeature().install(
+            HookContext(config(customLyricsEnabled = false), target),
+        )
+
+        assertEquals(FeatureState.DISABLED, result.state)
+        assertFalse(capabilityCalled)
+    }
+
+    @Test
+    fun `enabled setting maps the capability result`() {
+        val target = TargetAdaptation(
+            identity = "test",
+            dualPane = DualPaneTarget { TargetCapabilityInstall.Active("unused") },
+            editorialVideo = EditorialVideoTarget { TargetCapabilityInstall.Active("unused") },
+            bidirectionalLyricBlur = BidirectionalLyricBlurTarget {
+                TargetCapabilityInstall.Active("unused")
+            },
+            customLyrics = CustomLyricsTarget {
+                TargetCapabilityInstall.Active("replacement installed")
+            },
+        )
+
+        val result = CustomLyricsFeature().install(
+            HookContext(config(customLyricsEnabled = true), target),
+        )
+
+        assertEquals(FeatureState.ACTIVE, result.state)
+        assertTrue(result.message.contains("replacement installed"))
+    }
+
+    @Test
+    fun `enabled setting maps a degraded capability as degraded`() {
+        val target = TargetAdaptation(
+            identity = "test",
+            dualPane = DualPaneTarget { TargetCapabilityInstall.Active("unused") },
+            editorialVideo = EditorialVideoTarget { TargetCapabilityInstall.Active("unused") },
+            bidirectionalLyricBlur = BidirectionalLyricBlurTarget {
+                TargetCapabilityInstall.Active("unused")
+            },
+            customLyrics = CustomLyricsTarget {
+                TargetCapabilityInstall.Degraded("symbol missing")
+            },
+        )
+
+        val result = CustomLyricsFeature().install(
+            HookContext(config(customLyricsEnabled = true), target),
+        )
+
+        assertEquals(FeatureState.DEGRADED, result.state)
+        assertTrue(result.message.contains("symbol missing"))
+    }
+
+    private fun config(customLyricsEnabled: Boolean): TargetConfigClient =
+        TargetConfigClient(
+            Proxy.newProxyInstance(
+                SharedPreferences::class.java.classLoader,
+                arrayOf(SharedPreferences::class.java),
+            ) { _, method, _ ->
+                when (method.name) {
+                    "getAll" ->
+                        mapOf<String, Any>(
+                            "custom_lyrics_enabled" to customLyricsEnabled,
+                        )
+                    "toString" -> "custom-lyrics-feature-test-preferences"
+                    "hashCode" -> 1
+                    "equals" -> false
+                    else -> null
+                }
+            } as SharedPreferences,
+        )
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsInstallArgumentPolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsInstallArgumentPolicyTest.kt
@@ -1,0 +1,29 @@
+package dev.amenhancer.module.hook
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CustomLyricsInstallArgumentPolicyTest {
+    @Test
+    fun `null pointer is accepted for songs without native lyrics`() {
+        assertTrue(acceptsLyricsInstallArguments(arrayOf(null), Pointer::class.java))
+    }
+
+    @Test
+    fun `the expected pointer type is accepted`() {
+        assertTrue(acceptsLyricsInstallArguments(arrayOf(Pointer()), Pointer::class.java))
+    }
+
+    @Test
+    fun `an unrelated non null argument is rejected`() {
+        assertFalse(acceptsLyricsInstallArguments(arrayOf("not a pointer"), Pointer::class.java))
+    }
+
+    @Test
+    fun `missing install argument is rejected`() {
+        assertFalse(acceptsLyricsInstallArguments(emptyArray(), Pointer::class.java))
+    }
+
+    private class Pointer
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsReplacementSessionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsReplacementSessionTest.kt
@@ -174,6 +174,39 @@ class CustomLyricsReplacementSessionTest {
         assertEquals(1, manifestReads)
     }
 
+    @Test
+    fun `availability queues background reprepare only for a mapped dead pointer`() {
+        val queued = QueuedExecutor()
+        var manifestReads = 0
+        var parses = 0
+        val first = Pointer(42L)
+        val second = Pointer(42L)
+        val session = CustomLyricsReplacementSession(
+            manifestProvider = { manifestReads += 1; manifest(entry(42L)) },
+            readTtml = { TTML },
+            parseTtml = { if (parses++ == 0) first else second },
+            isAlive = { it is Pointer && it.live },
+            verifyPtr = { it is Pointer && it.live },
+            readAdamId = { (it as Pointer).adamId },
+            bindAdamId = { value, id -> (value as Pointer).adamId = id; true },
+            executor = queued,
+            logger = {},
+        )
+
+        session.start()
+        queued.runAll()
+        first.live = false
+
+        assertNull(session.replacementOrPrepareFor(42L))
+        assertEquals(1, manifestReads)
+        queued.runAll()
+        assertSame(second, session.replacementOrPrepareFor(42L))
+
+        assertNull(session.replacementOrPrepareFor(41L))
+        queued.runAll()
+        assertEquals(2, manifestReads)
+    }
+
     private fun session(
         manifest: CustomLyricsManifest,
         read: (CustomLyricsEntry) -> String?,
@@ -203,7 +236,7 @@ class CustomLyricsReplacementSessionTest {
         enabled = enabled,
     )
 
-    private data class Pointer(var adamId: Long)
+    private data class Pointer(var adamId: Long, var live: Boolean = true)
 
     private class QueuedExecutor : Executor {
         private val commands = mutableListOf<Runnable>()

--- a/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsReplacementSessionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsReplacementSessionTest.kt
@@ -1,0 +1,223 @@
+package dev.amenhancer.module.hook
+
+import dev.amenhancer.module.model.CustomLyricsEntry
+import dev.amenhancer.module.model.CustomLyricsManifest
+import dev.amenhancer.module.model.CustomLyricsSources
+import java.util.concurrent.Executor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class CustomLyricsReplacementSessionTest {
+    @Test
+    fun `only an enabled exact apple music id is parsed and bound`() {
+        var reads = 0
+        val pointer = Pointer(0L)
+        val session = session(
+            manifest = manifest(entry(42L)),
+            read = { reads += 1; TTML },
+            parse = { pointer },
+        )
+
+        assertNull(session.replacementFor(41L))
+        assertSame(pointer, session.replacementFor(42L))
+        assertEquals(1, reads)
+        assertEquals(42L, pointer.adamId)
+    }
+
+    @Test
+    fun `a cached pointer is reused only for the same published file hash`() {
+        var parses = 0
+        val pointer = Pointer(42L)
+        val session = session(
+            manifest = manifest(entry(42L)),
+            read = { TTML },
+            parse = { parses += 1; pointer },
+        )
+
+        assertSame(pointer, session.replacementFor(42L))
+        assertSame(pointer, session.replacementFor(42L))
+        assertEquals(1, parses)
+    }
+
+    @Test
+    fun `disabled mappings and binding failures fail open`() {
+        val disabled = session(manifest(entry(42L, enabled = false)), { TTML }, { Pointer(0L) })
+        assertNull(disabled.replacementFor(42L))
+
+        val failedBinding = session(
+            manifest(entry(42L)),
+            { TTML },
+            { Pointer(0L) },
+            bind = { _, _ -> false },
+        )
+        assertNull(failedBinding.replacementFor(42L))
+    }
+
+    @Test
+    fun `i2 lookup never reads a manifest file or parses on the hook thread`() {
+        val queued = QueuedExecutor()
+        var manifestReads = 0
+        var fileReads = 0
+        var parses = 0
+        val pointer = Pointer(42L)
+        val session = CustomLyricsReplacementSession(
+            manifestProvider = { manifestReads += 1; manifest(entry(42L)) },
+            readTtml = { fileReads += 1; TTML },
+            parseTtml = { parses += 1; pointer },
+            isAlive = { it is Pointer },
+            verifyPtr = { it is Pointer },
+            readAdamId = { (it as Pointer).adamId },
+            bindAdamId = { value, id -> (value as Pointer).adamId = id; true },
+            executor = queued,
+            logger = {},
+        )
+
+        session.start()
+
+        assertNull(session.replacementFor(42L))
+        assertEquals(0, manifestReads)
+        assertEquals(0, fileReads)
+        assertEquals(0, parses)
+
+        queued.runAll()
+
+        assertSame(pointer, session.replacementFor(42L))
+        assertEquals(1, manifestReads)
+        assertEquals(1, fileReads)
+        assertEquals(1, parses)
+    }
+
+    @Test
+    fun `a failed initial manifest read retries from a later i2 without blocking it`() {
+        val queued = QueuedExecutor()
+        var manifestReads = 0
+        val pointer = Pointer(42L)
+        val session = CustomLyricsReplacementSession(
+            manifestProvider = {
+                manifestReads += 1
+                if (manifestReads == 1) error("remote preferences unavailable")
+                manifest(entry(42L))
+            },
+            readTtml = { TTML },
+            parseTtml = { pointer },
+            isAlive = { it is Pointer },
+            verifyPtr = { it is Pointer },
+            readAdamId = { (it as Pointer).adamId },
+            bindAdamId = { value, id -> (value as Pointer).adamId = id; true },
+            executor = queued,
+            logger = {},
+        )
+
+        session.start()
+        queued.runAll()
+        assertNull(session.replacementFor(42L))
+        queued.runAll()
+
+        assertSame(pointer, session.replacementFor(42L))
+        assertEquals(2, manifestReads)
+    }
+
+    @Test
+    fun `an unknown id reloads a mapping published after target startup`() {
+        val queued = QueuedExecutor()
+        var manifest = CustomLyricsManifest()
+        val pointer = Pointer(42L)
+        val session = CustomLyricsReplacementSession(
+            manifestProvider = { manifest },
+            readTtml = { TTML },
+            parseTtml = { pointer },
+            isAlive = { it is Pointer },
+            verifyPtr = { it is Pointer },
+            readAdamId = { (it as Pointer).adamId },
+            bindAdamId = { value, id -> (value as Pointer).adamId = id; true },
+            executor = queued,
+            logger = {},
+        )
+
+        session.start()
+        queued.runAll()
+        manifest = manifest(entry(42L))
+
+        assertNull(session.replacementFor(42L))
+        queued.runAll()
+        assertSame(pointer, session.replacementFor(42L))
+    }
+
+    @Test
+    fun `availability lookup returns only a ready pointer without queueing preload`() {
+        val queued = QueuedExecutor()
+        var manifestReads = 0
+        val pointer = Pointer(42L)
+        val session = CustomLyricsReplacementSession(
+            manifestProvider = { manifestReads += 1; manifest(entry(42L)) },
+            readTtml = { TTML },
+            parseTtml = { pointer },
+            isAlive = { it is Pointer },
+            verifyPtr = { it is Pointer },
+            readAdamId = { (it as Pointer).adamId },
+            bindAdamId = { value, id -> (value as Pointer).adamId = id; true },
+            executor = queued,
+            logger = {},
+        )
+
+        assertNull(session.readyReplacementFor(42L))
+        queued.runAll()
+        assertEquals(0, manifestReads)
+
+        session.start()
+        queued.runAll()
+        assertSame(pointer, session.readyReplacementFor(42L))
+        assertNull(session.readyReplacementFor(41L))
+        queued.runAll()
+        assertEquals(1, manifestReads)
+    }
+
+    private fun session(
+        manifest: CustomLyricsManifest,
+        read: (CustomLyricsEntry) -> String?,
+        parse: (String) -> Any?,
+        bind: (Pointer, Long) -> Boolean = { pointer, id -> pointer.adamId = id; true },
+    ): CustomLyricsReplacementSession = CustomLyricsReplacementSession(
+        manifestProvider = { manifest },
+        readTtml = read,
+        parseTtml = parse,
+        isAlive = { it is Pointer },
+        verifyPtr = { it is Pointer },
+        readAdamId = { (it as Pointer).adamId },
+        bindAdamId = { pointer, id -> bind(pointer as Pointer, id) },
+        executor = Executor { command -> command.run() },
+        logger = {},
+    ).also(CustomLyricsReplacementSession::start)
+
+    private fun manifest(entry: CustomLyricsEntry) = CustomLyricsManifest(listOf(entry))
+
+    private fun entry(id: Long, enabled: Boolean = true) = CustomLyricsEntry(
+        appleMusicId = id,
+        displayName = "Song",
+        fileId = "lyrics_$id",
+        sizeBytes = TTML.toByteArray().size.toLong(),
+        sha256 = "0cba697d61a21fb62408b2411aa2152d1bc24cc2414d2bd162f70e04d20c5e53",
+        source = CustomLyricsSources.MANUAL,
+        enabled = enabled,
+    )
+
+    private data class Pointer(var adamId: Long)
+
+    private class QueuedExecutor : Executor {
+        private val commands = mutableListOf<Runnable>()
+
+        override fun execute(command: Runnable) {
+            commands += command
+        }
+
+        fun runAll() {
+            while (commands.isNotEmpty()) commands.removeAt(0).run()
+        }
+    }
+
+    private companion object {
+        const val TTML = "<tt><body><p><span>word</span></p></body></tt>"
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/FeatureInstallationModuleTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/FeatureInstallationModuleTest.kt
@@ -23,6 +23,7 @@ class FeatureInstallationModuleTest {
                 plan("phone", events, "phone resources"),
                 plan("blur", events),
                 plan("font", events, "font resources"),
+                plan("online", events),
             ),
             installLayoutInflationHooks = { events += "layout hooks" },
             registerApplicationCreated = { _, _, callback ->
@@ -69,22 +70,18 @@ class FeatureInstallationModuleTest {
                 "report blur",
                 "install font",
                 "report font",
+                "install online",
+                "report online",
             ),
             events,
         )
         assertEquals(FeatureInstallationPhase.COMPLETE, session.snapshot().phase)
         assertEquals(
-            listOf("dual", "editorial", "phone", "blur", "font"),
+            listOf("dual", "editorial", "phone", "blur", "font", "online"),
             session.snapshot().health.map(FeatureHealth::feature),
         )
         assertEquals(
-            listOf(
-                "6.5.0 (1580)",
-                "6.5.0 (1580)",
-                "6.5.0 (1580)",
-                "6.5.0 (1580)",
-                "6.5.0 (1580)",
-            ),
+            List(6) { "6.5.0 (1580)" },
             session.snapshot().health.map(FeatureHealth::targetVersion),
         )
 
@@ -93,7 +90,7 @@ class FeatureInstallationModuleTest {
             context("unexpected")
         }
         assertSame(session, module.install(config(), javaClass.classLoader!!))
-        assertEquals(15, events.size)
+        assertEquals(17, events.size)
         assertEquals(1, contextFactoryCalls)
     }
 

--- a/app/src/test/java/dev/amenhancer/module/hook/HttpLyricTransportTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/HttpLyricTransportTest.kt
@@ -1,0 +1,85 @@
+package dev.amenhancer.module.hook
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class HttpLyricTransportTest {
+
+    private lateinit var server: HttpServer
+    private lateinit var baseUrl: String
+    private var lastRequestContentType: String? = null
+
+    @Before
+    fun startServer() {
+        server = HttpServer.create(InetSocketAddress(0), 0)
+        server.createContext("/") { exchange ->
+            handle(exchange)
+        }
+        server.start()
+        baseUrl = "http://127.0.0.1:${server.address.port}"
+    }
+
+    @After
+    fun stopServer() {
+        server.stop(0)
+    }
+
+    private fun handle(exchange: HttpExchange) {
+        try {
+            when (exchange.requestURI.path) {
+                "/ok" -> respond(exchange, 200, "hello world")
+                "/missing" -> respond(exchange, 404, "not found")
+                "/large" -> respond(exchange, 200, "x".repeat(200))
+                "/echo" -> {
+                    lastRequestContentType = exchange.requestHeaders.getFirst("Content-Type")
+                    val body = exchange.requestBody.readBytes().toString(Charsets.UTF_8)
+                    respond(exchange, 200, "echo:$body")
+                }
+                else -> respond(exchange, 500, "unexpected")
+            }
+        } finally {
+            exchange.close()
+        }
+    }
+
+    private fun respond(exchange: HttpExchange, code: Int, body: String) {
+        val bytes = body.toByteArray(Charsets.UTF_8)
+        exchange.sendResponseHeaders(code, bytes.size.toLong())
+        exchange.responseBody.use { it.write(bytes) }
+    }
+
+    @Test
+    fun `get returns the body for a success response`() {
+        val transport = HttpLyricTransport(maxResponseBytes = 64)
+        assertEquals("hello world", transport.get("$baseUrl/ok"))
+    }
+
+    @Test
+    fun `get returns null for a non success response`() {
+        val transport = HttpLyricTransport(maxResponseBytes = 64)
+        assertNull(transport.get("$baseUrl/missing"))
+    }
+
+    @Test
+    fun `get returns null when the body exceeds the cap`() {
+        val transport = HttpLyricTransport(maxResponseBytes = 64)
+        assertNull(transport.get("$baseUrl/large"))
+    }
+
+    @Test
+    fun `postForm sends the form body and returns the response`() {
+        val transport = HttpLyricTransport(maxResponseBytes = 1024)
+
+        val response = transport.postForm("$baseUrl/echo", "params=ABCD1234")
+
+        assertEquals("echo:params=ABCD1234", response)
+        assertTrue(lastRequestContentType.orEmpty().startsWith("application/x-www-form-urlencoded"))
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/OnlineLyricClientsTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/OnlineLyricClientsTest.kt
@@ -1,0 +1,105 @@
+package dev.amenhancer.module.hook
+
+import dev.amenhancer.module.lyrics.NeteaseEapi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OnlineLyricClientsTest {
+
+    private class FakeTransport(
+        var getResult: String? = null,
+        var postResult: String? = null,
+    ) : LyricHttpTransport {
+        val getUrls = mutableListOf<String>()
+        val postCalls = mutableListOf<Triple<String, String, Map<String, String>>>()
+
+        override fun get(url: String): String? {
+            getUrls += url
+            return getResult
+        }
+
+        override fun postForm(
+            url: String,
+            body: String,
+            extraHeaders: Map<String, String>,
+        ): String? {
+            postCalls += Triple(url, body, extraHeaders)
+            return postResult
+        }
+    }
+
+    private val eapiResponseJson = """
+        {"code":200,
+         "yrc":{"version":13,"lyric":"[190871,1984](190871,361,0)For (191232,172,0)the (191404,134,0)longest (191538,301,0)time"},
+         "lrc":{"lyric":"[03:10.871]For the longest time"}}
+    """.trimIndent()
+
+    @Test
+    fun `amll client fetches the exact adam id ttml url`() {
+        val transport = FakeTransport(getResult = "<tt>lyrics</tt>")
+        val client = AmllTtmlClient(transport)
+
+        assertEquals("<tt>lyrics</tt>", client.fetch(42L))
+        assertEquals(
+            "https://raw.githubusercontent.com/amll-dev/amll-ttml-db/refs/heads/main/am-lyrics/42.ttml",
+            transport.getUrls.single(),
+        )
+    }
+
+    @Test
+    fun `amll client returns null when the transport fails`() {
+        val transport = FakeTransport(getResult = null)
+        assertNull(AmllTtmlClient(transport).fetch(42L))
+    }
+
+    @Test
+    fun `netease yrc uses the eapi post with the fixed url and headers`() {
+        val transport = FakeTransport(postResult = eapiResponseJson)
+        val client = NeteaseLyricClient(transport)
+
+        val document = client.fetchYrc(33_241_436)
+
+        assertNotNull(document)
+        assertEquals(1, document!!.lines.size)
+        assertEquals("For ", document.lines.single().words.first().text)
+        val (url, body, headers) = transport.postCalls.single()
+        assertEquals(NeteaseEapi.LYRIC_V1_URL, url)
+        assertTrue(body.startsWith("params="))
+        assertTrue(body.length > "params=".length)
+        assertEquals("https://music.163.com", headers["Origin"])
+        assertTrue(headers["User-Agent"].orEmpty().contains("Chrome"))
+    }
+
+    @Test
+    fun `netease yrc fails open on non 200 responses`() {
+        val transport = FakeTransport(
+            postResult = """{"code":404,"message":"resource not found"}""",
+        )
+        assertNull(NeteaseLyricClient(transport).fetchYrc(1L))
+    }
+
+    @Test
+    fun `netease yrc without a yrc track returns null`() {
+        val transport = FakeTransport(
+            postResult = """{"code":200,"lrc":{"lyric":"[03:10.871]line only"}}""",
+        )
+        assertNull(NeteaseLyricClient(transport).fetchYrc(1L))
+    }
+
+    @Test
+    fun `netease yrc without word timing returns null`() {
+        val transport = FakeTransport(
+            postResult = """{"code":200,"yrc":{"lyric":"[190871,1984]plain line"}}""",
+        )
+        assertNull(NeteaseLyricClient(transport).fetchYrc(1L))
+    }
+
+    @Test
+    fun `netease yrc fails open when the transport fails`() {
+        assertNull(NeteaseLyricClient(FakeTransport(postResult = null)).fetchYrc(1L))
+        assertNull(NeteaseLyricClient(FakeTransport(postResult = "garbage")).fetchYrc(1L))
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/TargetSymbolsTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/TargetSymbolsTest.kt
@@ -1,5 +1,9 @@
 package dev.amenhancer.module.hook
 
+import com.apple.android.music.model.BaseContentItem
+import com.apple.android.music.player.fragment.m
+import com.apple.android.music.player.fragment.mWrongType
+import com.apple.android.music.player.fragment.n
 import com.apple.android.music.ttml.javanative.model.SongInfo
 import dev.amenhancer.module.ModuleConstants
 import org.junit.Assert.assertEquals
@@ -190,12 +194,324 @@ class TargetSymbolsTest {
         assertEquals(1, source.loadCounts["com.apple.missing"])
     }
 
+    @Test
+    fun `650 profile resolves the exact I2 lyrics install method among same-shaped R2`() {
+        val fragmentName = "com.apple.android.music.player.fragment.PlayerLyricsViewFragment"
+        val source = FakeTargetClassSource(
+            classes = mapOf(fragmentName to LyricsInstallFixture::class.java),
+        )
+        val resolver = IndexedTargetSymbolResolver(
+            build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.0", 1580L),
+            source = source,
+        )
+
+        val resolution = resolver.resolve(AppleMusicSymbols.LyricsInstallMethod)
+
+        assertTrue(resolution is TargetResolution.Found)
+        assertEquals("I2", (resolution as TargetResolution.Found).value.name)
+        assertEquals(SymbolMatch.VERSION_PROFILE, resolution.match)
+        assertEquals(0, source.classNameReads)
+    }
+
+    @Test
+    fun `650 profile resolves the player metadata identity funnel`() {
+        val source = FakeTargetClassSource(
+            classes = mapOf(
+                "com.apple.android.music.player.f" to PlayerMetadataHubFixture::class.java,
+                "com.apple.android.music.player.P" to MetadataConverterFixture::class.java,
+            ),
+        )
+        val resolver = IndexedTargetSymbolResolver(
+            build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.0", 1580L),
+            source = source,
+        )
+
+        val publish = resolver.resolve(AppleMusicSymbols.PlayerMetadataPublishMethod)
+        val converter = resolver.resolve(AppleMusicSymbols.MetadataToPlaybackItemMethod)
+
+        assertTrue(publish is TargetResolution.Found)
+        assertEquals("g", (publish as TargetResolution.Found).value.name)
+        assertTrue(converter is TargetResolution.Found)
+        assertEquals("b", (converter as TargetResolution.Found).value.name)
+        assertEquals(0, source.classNameReads)
+    }
+
+    @Test
+    fun `650 profile resolves the lyrics availability gate`() {
+        val source = FakeTargetClassSource(
+            classes = mapOf(
+                "com.apple.android.music.player.d1" to LyricsAvailabilityFixture::class.java,
+            ),
+        )
+        val resolver = IndexedTargetSymbolResolver(
+            build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.0", 1580L),
+            source = source,
+        )
+
+        val availability = resolver.resolve(AppleMusicSymbols.LyricsAvailabilityPredicate)
+
+        assertTrue(availability is TargetResolution.Found)
+        assertEquals("i", (availability as TargetResolution.Found).value.name)
+        assertEquals(0, source.classNameReads)
+    }
+
+    @Test
+    fun `structural fallback never mistakes same-shaped R2 for I2`() {
+        val fragmentName = "com.apple.android.music.player.fragment.PlayerLyricsViewFragment"
+        val source = FakeTargetClassSource(
+            names = listOf(fragmentName),
+            classes = mapOf(fragmentName to LyricsInstallFixture::class.java),
+        )
+        val resolver = IndexedTargetSymbolResolver(TargetBuild.UNKNOWN, source)
+
+        val resolution = resolver.resolve(AppleMusicSymbols.LyricsInstallMethod)
+
+        assertTrue(resolution is TargetResolution.Found)
+        assertEquals("I2", (resolution as TargetResolution.Found).value.name)
+    }
+
+    @Test
+    fun `a class with only the same-shaped R2 method stays missing`() {
+        val fragmentName = "com.apple.android.music.player.fragment.PlayerLyricsViewFragment"
+        val source = FakeTargetClassSource(
+            names = listOf(fragmentName),
+            classes = mapOf(fragmentName to LyricsR2OnlyFixture::class.java),
+        )
+        val resolver = IndexedTargetSymbolResolver(TargetBuild.UNKNOWN, source)
+
+        val resolution = resolver.resolve(AppleMusicSymbols.LyricsInstallMethod)
+
+        assertTrue(resolution is TargetResolution.Missing)
+    }
+
+    @Test
+    fun `650 profile resolves the native ttml parse method`() {
+        val parserName =
+            "com.apple.android.music.ttml.javanative.TTMLParser\$TTMLParserNative"
+        val source = FakeTargetClassSource(
+            classes = mapOf(parserName to TtmlParserNativeFixture::class.java),
+        )
+        val resolver = IndexedTargetSymbolResolver(
+            build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.0", 1580L),
+            source = source,
+        )
+
+        val resolution = resolver.resolve(AppleMusicSymbols.TtmlSongInfoFromTtml)
+
+        assertTrue(resolution is TargetResolution.Found)
+        assertEquals(
+            "songInfoFromTTML",
+            (resolution as TargetResolution.Found).value.name,
+        )
+        assertEquals(0, source.classNameReads)
+    }
+
+    @Test
+    fun `650 profile resolves the song info pointer class with its contract`() {
+        val ptrName = "com.apple.android.music.ttml.javanative.model.SongInfo\$SongInfoPtr"
+        val source = FakeTargetClassSource(
+            classes = mapOf(ptrName to SongInfo.SongInfoPtr::class.java),
+        )
+        val resolver = IndexedTargetSymbolResolver(
+            build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.0", 1580L),
+            source = source,
+        )
+
+        val resolution = resolver.resolve(AppleMusicSymbols.SongInfoPtr)
+
+        assertTrue(resolution is TargetResolution.Found)
+        assertEquals(ptrName, (resolution as TargetResolution.Found).value.name)
+        assertEquals(0, source.classNameReads)
+    }
+
+    @Test
+    fun `650 profile resolves the song info native class with its contract`() {
+        val nativeName = "com.apple.android.music.ttml.javanative.model.SongInfo\$SongInfoNative"
+        val source = FakeTargetClassSource(
+            classes = mapOf(nativeName to SongInfo.SongInfoNative::class.java),
+        )
+        val resolver = IndexedTargetSymbolResolver(
+            build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.0", 1580L),
+            source = source,
+        )
+
+        val resolution = resolver.resolve(AppleMusicSymbols.SongInfoNative)
+
+        assertTrue(resolution is TargetResolution.Found)
+        assertEquals(SongInfo.SongInfoNative::class.java, (resolution as TargetResolution.Found).value)
+    }
+
+    @Test
+    fun `650 profile resolves the ttml parser native class with its contract`() {
+        val parserName =
+            "com.apple.android.music.ttml.javanative.TTMLParser\$TTMLParserNative"
+        val source = FakeTargetClassSource(
+            classes = mapOf(parserName to TtmlParserNativeContractFixture::class.java),
+        )
+        val resolver = IndexedTargetSymbolResolver(
+            build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.0", 1580L),
+            source = source,
+        )
+
+        val resolution = resolver.resolve(AppleMusicSymbols.TtmlParserNative)
+
+        assertTrue(resolution is TargetResolution.Found)
+        assertEquals(
+            TtmlParserNativeContractFixture::class.java,
+            (resolution as TargetResolution.Found).value,
+        )
+        assertEquals(SymbolMatch.VERSION_PROFILE, resolution.match)
+    }
+
+    @Test
+    fun `a contract broken class stays missing instead of matching by name`() {
+        val ptrName = "com.apple.android.music.ttml.javanative.model.SongInfo\$SongInfoPtr"
+        val source = FakeTargetClassSource(
+            names = listOf(ptrName),
+            classes = mapOf(ptrName to BrokenSongInfoPtrFixture::class.java),
+        )
+        val resolver = IndexedTargetSymbolResolver(TargetBuild.UNKNOWN, source)
+
+        val resolution = resolver.resolve(AppleMusicSymbols.SongInfoPtr)
+
+        assertTrue(resolution is TargetResolution.Missing)
+    }
+
+    @Test
+    fun `650 profile resolves the exact current lyric item field without scanning dex`() {
+        val ownerName = "com.apple.android.music.player.fragment.m"
+        val source = FakeTargetClassSource(classes = mapOf(ownerName to m::class.java))
+        val resolver = IndexedTargetSymbolResolver(
+            build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.0", 1580L),
+            source = source,
+        )
+
+        val resolution = resolver.resolve(AppleMusicSymbols.LyricsCurrentItemField)
+
+        assertTrue(resolution is TargetResolution.Found)
+        val found = resolution as TargetResolution.Found
+        assertEquals(SymbolMatch.VERSION_PROFILE, found.match)
+        assertEquals("c", found.value.name)
+        assertEquals(BaseContentItem::class.java, found.value.type)
+        assertEquals(0, source.classNameReads)
+        assertEquals(1, source.loadCounts[ownerName])
+    }
+
+    @Test
+    fun `a contract broken current item field stays missing under the profile`() {
+        val ownerName = "com.apple.android.music.player.fragment.m"
+        val source = FakeTargetClassSource(classes = mapOf(ownerName to mWrongType::class.java))
+        val resolver = IndexedTargetSymbolResolver(
+            build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.0", 1580L),
+            source = source,
+        )
+
+        val resolution = resolver.resolve(AppleMusicSymbols.LyricsCurrentItemField)
+
+        assertTrue(resolution is TargetResolution.Missing)
+        assertNull(source.loadCounts["com.apple.android.music.model.BaseContentItem"])
+    }
+
+    @Test
+    fun `structural ambiguity of the current item field is reported instead of a silent first match`() {
+        val source = FakeTargetClassSource(
+            names = listOf(
+                "com.apple.android.music.player.fragment.m",
+                "com.apple.android.music.player.fragment.n",
+            ),
+            classes = mapOf(
+                "com.apple.android.music.player.fragment.m" to m::class.java,
+                "com.apple.android.music.player.fragment.n" to n::class.java,
+            ),
+        )
+        val resolver = IndexedTargetSymbolResolver(TargetBuild.UNKNOWN, source)
+
+        val resolution = resolver.resolve(AppleMusicSymbols.LyricsCurrentItemField)
+
+        assertTrue(resolution is TargetResolution.Ambiguous)
+        resolution as TargetResolution.Ambiguous
+        assertEquals(2, resolution.candidates.size)
+        assertTrue(
+            resolution.candidates.any { candidate ->
+                candidate.contains(
+                    "com.apple.android.music.player.fragment.m#c:" +
+                        "com.apple.android.music.model.BaseContentItem",
+                )
+            },
+        )
+    }
+
+    @Test
+    fun `structural fallback uniquely finds the current item field`() {
+        val ownerName = "com.apple.android.music.player.fragment.m"
+        val source = FakeTargetClassSource(
+            names = listOf(ownerName),
+            classes = mapOf(ownerName to m::class.java),
+        )
+        val resolver = IndexedTargetSymbolResolver(TargetBuild.UNKNOWN, source)
+
+        val resolution = resolver.resolve(AppleMusicSymbols.LyricsCurrentItemField)
+
+        assertTrue(resolution is TargetResolution.Found)
+        assertEquals(SymbolMatch.STRUCTURAL_FALLBACK, (resolution as TargetResolution.Found).match)
+        assertEquals("c", resolution.value.name)
+        assertEquals(BaseContentItem::class.java, resolution.value.type)
+    }
+
     private fun fixtureKey(predicate: (String) -> Boolean) = TargetSymbolKey(
         id = "fixture-" + System.identityHashCode(predicate),
         structuralCandidates = { classes(predicate) { true } },
         identity = { type: Class<*> -> type.name },
     )
 }
+
+private class LyricsInstallFixture {
+    @Suppress("UNUSED_PARAMETER")
+    fun I2(ptr: SongInfo.SongInfoPtr) = Unit
+
+    @Suppress("UNUSED_PARAMETER")
+    fun R2(ptr: SongInfo.SongInfoPtr) = Unit
+}
+
+private class LyricsR2OnlyFixture {
+    @Suppress("UNUSED_PARAMETER")
+    fun R2(ptr: SongInfo.SongInfoPtr) = Unit
+}
+
+private class PlayerMetadataHubFixture {
+    @Suppress("UNUSED_PARAMETER")
+    fun g(metadata: v3.v) = Unit
+}
+
+private class MetadataConverterFixture {
+    companion object {
+        @JvmStatic
+        @Suppress("UNUSED_PARAMETER")
+        fun b(metadata: v3.v): com.apple.android.music.model.PlaybackItem =
+            com.apple.android.music.model.PlaybackItem()
+    }
+}
+
+private class LyricsAvailabilityFixture {
+    companion object {
+        @JvmStatic
+        @Suppress("UNUSED_PARAMETER")
+        fun i(item: com.apple.android.music.model.PlaybackItem): Boolean = false
+    }
+}
+
+private class TtmlParserNativeFixture {
+    @Suppress("UNUSED_PARAMETER")
+    fun songInfoFromTTML(ttml: String): SongInfo.SongInfoPtr = SongInfo.SongInfoPtr()
+}
+
+private class TtmlParserNativeContractFixture {
+    @Suppress("UNUSED_PARAMETER")
+    fun songInfoFromTTML(ttml: String): SongInfo.SongInfoPtr = SongInfo.SongInfoPtr()
+}
+
+/** Same binary name as the real SongInfoPtr but without the `get()` contract. */
+private class BrokenSongInfoPtrFixture
 
 private class FakeTargetClassSource(
     private val names: List<String> = emptyList(),

--- a/app/src/test/java/dev/amenhancer/module/hook/TtmlNativeParserTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/TtmlNativeParserTest.kt
@@ -1,0 +1,133 @@
+package dev.amenhancer.module.hook
+
+import com.apple.android.music.ttml.javanative.model.SongInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TtmlNativeParserTest {
+
+    private fun parserWith(nativeFixture: Class<*>): TtmlNativeParser? =
+        TtmlNativeParser.create(
+            parserClass = TtmlParserFixture::class.java,
+            parseMethod = TtmlParserFixture::class.java.getDeclaredMethod(
+                "songInfoFromTTML",
+                String::class.java,
+            ),
+            ptrClass = SongInfo.SongInfoPtr::class.java,
+            nativeClass = nativeFixture,
+        )
+
+    @Test
+    fun `create builds the wrapper from the resolved surface`() {
+        val parser = parserWith(SongInfo.SongInfoNative::class.java)
+
+        assertNotNull(parser)
+    }
+
+    @Test
+    fun `create returns null when the native surface is incomplete`() {
+        val parser = TtmlNativeParser.create(
+            parserClass = TtmlParserFixture::class.java,
+            parseMethod = TtmlParserFixture::class.java.getDeclaredMethod(
+                "songInfoFromTTML",
+                String::class.java,
+            ),
+            ptrClass = SongInfo.SongInfoPtr::class.java,
+            nativeClass = IncompleteNativeFixture::class.java,
+        )
+
+        assertNull(parser)
+    }
+
+    @Test
+    fun `create fails closed without a JavaCPP liveness surface`() {
+        val parser = TtmlNativeParser.create(
+            parserClass = TtmlParserFixture::class.java,
+            parseMethod = TtmlParserFixture::class.java.getDeclaredMethod(
+                "songInfoFromTTML",
+                String::class.java,
+            ),
+            ptrClass = PointerlessFixture::class.java,
+            nativeClass = SongInfo.SongInfoNative::class.java,
+        )
+
+        assertNull(parser)
+    }
+
+    @Test
+    fun `parse produces a pointer and validity requires sections`() {
+        val parser = requireNotNull(parserWith(SongInfo.SongInfoNative::class.java))
+
+        val ptr = parser.parse("<tt><body>ok</body></tt>")
+        assertNotNull(ptr)
+        // Fixture sections are empty (size 0) so the pointer is invalid.
+        assertFalse(parser.isValid(ptr))
+        // The fixture SongInfoNative reports adam id 0.
+        assertEquals(0L, parser.adamIdOf(ptr!!))
+    }
+
+    @Test
+    fun `null and foreign pointers are never valid or alive`() {
+        val parser = requireNotNull(parserWith(SongInfo.SongInfoNative::class.java))
+
+        assertFalse(parser.isValid(null))
+        assertFalse(parser.isValid("not a pointer"))
+        assertFalse(parser.isAlive(null))
+        assertFalse(parser.isAlive("not a pointer"))
+    }
+
+    @Test
+    fun `bind adam id verifies the value stuck`() {
+        val parser = requireNotNull(parserWith(SongInfo.SongInfoNative::class.java))
+        val ptr = parser.parse("<tt><body>ok</body></tt>")
+
+        // Fixture always reports 0, so binding to 42 cannot verify.
+        assertFalse(parser.bindAdamId(requireNotNull(ptr), 42L))
+    }
+
+    @Test
+    fun `parse never throws and returns the fixture pointer`() {
+        val parser = requireNotNull(parserWith(SongInfo.SongInfoNative::class.java))
+
+        assertNotNull(parser.parse(""))
+        assertNotNull(parser.parse("<tt><body>ok</body></tt>"))
+    }
+
+    @Test
+    fun `a throwing parse invocation returns null`() {
+        val parser = TtmlNativeParser.create(
+            parserClass = ThrowingParserFixture::class.java,
+            parseMethod = ThrowingParserFixture::class.java.getDeclaredMethod(
+                "songInfoFromTTML",
+                String::class.java,
+            ),
+            ptrClass = SongInfo.SongInfoPtr::class.java,
+            nativeClass = SongInfo.SongInfoNative::class.java,
+        )
+
+        assertNull(parser?.parse("<tt>x</tt>"))
+    }
+
+    private class TtmlParserFixture {
+        @Suppress("UNUSED_PARAMETER")
+        fun songInfoFromTTML(ttml: String): SongInfo.SongInfoPtr = SongInfo.SongInfoPtr()
+    }
+
+    private class ThrowingParserFixture {
+        @Suppress("UNUSED_PARAMETER")
+        fun songInfoFromTTML(ttml: String): SongInfo.SongInfoPtr = error("native parse failed")
+    }
+
+    private class IncompleteNativeFixture {
+        // No getSections / getAdamId / setAdamId surface.
+        fun unrelated() = Unit
+    }
+
+    private class PointerlessFixture {
+        fun get(): SongInfo.SongInfoNative = SongInfo.SongInfoNative()
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/lyrics/CustomLyricsFileReaderTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/lyrics/CustomLyricsFileReaderTest.kt
@@ -1,0 +1,30 @@
+package dev.amenhancer.module.lyrics
+
+import dev.amenhancer.module.model.CustomLyricsEntry
+import dev.amenhancer.module.model.CustomLyricsSources
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CustomLyricsFileReaderTest {
+    private val ttml = "<tt><body><p><span>word</span></p></body></tt>"
+    private val bytes = ttml.toByteArray()
+    private val entry = CustomLyricsEntry(
+        appleMusicId = 42L,
+        displayName = "Song",
+        fileId = "lyrics_abc123",
+        sizeBytes = bytes.size.toLong(),
+        sha256 = CustomLyricsFilePolicy.sha256(bytes),
+        source = CustomLyricsSources.MANUAL,
+    )
+
+    @Test
+    fun `reader accepts only a file that matches its published size hash and ttml policy`() {
+        assertEquals(ttml, CustomLyricsFileReader { bytes }.read(entry))
+        assertNull(CustomLyricsFileReader { bytes + byteArrayOf(0) }.read(entry))
+        assertNull(CustomLyricsFileReader { "not ttml".toByteArray() }.read(entry.copy(
+            sizeBytes = "not ttml".toByteArray().size.toLong(),
+            sha256 = CustomLyricsFilePolicy.sha256("not ttml".toByteArray()),
+        )))
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/lyrics/CustomLyricsImportTransactionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/lyrics/CustomLyricsImportTransactionTest.kt
@@ -1,0 +1,75 @@
+package dev.amenhancer.module.lyrics
+
+import dev.amenhancer.module.model.CustomLyricsEntry
+import dev.amenhancer.module.model.CustomLyricsManifest
+import dev.amenhancer.module.model.CustomLyricsSources
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CustomLyricsImportTransactionTest {
+    private val ttml = "<tt><body><p><span>word</span></p></body></tt>"
+
+    @Test
+    fun `writes the new ttml before publishing its manifest then retires the old file`() {
+        val events = mutableListOf<String>()
+        val old = CustomLyricsManifest(listOf(existingEntry()))
+        val transaction = transaction(events) { events += "publish"; true }
+
+        val result = transaction.upsert(old, draft())
+
+        assertTrue(result is CustomLyricsSaveResult.Saved)
+        assertEquals(listOf("write", "publish", "delete:lyrics_old"), events)
+        val saved = result as CustomLyricsSaveResult.Saved
+        assertEquals(42L, saved.entry.appleMusicId)
+        assertEquals("lyrics_new", saved.entry.fileId)
+    }
+
+    @Test
+    fun `a failed manifest publication deletes only the new file`() {
+        val events = mutableListOf<String>()
+        val transaction = transaction(events) { events += "publish"; false }
+
+        val result = transaction.upsert(CustomLyricsManifest.empty(), draft())
+
+        assertEquals(CustomLyricsSaveResult.Failed("无法发布歌词映射"), result)
+        assertEquals(listOf("write", "publish", "delete:lyrics_new"), events)
+    }
+
+    @Test
+    fun `invalid ttml never writes or publishes a mapping`() {
+        val events = mutableListOf<String>()
+        val transaction = transaction(events) { events += "publish"; true }
+
+        val result = transaction.upsert(CustomLyricsManifest.empty(), draft(ttml = "not ttml"))
+
+        assertTrue(result is CustomLyricsSaveResult.Failed)
+        assertTrue(events.isEmpty())
+    }
+
+    private fun transaction(
+        events: MutableList<String>,
+        publish: (CustomLyricsManifest) -> Boolean,
+    ): CustomLyricsImportTransaction = CustomLyricsImportTransaction(
+        fileIdFactory = { "lyrics_new" },
+        writeRemoteFile = { _, _ -> events += "write"; true },
+        publishManifest = publish,
+        deleteRemoteFile = { fileId -> events += "delete:$fileId" },
+    )
+
+    private fun draft(ttml: String = this.ttml) = CustomLyricsDraft(
+        appleMusicId = 42L,
+        displayName = "Song",
+        ttml = ttml,
+        source = CustomLyricsSources.MANUAL,
+    )
+
+    private fun existingEntry() = CustomLyricsEntry(
+        appleMusicId = 42L,
+        displayName = "Old song",
+        fileId = "lyrics_old",
+        sizeBytes = 42L,
+        sha256 = "0cba697d61a21fb62408b2411aa2152d1bc24cc2414d2bd162f70e04d20c5e53",
+        source = CustomLyricsSources.MANUAL,
+    )
+}

--- a/app/src/test/java/dev/amenhancer/module/lyrics/CustomLyricsImportTransactionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/lyrics/CustomLyricsImportTransactionTest.kt
@@ -47,6 +47,48 @@ class CustomLyricsImportTransactionTest {
         assertTrue(events.isEmpty())
     }
 
+    @Test
+    fun `editing an entry to a new id replaces its original identity and file`() {
+        val events = mutableListOf<String>()
+        var published = CustomLyricsManifest.empty()
+        val transaction = transaction(events) { manifest ->
+            events += "publish"
+            published = manifest
+            true
+        }
+
+        val result = transaction.upsert(
+            oldManifest = CustomLyricsManifest(listOf(existingEntry())),
+            draft = draft(appleMusicId = 84L),
+            replacingAppleMusicId = 42L,
+        )
+
+        assertTrue(result is CustomLyricsSaveResult.Saved)
+        assertEquals(listOf(84L), published.entries.map(CustomLyricsEntry::appleMusicId))
+        assertEquals(listOf("write", "publish", "delete:lyrics_old"), events)
+    }
+
+    @Test
+    fun `editing to an id owned by another entry fails before writing`() {
+        val events = mutableListOf<String>()
+        val transaction = transaction(events) { events += "publish"; true }
+        val old = CustomLyricsManifest(
+            listOf(
+                existingEntry(),
+                existingEntry(appleMusicId = 84L, fileId = "lyrics_other"),
+            ),
+        )
+
+        val result = transaction.upsert(
+            oldManifest = old,
+            draft = draft(appleMusicId = 84L),
+            replacingAppleMusicId = 42L,
+        )
+
+        assertEquals(CustomLyricsSaveResult.Failed("目标 Apple Music ID 已存在"), result)
+        assertTrue(events.isEmpty())
+    }
+
     private fun transaction(
         events: MutableList<String>,
         publish: (CustomLyricsManifest) -> Boolean,
@@ -57,17 +99,23 @@ class CustomLyricsImportTransactionTest {
         deleteRemoteFile = { fileId -> events += "delete:$fileId" },
     )
 
-    private fun draft(ttml: String = this.ttml) = CustomLyricsDraft(
-        appleMusicId = 42L,
+    private fun draft(
+        ttml: String = this.ttml,
+        appleMusicId: Long = 42L,
+    ) = CustomLyricsDraft(
+        appleMusicId = appleMusicId,
         displayName = "Song",
         ttml = ttml,
         source = CustomLyricsSources.MANUAL,
     )
 
-    private fun existingEntry() = CustomLyricsEntry(
-        appleMusicId = 42L,
+    private fun existingEntry(
+        appleMusicId: Long = 42L,
+        fileId: String = "lyrics_old",
+    ) = CustomLyricsEntry(
+        appleMusicId = appleMusicId,
         displayName = "Old song",
-        fileId = "lyrics_old",
+        fileId = fileId,
         sizeBytes = 42L,
         sha256 = "0cba697d61a21fb62408b2411aa2152d1bc24cc2414d2bd162f70e04d20c5e53",
         source = CustomLyricsSources.MANUAL,

--- a/app/src/test/java/dev/amenhancer/module/lyrics/CustomLyricsOnlineImporterTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/lyrics/CustomLyricsOnlineImporterTest.kt
@@ -1,0 +1,45 @@
+package dev.amenhancer.module.lyrics
+
+import dev.amenhancer.module.model.CustomLyricsSources
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CustomLyricsOnlineImporterTest {
+    private val ttml = "<tt><body><p><span>word</span></p></body></tt>"
+
+    @Test
+    fun `amll is fetched only for the user supplied apple music id`() {
+        var requestedId = 0L
+        val importer = CustomLyricsOnlineImporter(
+            fetchAmll = { id -> requestedId = id; ttml },
+            fetchNeteaseYrc = { error("must not fetch NetEase") },
+        )
+
+        val result = importer.importAmll(42L)
+
+        assertEquals(42L, requestedId)
+        assertEquals(
+            CustomLyricsOnlineImportResult.Imported(ttml, CustomLyricsSources.AMLL),
+            result,
+        )
+    }
+
+    @Test
+    fun `netease import needs an explicit netease id and serializes word timing`() {
+        var requestedId = 0L
+        val importer = CustomLyricsOnlineImporter(
+            fetchAmll = { error("must not fetch AMLL") },
+            fetchNeteaseYrc = { id ->
+                requestedId = id
+                LyricDocument(listOf(LyricLine(0, 1_000, listOf(LyricWord("word", 0, 1_000)))))
+            },
+        )
+
+        val result = importer.importNetease(99L, "Song")
+
+        assertEquals(99L, requestedId)
+        assertTrue(result is CustomLyricsOnlineImportResult.Imported)
+        assertEquals(CustomLyricsSources.NETEASE, (result as CustomLyricsOnlineImportResult.Imported).source)
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/lyrics/NeteaseEapiTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/lyrics/NeteaseEapiTest.kt
@@ -1,0 +1,63 @@
+package dev.amenhancer.module.lyrics
+
+import javax.crypto.Cipher
+import javax.crypto.spec.SecretKeySpec
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NeteaseEapiTest {
+
+    @Test
+    fun `lyric v1 json keeps the upstream key order`() {
+        assertEquals(
+            "{\"id\":314159,\"cp\":false,\"tv\":0,\"lv\":0,\"rv\":0,\"kv\":0,\"yv\":0,\"ytv\":0,\"yrv\":0}",
+            NeteaseEapi.lyricV1Json(314159),
+        )
+    }
+
+    @Test
+    fun `digest matches the published nobody-use-md5forencrypt vector`() {
+        val json = NeteaseEapi.lyricV1Json(314159)
+        val message = "nobody/api/song/lyric/v1use$json" + "md5forencrypt"
+
+        assertEquals("db59d4b77c7ee845d41a3f102937f76f", NeteaseEapi.md5Hex(message))
+    }
+
+    @Test
+    fun `params are uppercase hex of the AES ECB encrypted message`() {
+        val params = NeteaseEapi.lyricV1Params(314159)
+
+        assertTrue(params.isNotEmpty())
+        assertTrue(params.length % 32 == 0) // 16-byte AES blocks as hex
+        assertTrue(params.all { it in "0123456789ABCDEF" })
+    }
+
+    @Test
+    fun `params decrypt back to the canonical message`() {
+        val json = NeteaseEapi.lyricV1Json(314159)
+        val message = "nobody/api/song/lyric/v1use$json" + "md5forencrypt"
+        val digest = NeteaseEapi.md5Hex(message)
+        val expected = "/api/song/lyric/v1-36cd479b6b5-$json-36cd479b6b5-$digest"
+
+        val params = NeteaseEapi.lyricV1Params(314159)
+        val decrypted = aesEcbDecrypt(params)
+
+        assertEquals(expected, decrypted)
+    }
+
+    private fun aesEcbDecrypt(uppercaseHex: String): String {
+        val bytes = ByteArray(uppercaseHex.length / 2)
+        for (index in bytes.indices) {
+            bytes[index] = uppercaseHex.substring(index * 2, index * 2 + 2)
+                .toInt(16)
+                .toByte()
+        }
+        val cipher = Cipher.getInstance("AES/ECB/PKCS5Padding")
+        cipher.init(
+            Cipher.DECRYPT_MODE,
+            SecretKeySpec("e82ckenh8dichen8".toByteArray(Charsets.UTF_8), "AES"),
+        )
+        return String(cipher.doFinal(bytes), Charsets.UTF_8)
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/lyrics/TtmlInputPolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/lyrics/TtmlInputPolicyTest.kt
@@ -1,0 +1,55 @@
+package dev.amenhancer.module.lyrics
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TtmlInputPolicyTest {
+
+    private val valid = "<tt xmlns=\"http://www.w3.org/ns/ttml\">" +
+        "<body><div><p begin=\"0.000\" end=\"1.000\">" +
+        "<span begin=\"0.000\" end=\"1.000\">word</span></p></div></body></tt>"
+
+    @Test
+    fun `a well formed small ttml passes`() {
+        assertTrue(TtmlInputPolicy.isAcceptable(valid))
+    }
+
+    @Test
+    fun `empty input is rejected`() {
+        assertFalse(TtmlInputPolicy.isAcceptable(""))
+    }
+
+    @Test
+    fun `input above the byte cap is rejected`() {
+        val oversized = valid + "x".repeat(TtmlInputPolicy.MAX_TTML_BYTES)
+        assertFalse(TtmlInputPolicy.isAcceptable(oversized))
+    }
+
+    @Test
+    fun `missing root markers is rejected`() {
+        assertFalse(TtmlInputPolicy.isAcceptable("<div>no tt root</div>"))
+        assertFalse(TtmlInputPolicy.isAcceptable("<tt><div>no body</div></tt>"))
+        assertFalse(TtmlInputPolicy.isAcceptable("<body><div>no tt</div></body>"))
+    }
+
+    @Test
+    fun `line count above the cap is rejected`() {
+        val manyLines = "<tt><body>" + "<p>x</p>".repeat(TtmlInputPolicy.MAX_LINES + 1) + "</body></tt>"
+        assertFalse(TtmlInputPolicy.isAcceptable(manyLines))
+    }
+
+    @Test
+    fun `word count above the cap is rejected`() {
+        val manyWords = "<tt><body><p>" +
+            "<span>x</span>".repeat(TtmlInputPolicy.MAX_WORDS + 1) +
+            "</p></body></tt>"
+        assertFalse(TtmlInputPolicy.isAcceptable(manyWords))
+    }
+
+    @Test
+    fun `tags that merely contain the markers do not count`() {
+        val tricky = "<tt><body><paper>not a line</paper><spanish>not a word</spanish></body></tt>"
+        assertTrue(TtmlInputPolicy.isAcceptable(tricky))
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/lyrics/WordTtmlSerializerTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/lyrics/WordTtmlSerializerTest.kt
@@ -1,0 +1,108 @@
+package dev.amenhancer.module.lyrics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WordTtmlSerializerTest {
+
+    private val document = LyricDocument(
+        lines = listOf(
+            LyricLine(
+                startMs = 20_519,
+                endMs = 23_530,
+                words = listOf(
+                    LyricWord("你", 20_519, 20_942),
+                    LyricWord("好", 20_942, 23_530),
+                ),
+            ),
+            LyricLine(
+                startMs = 24_449,
+                endMs = 27_940,
+                words = listOf(
+                    LyricWord("世", 24_449, 24_634),
+                    LyricWord("界", 24_634, 27_940),
+                ),
+            ),
+        ),
+    )
+
+    @Test
+    fun `serializes lines and words with millisecond precision times`() {
+        val ttml = WordTtmlSerializer.serialize(document)
+
+        assertTrue(ttml!!.contains("<p begin=\"20.519\" end=\"23.530\" itunes:key=\"L1\" ttm:agent=\"v1\">"))
+        assertTrue(ttml.contains("<span begin=\"20.519\" end=\"20.942\">你</span>"))
+        assertTrue(ttml.contains("<span begin=\"24.449\" end=\"24.634\">世</span>"))
+        assertTrue(ttml.contains("itunes:timing=\"Word\""))
+        assertTrue(ttml.startsWith("<tt xmlns=\"http://www.w3.org/ns/ttml\""))
+        assertTrue(ttml.endsWith("</div></body></tt>"))
+    }
+
+    @Test
+    fun `escapes every xml special character in word text and metadata`() {
+        val tricky = LyricDocument(
+            lines = listOf(
+                LyricLine(
+                    startMs = 0,
+                    endMs = 1000,
+                    words = listOf(
+                        LyricWord("a<b>&\"c'", 0, 1000),
+                    ),
+                ),
+            ),
+        )
+
+        val ttml = WordTtmlSerializer.serialize(
+            tricky,
+            title = "T<itle> & \"quoted\" 'one'",
+            artist = "A&B",
+        )
+
+        assertTrue(ttml!!.contains("<span begin=\"0.000\" end=\"1.000\">a&lt;b&gt;&amp;&quot;c&apos;</span>"))
+        assertTrue(ttml.contains("value=\"T&lt;itle&gt; &amp; &quot;quoted&quot; &apos;one&apos;\""))
+        assertTrue(ttml.contains("value=\"A&amp;B\""))
+        assertTrue(!ttml.contains("<\"") && !ttml.contains("&\"c'<"))
+    }
+
+    @Test
+    fun `whitespace words are serialized as their own spans`() {
+        val spaced = LyricDocument(
+            lines = listOf(
+                LyricLine(
+                    startMs = 0,
+                    endMs = 1000,
+                    words = listOf(
+                        LyricWord(" ", 0, 100),
+                        LyricWord("A", 100, 1000),
+                    ),
+                ),
+            ),
+        )
+
+        val ttml = WordTtmlSerializer.serialize(spaced)
+
+        assertTrue(ttml!!.contains("<span begin=\"0.000\" end=\"0.100\"> </span>"))
+        assertTrue(ttml.contains("<span begin=\"0.100\" end=\"1.000\">A</span>"))
+    }
+
+    @Test
+    fun `an empty document serializes to null`() {
+        assertNull(WordTtmlSerializer.serialize(LyricDocument(lines = emptyList())))
+    }
+
+    @Test
+    fun `seconds formatting keeps three fraction digits`() {
+        assertEquals("0.000", WordTtmlSerializer.seconds(0))
+        assertEquals("0.001", WordTtmlSerializer.seconds(1))
+        assertEquals("20.519", WordTtmlSerializer.seconds(20_519))
+        assertEquals("244.497", WordTtmlSerializer.seconds(244_497))
+    }
+
+    @Test
+    fun `escape keeps plain text and every special form`() {
+        assertEquals("plain", WordTtmlSerializer.escape("plain"))
+        assertEquals("&amp;&lt;&gt;&quot;&apos;", WordTtmlSerializer.escape("&<>\"'"))
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/lyrics/YrcParserTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/lyrics/YrcParserTest.kt
@@ -1,0 +1,126 @@
+package dev.amenhancer.module.lyrics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class YrcParserTest {
+
+    @Test
+    fun `parses the real netease yrc sample with absolute millisecond words`() {
+        // Verified real YRC line (absolute ms word starts and explicit
+        // durations; each word keeps its own trailing space).
+        val document = YrcParser.parse(
+            "[190871,1984](190871,361,0)For (191232,172,0)the (191404,134,0)longest (191538,301,0)time",
+        )
+
+        assertNotNull(document)
+        val line = document!!.lines.single()
+        assertEquals(190_871L, line.startMs)
+        assertEquals(192_855L, line.endMs)
+        assertEquals(
+            listOf("For ", "the ", "longest ", "time"),
+            line.words.map { it.text },
+        )
+        assertEquals(
+            listOf(190_871L, 191_232L, 191_404L, 191_538L),
+            line.words.map { it.startMs },
+        )
+        assertEquals(
+            listOf(191_232L, 191_404L, 191_538L, 191_839L),
+            line.words.map { it.endMs },
+        )
+    }
+
+    @Test
+    fun `parses a multi line document with exact line bounds`() {
+        val document = YrcParser.parse(
+            "[20519,3011](20519,423,0)ż(20942,2588,0)词\n" +
+                "[24449,3491](24449,185,0)词(24634,158,0)词(24792,203,0)词",
+        )
+
+        assertEquals(2, document!!.lines.size)
+        assertEquals(listOf(20_519L, 24_449L), document.lines.map { it.startMs })
+        assertEquals(listOf(23_530L, 27_940L), document.lines.map { it.endMs })
+        assertEquals(2, document.lines[0].words.size)
+        assertEquals(3, document.lines[1].words.size)
+    }
+
+    @Test
+    fun `zero duration placeholders merge into the next word as leading text`() {
+        val document = YrcParser.parse(
+            "[30258,2239](30258,363,0)A(30621,421,0)B(31042,370,0)C(0,0,0) (31412,427,0)D",
+        )
+
+        val line = document!!.lines.single()
+        assertEquals(listOf("A", "B", "C", " D"), line.words.map { it.text })
+        assertEquals(listOf(31_412L), line.words.drop(3).map { it.startMs })
+        assertEquals(31_839L, line.words.last().endMs)
+    }
+
+    @Test
+    fun `a trailing zero duration placeholder merges into the previous word`() {
+        val document = YrcParser.parse("[0,1000](0,300,0)word(0,0,0) !")
+
+        val line = document!!.lines.single()
+        assertEquals(listOf("word !"), line.words.map { it.text })
+        assertEquals(listOf(0L, 300L), listOf(line.words.single().startMs, line.words.single().endMs))
+    }
+
+    @Test
+    fun `lines without timed word markers are skipped`() {
+        val document = YrcParser.parse(
+            "[1000,500]plain line without markers\n" +
+                "[2000,500](0,0,0) only timeless\n" +
+                "[3000,500](3000,200,0)real",
+        )
+
+        assertEquals(1, document!!.lines.size)
+        assertEquals(3000L, document!!.lines.single().startMs)
+        assertEquals("real", document.lines.single().words.single().text)
+    }
+
+    @Test
+    fun `a document without any timed word marker returns null`() {
+        assertNull(YrcParser.parse("[1000,500]line one\n[2000,500]line two"))
+        assertNull(YrcParser.parse("[1000,500](0,0,0) "))
+    }
+
+    @Test
+    fun `words outside the line range are dropped never clamped`() {
+        val document = YrcParser.parse("[1000,500](1000,300,0)ok(1500,600,0)too late")
+
+        val line = document!!.lines.single()
+        assertEquals(listOf("ok"), line.words.map { it.text })
+        assertEquals(1300L, line.words.single().endMs)
+    }
+
+    @Test
+    fun `empty word markers are dropped`() {
+        val document = YrcParser.parse("[0,1000](0,200,0)(200,300,0)A(500,200,0)(700,300,0)B")
+
+        val words = document!!.lines.single().words
+        assertEquals(listOf("A", "B"), words.map { it.text })
+        assertEquals(listOf(200L, 700L), words.map { it.startMs })
+    }
+
+    @Test
+    fun `malformed lines are isolated without failing the document`() {
+        val document = YrcParser.parse(
+            "[12345]header without duration\n" +
+                "[abc,123]garbage header\n" +
+                "(0,0,0)no header at all\n" +
+                "[5000,1000](5000,400,0)good",
+        )
+
+        assertEquals(1, document!!.lines.size)
+        assertEquals("good", document!!.lines.single().words.single().text)
+    }
+
+    @Test
+    fun `blank input returns null`() {
+        assertNull(YrcParser.parse(""))
+        assertNull(YrcParser.parse("   \n  "))
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/ui/SettingsUiStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/ui/SettingsUiStructuralRegressionTest.kt
@@ -71,7 +71,9 @@ class SettingsUiStructuralRegressionTest {
             "application/vnd.ms-opentype",
         ).forEach { mime -> assertTrue(activity.contains("\"$mime\"")) }
         assertTrue(activity.contains("backgroundExecutor.execute"))
-        assertTrue(activity.contains("backgroundExecutor.shutdown()"))
+        assertTrue(activity.contains("val backgroundExecutor: ExecutorService get() = settingsExecutor"))
+        assertTrue(activity.contains("val settingsExecutor: ExecutorService = Executors.newSingleThreadExecutor()"))
+        assertFalse(activity.contains("backgroundExecutor.shutdown()"))
         assertFalse(activity.contains("backgroundExecutor.shutdownNow()"))
         assertTrue(activity.contains("snapshot.isRemoteFileAvailable"))
         assertTrue(activity.contains("歌词字体"))
@@ -83,6 +85,80 @@ class SettingsUiStructuralRegressionTest {
         assertFalse(activity.contains("takePersistableUriPermission"))
         assertFalse(importer.contains("uri.toString()"))
         assertFalse(manifest.contains("<provider"))
+    }
+
+    @Test
+    fun `keeps custom lyrics manual at playback time and online only at explicit import time`() {
+        val activity = projectFile("app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt")
+        val target = projectFile(
+            "app/src/main/java/dev/amenhancer/module/hook/AppleMusicCustomLyricsTarget.kt",
+        )
+        val session = projectFile(
+            "app/src/main/java/dev/amenhancer/module/hook/CustomLyricsReplacementSession.kt",
+        )
+        val manifest = projectFile("app/src/main/AndroidManifest.xml")
+
+        assertTrue(activity.contains("从 AMLL 导入"))
+        assertTrue(activity.contains("从网易云导入"))
+        assertTrue(activity.contains("不会在播放时联网识歌"))
+        assertTrue(manifest.contains("android.permission.INTERNET"))
+        assertTrue(target.contains("session.start()"))
+        assertFalse(target.contains("HttpLyricTransport"))
+        assertFalse(session.contains("HttpLyricTransport"))
+        assertFalse(session.contains("config.settings()"))
+        assertTrue(session.contains("files and native parsing are prepared off-hook"))
+    }
+
+    @Test
+    fun `gets the current song id only through an explicit standalone settings request`() {
+        val activity = projectFile("app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt")
+        val requester = projectFile(
+            "app/src/main/java/dev/amenhancer/module/ui/CurrentSongIdentityRequester.kt",
+        )
+
+        assertTrue(activity.contains("获取当前歌曲信息"))
+        assertTrue(activity.contains("dialogActionButton(\"获取 ID\") { requestCurrentSongId(appleMusicId, displayName) }"))
+        assertTrue(activity.contains("requestCurrentSongId(appleMusicId, displayName)"))
+        assertTrue(activity.contains("appleMusicId.setText(currentSong.appleMusicId.toString())"))
+        assertTrue(activity.contains("formatCurrentSongDisplayName(currentSong.title, currentSong.artist)"))
+        assertTrue(activity.contains("displayName.setText(it)"))
+        assertTrue(activity.contains("val actionBar = LinearLayout(this).apply"))
+        assertTrue(activity.contains("orientation = LinearLayout.HORIZONTAL"))
+        assertTrue(activity.contains("dialogActionButton(\"导入 TTML\")"))
+        assertTrue(activity.contains("dialogActionButton(\"取消\") { dialog.dismiss() }"))
+        assertTrue(activity.contains("dialogActionButton(\"保存\") save@{"))
+        assertTrue(activity.contains("LinearLayout.LayoutParams(0, dp(56), 1f)"))
+        assertFalse(activity.contains("setAllowStacking"))
+        assertFalse(activity.contains("dialog.getButton("))
+        assertFalse(activity.contains("fontActionButton(\"获取当前歌曲 ID\""))
+        assertTrue(activity.contains("未获取到当前歌曲信息，请先在 Apple Music 播放一首歌"))
+        assertTrue(requester.contains("setPackage(ModuleConstants.TARGET_PACKAGE)"))
+        assertTrue(requester.contains("ResultReceiver"))
+        assertTrue(requester.contains("TIMEOUT_MILLIS"))
+        assertFalse(requester.contains("SharedPreferences"))
+        assertFalse(requester.contains("HttpLyricTransport"))
+    }
+
+    @Test
+    fun `moves custom lyrics management to a saved secondary page`() {
+        val activity = projectFile("app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt")
+
+        assertTrue(activity.contains("enum class SettingsPage"))
+        assertTrue(activity.contains("STATE_SETTINGS_PAGE"))
+        assertTrue(activity.contains("renderMainPage(settings, snapshot)"))
+        assertTrue(activity.contains("renderCustomLyricsPage(settings, snapshot)"))
+        assertTrue(activity.contains("customLyricsNavigationRow(settings.customLyricsManifest)"))
+        assertTrue(activity.contains("showPage(SettingsPage.CUSTOM_LYRICS)"))
+        assertTrue(activity.contains("customLyricsEnabled = enabled"))
+        assertTrue(activity.contains("customLyricsCard(settings.customLyricsManifest"))
+        assertTrue(activity.contains("override fun onBackPressed()"))
+        assertTrue(activity.contains("showPage(SettingsPage.MAIN)"))
+        assertTrue(activity.contains("settingsScroll.post { settingsScroll.scrollTo(0, 0) }"))
+
+        val mainPage = activity.substringAfter("private fun renderMainPage(")
+            .substringBefore("private fun renderCustomLyricsPage(")
+        assertFalse(mainPage.contains("customLyricsCard("))
+        assertFalse(mainPage.contains("customLyricsEnabled = enabled"))
     }
 
     @Test

--- a/app/src/test/java/org/bytedeco/javacpp/Pointer.kt
+++ b/app/src/test/java/org/bytedeco/javacpp/Pointer.kt
@@ -1,0 +1,7 @@
+package org.bytedeco.javacpp
+
+/** JVM fixture for the JavaCPP liveness field used by the target adapter. */
+open class Pointer {
+    @JvmField
+    var address: Long = 1L
+}

--- a/app/src/test/java/v3/v.kt
+++ b/app/src/test/java/v3/v.kt
@@ -1,0 +1,3 @@
+package v3
+
+class v


### PR DESCRIPTION
## Summary
- add user-managed Apple Music ID to TTML mappings with transactional remote-file storage
- support manual TTML plus explicit AMLL and NetEase imports without playback-time networking
- replace lyrics through the verified Apple Music 6.5.0 I2 path and expose ready custom lyrics for songs without native lyrics
- add signature-protected current-song identity lookup and move custom-lyrics management to a secondary settings page

## Safety
- parse and prepare native pointers off the hook thread
- require exact current-item Adam ID and live pointer checks before replacement
- keep active I2, o2, loadLyrics, onResume, and LiveData injection paths out of the implementation

## Verification
- \.\gradlew.bat test assembleDebug assembleRelease lintVitalRelease --offline`n- git diff --check origin/main...HEAD`n- device-tested existing native-lyrics mappings, songs without native lyrics, repeated song switching, and secondary-page navigation on Apple Music 6.5.0/1580