### PR TITLE
Add custom lyrics backup and restore

### DIFF
--- a/app/src/main/java/dev/amenhancer/module/config/CustomLyricsManifestCodec.kt
+++ b/app/src/main/java/dev/amenhancer/module/config/CustomLyricsManifestCodec.kt
@@ -3,6 +3,7 @@ package dev.amenhancer.module.config
 import dev.amenhancer.module.model.CustomLyricsEntry
 import dev.amenhancer.module.model.CustomLyricsManifest
 import org.json.JSONArray
+import org.json.JSONException
 import org.json.JSONObject
 
 /** JSON codec for the manifest only; TTML remains in remote files. */
@@ -49,6 +50,38 @@ internal object CustomLyricsManifestCodec {
         }
         CustomLyricsManifestPolicy.sanitize(CustomLyricsManifest(parsed))
     }.getOrDefault(CustomLyricsManifest.empty())
+
+    /**
+     * Strict decode for backup restore: returns null unless the version
+     * matches exactly, the entries array parses cleanly, and every entry
+     * survives policy sanitization unchanged. A corrupt or foreign-version
+     * manifest is never treated as a valid empty backup.
+     */
+    fun decodeStrict(raw: String): CustomLyricsManifest? {
+        val root = try {
+            JSONObject(raw)
+        } catch (e: JSONException) {
+            return null
+        }
+        if (root.optInt(KEY_VERSION, 0) != VERSION) return null
+        val entries = root.optJSONArray(KEY_ENTRIES) ?: return null
+        if (entries.length() > CustomLyricsManifestPolicy.MAX_ENTRIES) return null
+        val parsed = mutableListOf<CustomLyricsEntry>()
+        for (index in 0 until entries.length()) {
+            val entry = entries.optJSONObject(index) ?: return null
+            parsed += CustomLyricsEntry(
+                appleMusicId = entry.optLong(KEY_APPLE_MUSIC_ID, 0L),
+                displayName = entry.optString(KEY_DISPLAY_NAME),
+                fileId = entry.optString(KEY_FILE_ID),
+                sizeBytes = entry.optLong(KEY_SIZE_BYTES, 0L),
+                sha256 = entry.optString(KEY_SHA256),
+                source = entry.optString(KEY_SOURCE),
+                enabled = entry.optBoolean(KEY_ENABLED, false),
+            )
+        }
+        val sanitized = CustomLyricsManifestPolicy.sanitize(CustomLyricsManifest(parsed))
+        return sanitized.takeIf { it.entries.size == parsed.size }
+    }
 
     private const val VERSION = 1
     private const val KEY_VERSION = "version"

--- a/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsBackupCodec.kt
+++ b/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsBackupCodec.kt
@@ -1,0 +1,149 @@
+package dev.amenhancer.module.lyrics
+
+import dev.amenhancer.module.config.CustomLyricsManifestCodec
+import dev.amenhancer.module.config.CustomLyricsManifestPolicy
+import dev.amenhancer.module.model.CustomLyricsEntry
+import dev.amenhancer.module.model.CustomLyricsManifest
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+
+internal sealed interface CustomLyricsBackupEncodeResult {
+    data class Encoded(val entryCount: Int) : CustomLyricsBackupEncodeResult
+    data class Failed(val message: String) : CustomLyricsBackupEncodeResult
+}
+
+internal sealed interface CustomLyricsBackupDecodeResult {
+    data class Decoded(val backup: CustomLyricsBackup) : CustomLyricsBackupDecodeResult
+    data class Rejected(val message: String) : CustomLyricsBackupDecodeResult
+}
+
+/** Decoded backup payload: the manifest plus one validated TTML file per entry. */
+internal data class CustomLyricsBackup(
+    val manifest: CustomLyricsManifest,
+    val files: Map<String, ByteArray>,
+)
+
+/**
+ * Bounded ZIP backup format: exactly one [MANIFEST_JSON_NAME] plus one file
+ * per manifest entry named by its fileId. Every TTML body passes the same
+ * size/hash/TTML-policy validation as [CustomLyricsFileReader]; decode never
+ * touches disk and rejects directories, duplicates, missing or extra files,
+ * invalid names, unsupported versions, and anything exceeding the size caps.
+ */
+internal object CustomLyricsBackupCodec {
+
+    private const val MANIFEST_JSON_NAME = "manifest.json"
+    private const val MAX_MANIFEST_JSON_BYTES = 64 * 1024
+    private const val MAX_ZIP_ENTRIES = CustomLyricsManifestPolicy.MAX_ENTRIES + 1
+    private val MAX_TOTAL_TTML_BYTES =
+        TtmlInputPolicy.MAX_TTML_BYTES.toLong() * CustomLyricsManifestPolicy.MAX_ENTRIES
+
+    /** Writes and closes [out]; fails the whole backup if any entry read fails. */
+    fun encode(
+        manifest: CustomLyricsManifest,
+        readRemoteFile: (String) -> ByteArray?,
+        out: OutputStream,
+    ): CustomLyricsBackupEncodeResult {
+        val safe = CustomLyricsManifestPolicy.sanitize(manifest)
+        if (safe.entries.size != manifest.entries.size) {
+            return CustomLyricsBackupEncodeResult.Failed("歌词映射无效，无法备份")
+        }
+        val reader = CustomLyricsFileReader(readRemoteFile)
+        val payload = buildList {
+            safe.entries.forEach { entry ->
+                val ttml = reader.read(entry)
+                    ?: return CustomLyricsBackupEncodeResult.Failed("读取歌词文件失败：${entry.displayName}")
+                add(entry to ttml.toByteArray(Charsets.UTF_8))
+            }
+        }
+        return try {
+            ZipOutputStream(BufferedOutputStream(out)).use { zip ->
+                zip.putNextEntry(ZipEntry(MANIFEST_JSON_NAME))
+                zip.write(CustomLyricsManifestCodec.encode(safe).toByteArray(Charsets.UTF_8))
+                zip.closeEntry()
+                payload.forEach { (entry, bytes) ->
+                    zip.putNextEntry(ZipEntry(entry.fileId))
+                    zip.write(bytes)
+                    zip.closeEntry()
+                }
+            }
+            CustomLyricsBackupEncodeResult.Encoded(safe.entries.size)
+        } catch (e: IOException) {
+            CustomLyricsBackupEncodeResult.Failed("写入备份失败")
+        }
+    }
+
+    /** Reads and closes [input]; returns only fully validated payloads. */
+    fun decode(input: InputStream): CustomLyricsBackupDecodeResult {
+        var manifestJson: ByteArray? = null
+        val files = linkedMapOf<String, ByteArray>()
+        var entryCount = 0
+        var totalBytes = 0L
+        return try {
+            ZipInputStream(BufferedInputStream(input)).use { zip ->
+                while (true) {
+                    val entry = zip.nextEntry ?: break
+                    entryCount += 1
+                    if (entryCount > MAX_ZIP_ENTRIES) {
+                        return CustomLyricsBackupDecodeResult.Rejected("备份条目过多")
+                    }
+                    if (entry.isDirectory) {
+                        return CustomLyricsBackupDecodeResult.Rejected("备份包含目录条目")
+                    }
+                    val name = entry.name
+                    if (name == MANIFEST_JSON_NAME) {
+                        if (manifestJson != null) {
+                            return CustomLyricsBackupDecodeResult.Rejected("备份包含重复的 manifest.json")
+                        }
+                        manifestJson = CustomLyricsFilePolicy.readBounded(zip)
+                        if (manifestJson.size > MAX_MANIFEST_JSON_BYTES) {
+                            return CustomLyricsBackupDecodeResult.Rejected("manifest.json 超出大小上限")
+                        }
+                    } else {
+                        if (!CustomLyricsManifestPolicy.isValidFileId(name)) {
+                            return CustomLyricsBackupDecodeResult.Rejected("备份包含非法文件名：$name")
+                        }
+                        if (files.containsKey(name)) {
+                            return CustomLyricsBackupDecodeResult.Rejected("备份包含重复文件：$name")
+                        }
+                        val bytes = CustomLyricsFilePolicy.readBounded(zip)
+                        files[name] = bytes
+                        totalBytes += bytes.size
+                        if (totalBytes > MAX_TOTAL_TTML_BYTES) {
+                            return CustomLyricsBackupDecodeResult.Rejected("备份解压总量超过上限")
+                        }
+                    }
+                    zip.closeEntry()
+                }
+                val raw = manifestJson
+                    ?: return CustomLyricsBackupDecodeResult.Rejected("备份缺少 manifest.json")
+                val manifest = CustomLyricsManifestCodec.decodeStrict(raw.toString(Charsets.UTF_8))
+                    ?: return CustomLyricsBackupDecodeResult.Rejected("manifest.json 无效或不支持的版本")
+                val expectedFileIds = manifest.entries.map(CustomLyricsEntry::fileId)
+                if (
+                    expectedFileIds.size != expectedFileIds.toSet().size ||
+                    expectedFileIds.toSet() != files.keys
+                ) {
+                    return CustomLyricsBackupDecodeResult.Rejected("备份文件与映射不一致")
+                }
+                val reader = CustomLyricsFileReader { fileId -> files[fileId] }
+                manifest.entries.forEach { entry ->
+                    if (reader.read(entry) == null) {
+                        return CustomLyricsBackupDecodeResult.Rejected("歌词文件校验失败：${entry.displayName}")
+                    }
+                }
+                CustomLyricsBackupDecodeResult.Decoded(CustomLyricsBackup(manifest, files))
+            }
+        } catch (e: CustomLyricsFilePolicy.SizeLimitExceeded) {
+            CustomLyricsBackupDecodeResult.Rejected("备份解压超过大小上限")
+        } catch (e: IOException) {
+            CustomLyricsBackupDecodeResult.Rejected("读取备份失败")
+        }
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsManager.kt
+++ b/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsManager.kt
@@ -6,11 +6,18 @@ import dev.amenhancer.module.XposedServiceSnapshot
 import dev.amenhancer.module.config.ConfigStore
 import dev.amenhancer.module.config.CustomLyricsManifestPolicy
 import dev.amenhancer.module.model.CustomLyricsManifest
+import java.io.InputStream
+import java.io.OutputStream
 import java.util.UUID
 
 internal sealed interface CustomLyricsMutationResult {
     data class Updated(val manifest: CustomLyricsManifest) : CustomLyricsMutationResult
     data class Failed(val message: String) : CustomLyricsMutationResult
+}
+
+internal sealed interface CustomLyricsBackupResult {
+    data class Done(val entryCount: Int) : CustomLyricsBackupResult
+    data class Failed(val message: String) : CustomLyricsBackupResult
 }
 
 /** Settings-process facade for atomic custom-lyrics file and manifest changes. */
@@ -66,6 +73,58 @@ internal class CustomLyricsManager(
             runCatching { snapshot.deleteRemoteFile(removed.fileId) }
         }
         return CustomLyricsMutationResult.Updated(next)
+    }
+
+    /**
+     * Writes a bounded ZIP backup (manifest.json plus one file per entry) into
+     * [out]; every TTML body is validated by [CustomLyricsFileReader] first.
+     * Consumes and closes [out].
+     */
+    fun backup(out: OutputStream): CustomLyricsBackupResult = synchronized(mutationLock) {
+        if (!isWritable()) return CustomLyricsBackupResult.Failed("libxposed remote file 服务不可用")
+        val manifest = configStore.settings(snapshot).customLyricsManifest
+        return when (val result = CustomLyricsBackupCodec.encode(manifest, ::readRemoteFile, out)) {
+            is CustomLyricsBackupEncodeResult.Encoded ->
+                CustomLyricsBackupResult.Done(result.entryCount)
+            is CustomLyricsBackupEncodeResult.Failed ->
+                CustomLyricsBackupResult.Failed(result.message)
+        }
+    }
+
+    /**
+     * Decodes a bounded ZIP backup from [input] and merge-restores it: backup
+     * entries overwrite same-ID current entries, current-only IDs are kept,
+     * every restored entry gets a fresh remote fileId. Consumes and closes
+     * [input].
+     */
+    fun restore(input: InputStream): CustomLyricsRestoreResult = synchronized(mutationLock) {
+        if (!isWritable()) return CustomLyricsRestoreResult.Failed("libxposed remote file 服务不可用")
+        val oldManifest = configStore.settings(snapshot).customLyricsManifest
+        val decoded = when (val result = CustomLyricsBackupCodec.decode(input)) {
+            is CustomLyricsBackupDecodeResult.Rejected ->
+                return CustomLyricsRestoreResult.Failed(result.message)
+            is CustomLyricsBackupDecodeResult.Decoded -> result.backup
+        }
+        return CustomLyricsRestoreTransaction(
+            fileIdFactory = ::newFileId,
+            writeRemoteFile = ::writeRemoteFile,
+            publishManifest = { manifest ->
+                isWritable() && configStore.saveCustomLyricsManifest(manifest, snapshot)
+            },
+            deleteRemoteFile = { fileId ->
+                if (ModuleApplication.isCurrentSnapshot(snapshot)) snapshot.deleteRemoteFile(fileId)
+            },
+        ).merge(oldManifest, decoded)
+    }
+
+    private fun readRemoteFile(fileId: String): ByteArray? {
+        if (!isWritable()) return null
+        val descriptor = snapshot.openRemoteFile(fileId) ?: return null
+        return runCatching {
+            ParcelFileDescriptor.AutoCloseInputStream(descriptor).use { input ->
+                CustomLyricsFilePolicy.readBounded(input)
+            }
+        }.getOrNull()
     }
 
     private fun mutate(

--- a/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsRestoreTransaction.kt
+++ b/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsRestoreTransaction.kt
@@ -1,0 +1,83 @@
+package dev.amenhancer.module.lyrics
+
+import dev.amenhancer.module.config.CustomLyricsManifestPolicy
+import dev.amenhancer.module.model.CustomLyricsEntry
+import dev.amenhancer.module.model.CustomLyricsManifest
+
+internal sealed interface CustomLyricsRestoreResult {
+    data class Restored(val manifest: CustomLyricsManifest) : CustomLyricsRestoreResult
+    data class Failed(val message: String) : CustomLyricsRestoreResult
+}
+
+/**
+ * Merge-restore semantics: backup entries overwrite current entries with the
+ * same Apple Music ID, current-only IDs are kept. Every backup entry is
+ * rebuilt with a fresh remote fileId; the merged manifest is published once
+ * after all new files are written, then old files of overwritten IDs are
+ * deleted. Any write or publish failure rolls back only the new files and
+ * leaves the old manifest and old files untouched. An empty backup is a
+ * successful no-op.
+ */
+internal class CustomLyricsRestoreTransaction(
+    private val fileIdFactory: () -> String,
+    private val writeRemoteFile: (String, ByteArray) -> Boolean,
+    private val publishManifest: (CustomLyricsManifest) -> Boolean,
+    private val deleteRemoteFile: (String) -> Unit,
+) {
+    fun merge(
+        oldManifest: CustomLyricsManifest,
+        backup: CustomLyricsBackup,
+    ): CustomLyricsRestoreResult {
+        if (backup.manifest.entries.isEmpty()) {
+            return CustomLyricsRestoreResult.Restored(oldManifest)
+        }
+        val rebuilt = mutableListOf<Pair<CustomLyricsEntry, ByteArray>>()
+        val allocatedFileIds = oldManifest.entries.mapTo(mutableSetOf(), CustomLyricsEntry::fileId)
+        for (incoming in backup.manifest.entries) {
+            val bytes = backup.files[incoming.fileId]
+                ?: return CustomLyricsRestoreResult.Failed("备份内容缺失")
+            val fileId = runCatching(fileIdFactory).getOrNull()
+                ?.takeIf(CustomLyricsManifestPolicy::isValidFileId)
+                ?: return CustomLyricsRestoreResult.Failed("无法生成歌词文件 ID")
+            if (!allocatedFileIds.add(fileId)) {
+                return CustomLyricsRestoreResult.Failed("无法生成唯一歌词文件 ID")
+            }
+            rebuilt += incoming.copy(fileId = fileId) to bytes
+        }
+        val incomingById = rebuilt.associate { it.first.appleMusicId to it }
+        val currentIds = oldManifest.entries.map { it.appleMusicId }.toSet()
+        val mergedEntries = mutableListOf<CustomLyricsEntry>()
+        val retiredFileIds = mutableListOf<String>()
+        oldManifest.entries.forEach { current ->
+            val replacement = incomingById[current.appleMusicId]
+            if (replacement != null) {
+                mergedEntries += replacement.first
+                retiredFileIds += current.fileId
+            } else {
+                mergedEntries += current
+            }
+        }
+        rebuilt.forEach { (entry, _) ->
+            if (entry.appleMusicId !in currentIds) mergedEntries += entry
+        }
+        if (mergedEntries.size > CustomLyricsManifestPolicy.MAX_ENTRIES) {
+            return CustomLyricsRestoreResult.Failed("合并后歌词映射数量超过上限")
+        }
+        val merged = CustomLyricsManifestPolicy.sanitize(CustomLyricsManifest(mergedEntries))
+        val written = mutableListOf<String>()
+        rebuilt.forEach { (entry, bytes) ->
+            if (!runCatching { writeRemoteFile(entry.fileId, bytes) }.getOrDefault(false)) {
+                runCatching { deleteRemoteFile(entry.fileId) }
+                written.forEach { runCatching { deleteRemoteFile(it) } }
+                return CustomLyricsRestoreResult.Failed("无法写入共享歌词文件")
+            }
+            written += entry.fileId
+        }
+        if (!runCatching { publishManifest(merged) }.getOrDefault(false)) {
+            written.forEach { runCatching { deleteRemoteFile(it) } }
+            return CustomLyricsRestoreResult.Failed("无法发布歌词映射")
+        }
+        retiredFileIds.forEach { runCatching { deleteRemoteFile(it) } }
+        return CustomLyricsRestoreResult.Restored(merged)
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt
+++ b/app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt
@@ -37,6 +37,7 @@ import dev.amenhancer.module.hook.AmllTtmlClient
 import dev.amenhancer.module.hook.HttpLyricTransport
 import dev.amenhancer.module.hook.NeteaseLyricClient
 import dev.amenhancer.module.lyrics.CustomLyricsDraft
+import dev.amenhancer.module.lyrics.CustomLyricsBackupResult
 import dev.amenhancer.module.lyrics.CustomLyricsFilePolicy
 import dev.amenhancer.module.lyrics.CustomLyricsFileReader
 import dev.amenhancer.module.lyrics.CustomLyricsInspection
@@ -44,6 +45,7 @@ import dev.amenhancer.module.lyrics.CustomLyricsManager
 import dev.amenhancer.module.lyrics.CustomLyricsMutationResult
 import dev.amenhancer.module.lyrics.CustomLyricsOnlineImportResult
 import dev.amenhancer.module.lyrics.CustomLyricsOnlineImporter
+import dev.amenhancer.module.lyrics.CustomLyricsRestoreResult
 import dev.amenhancer.module.lyrics.CustomLyricsSaveResult
 import dev.amenhancer.module.model.CustomLyricsEntry
 import dev.amenhancer.module.model.CustomLyricsManifest
@@ -149,6 +151,12 @@ class SettingsActivity : Activity() {
                         }
                     }
                 }
+            }
+            CUSTOM_LYRICS_BACKUP_CREATE_REQUEST_CODE -> {
+                if (resultCode == RESULT_OK) data?.data?.let(::backupCustomLyrics)
+            }
+            CUSTOM_LYRICS_BACKUP_RESTORE_REQUEST_CODE -> {
+                if (resultCode == RESULT_OK) data?.data?.let(::confirmRestoreCustomLyrics)
             }
         }
     }
@@ -590,7 +598,105 @@ class SettingsActivity : Activity() {
                     LinearLayout.LayoutParams(0, dp(48), 1f),
                 )
             })
+            addView(LinearLayout(this@SettingsActivity).apply {
+                orientation = LinearLayout.HORIZONTAL
+                setPadding(dp(12), 0, dp(12), dp(12))
+                addView(
+                    fontActionButton("备份歌词", writable) { chooseCustomLyricsBackupDestination() },
+                    LinearLayout.LayoutParams(0, dp(48), 1f),
+                )
+                addView(spacer(8), LinearLayout.LayoutParams(dp(8), dp(1)))
+                addView(
+                    fontActionButton("恢复备份", writable) { chooseCustomLyricsBackupRestore() },
+                    LinearLayout.LayoutParams(0, dp(48), 1f),
+                )
+            })
         }
+
+    private fun chooseCustomLyricsBackupDestination() {
+        if (!ModuleApplication.serviceSnapshot.isRemoteFileAvailable) {
+            toast("libxposed remote file 服务不可用")
+            return
+        }
+        startActivityForResult(Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
+            addCategory(Intent.CATEGORY_OPENABLE)
+            type = BACKUP_MIME_TYPE
+            putExtra(Intent.EXTRA_TITLE, "AM++-custom-lyrics-backup.zip")
+        }, CUSTOM_LYRICS_BACKUP_CREATE_REQUEST_CODE)
+    }
+
+    private fun chooseCustomLyricsBackupRestore() {
+        if (!ModuleApplication.serviceSnapshot.isRemoteFileAvailable) {
+            toast("libxposed remote file 服务不可用")
+            return
+        }
+        startActivityForResult(Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+            addCategory(Intent.CATEGORY_OPENABLE)
+            type = "*/*"
+            putExtra(
+                Intent.EXTRA_MIME_TYPES,
+                arrayOf(
+                    BACKUP_MIME_TYPE,
+                    "application/x-zip-compressed",
+                    "application/octet-stream",
+                ),
+            )
+        }, CUSTOM_LYRICS_BACKUP_RESTORE_REQUEST_CODE)
+    }
+
+    private fun backupCustomLyrics(uri: android.net.Uri) {
+        val snapshot = ModuleApplication.serviceSnapshot
+        backgroundExecutor.execute {
+            val result = runCatching {
+                contentResolver.openOutputStream(uri, "wt")?.use { output ->
+                    CustomLyricsManager(snapshot, store).backup(output)
+                } ?: CustomLyricsBackupResult.Failed("无法创建备份文件")
+            }.getOrElse { CustomLyricsBackupResult.Failed("写入备份失败") }
+            if (result is CustomLyricsBackupResult.Failed) {
+                runCatching { contentResolver.delete(uri, null, null) }
+            }
+            runOnUiThread {
+                if (isFinishing || isDestroyed) return@runOnUiThread
+                when (result) {
+                    is CustomLyricsBackupResult.Done -> toast("已备份 ${result.entryCount} 首歌词")
+                    is CustomLyricsBackupResult.Failed -> toast(result.message)
+                }
+            }
+        }
+    }
+
+    private fun confirmRestoreCustomLyrics(uri: android.net.Uri) {
+        AlertDialog.Builder(this)
+            .setTitle("合并恢复歌词备份")
+            .setMessage(
+                "同 Apple Music ID 的歌词将使用备份版本；" +
+                    "当前独有歌词会保留；总开关不会改变。是否继续？",
+            )
+            .setNegativeButton("取消", null)
+            .setPositiveButton("恢复") { _, _ -> restoreCustomLyrics(uri) }
+            .show()
+    }
+
+    private fun restoreCustomLyrics(uri: android.net.Uri) {
+        val snapshot = ModuleApplication.serviceSnapshot
+        backgroundExecutor.execute {
+            val result = runCatching {
+                contentResolver.openInputStream(uri)?.use { input ->
+                    CustomLyricsManager(snapshot, store).restore(input)
+                } ?: CustomLyricsRestoreResult.Failed("无法读取备份文件")
+            }.getOrElse { CustomLyricsRestoreResult.Failed("读取备份失败") }
+            runOnUiThread {
+                if (isFinishing || isDestroyed) return@runOnUiThread
+                when (result) {
+                    is CustomLyricsRestoreResult.Restored -> {
+                        render()
+                        toast("恢复完成，当前共 ${result.manifest.entries.size} 首歌词")
+                    }
+                    is CustomLyricsRestoreResult.Failed -> toast(result.message)
+                }
+            }
+        }
+    }
 
     private fun requestCurrentSongId(appleMusicId: EditText, displayName: EditText) {
         if (!currentSongIdentityRequester.request { currentSong ->
@@ -1297,6 +1403,9 @@ class SettingsActivity : Activity() {
     private companion object {
         const val FONT_PICKER_REQUEST_CODE = 4401
         const val CUSTOM_TTML_PICKER_REQUEST_CODE = 4402
+        const val CUSTOM_LYRICS_BACKUP_CREATE_REQUEST_CODE = 4403
+        const val CUSTOM_LYRICS_BACKUP_RESTORE_REQUEST_CODE = 4404
+        const val BACKUP_MIME_TYPE = "application/zip"
         const val STATE_AWAITING_CUSTOM_TTML_PICKER = "awaiting_custom_ttml_picker"
         const val STATE_SETTINGS_PAGE = "settings_page"
         val settingsExecutor: ExecutorService = Executors.newSingleThreadExecutor()

--- a/app/src/test/java/dev/amenhancer/module/lyrics/CustomLyricsBackupCodecTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/lyrics/CustomLyricsBackupCodecTest.kt
@@ -1,0 +1,388 @@
+package dev.amenhancer.module.lyrics
+
+import dev.amenhancer.module.config.CustomLyricsManifestCodec
+import dev.amenhancer.module.model.CustomLyricsEntry
+import dev.amenhancer.module.model.CustomLyricsManifest
+import dev.amenhancer.module.model.CustomLyricsSources
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.zip.CRC32
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+class CustomLyricsBackupCodecTest {
+    private val ttml1 = "<tt><body><p><span>hello</span></p></body></tt>"
+    private val ttml2 = "<tt><body><p><span>world</span><span>!</span></p></body></tt>"
+
+    @Test
+    fun `roundtrip preserves manifest and every ttml file`() {
+        val manifest = CustomLyricsManifest(
+            listOf(
+                entry(appleMusicId = 1L, fileId = "lyrics_a", ttml = ttml1),
+                entry(appleMusicId = 2L, fileId = "lyrics_b", ttml = ttml2),
+            ),
+        )
+        val files = mapOf(
+            "lyrics_a" to ttml1.toByteArray(Charsets.UTF_8),
+            "lyrics_b" to ttml2.toByteArray(Charsets.UTF_8),
+        )
+        val out = ByteArrayOutputStream()
+        val encoded = CustomLyricsBackupCodec.encode(manifest, { files[it] }, out)
+        assertTrue(encoded is CustomLyricsBackupEncodeResult.Encoded)
+        assertEquals(2, (encoded as CustomLyricsBackupEncodeResult.Encoded).entryCount)
+
+        val decoded = CustomLyricsBackupCodec.decode(ByteArrayInputStream(out.toByteArray()))
+        assertTrue(decoded is CustomLyricsBackupDecodeResult.Decoded)
+        val backup = (decoded as CustomLyricsBackupDecodeResult.Decoded).backup
+        assertEquals(manifest, backup.manifest)
+        assertEquals(ttml1, backup.files.getValue("lyrics_a").toString(Charsets.UTF_8))
+        assertEquals(ttml2, backup.files.getValue("lyrics_b").toString(Charsets.UTF_8))
+    }
+
+    @Test
+    fun `backup fails entirely when any remote file cannot be read`() {
+        val manifest = CustomLyricsManifest(
+            listOf(
+                entry(appleMusicId = 1L, fileId = "lyrics_a", ttml = ttml1),
+                entry(appleMusicId = 2L, fileId = "lyrics_b", ttml = ttml2),
+            ),
+        )
+        val out = ByteArrayOutputStream()
+
+        val result = CustomLyricsBackupCodec.encode(manifest, { null }, out)
+
+        assertTrue(result is CustomLyricsBackupEncodeResult.Failed)
+        assertEquals(0, out.size())
+    }
+
+    @Test
+    fun `encode rejects a manifest that policy would alter`() {
+        val manifest = CustomLyricsManifest((1L..33L).map { entry(it, "lyrics_$it", ttml1) })
+
+        val result = CustomLyricsBackupCodec.encode(manifest, { ttml1.toByteArray() }, ByteArrayOutputStream())
+
+        assertTrue(result is CustomLyricsBackupEncodeResult.Failed)
+    }
+
+    @Test
+    fun `decode rejects a zip without manifest json`() {
+        val result = decode(zipBytes(listOf("lyrics_a" to ttml1.toByteArray(Charsets.UTF_8))))
+
+        assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
+    }
+
+    @Test
+    fun `decode rejects a corrupt manifest json instead of treating it as empty backup`() {
+        val result = decode(zipBytes(listOf("manifest.json" to "not json".toByteArray())))
+
+        assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
+    }
+
+    @Test
+    fun `decode rejects an unsupported version`() {
+        val json = JSONObject(CustomLyricsManifestCodec.encode(CustomLyricsManifest.empty()))
+            .put("version", 99)
+            .toString()
+        val result = decode(zipBytes(listOf("manifest.json" to json.toByteArray())))
+
+        assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
+    }
+
+    @Test
+    fun `decode rejects a manifest with more than 32 entries`() {
+        val entries = JSONArray()
+        repeat(33) { index ->
+            entries.put(
+                JSONObject().apply {
+                    put("appleMusicId", index + 1L)
+                    put("displayName", "s")
+                    put("fileId", "lyrics_$index")
+                    put("sizeBytes", 5L)
+                    put("sha256", "0".repeat(64))
+                    put("source", CustomLyricsSources.MANUAL)
+                    put("enabled", true)
+                },
+            )
+        }
+        val json = JSONObject().apply { put("version", 1); put("entries", entries) }.toString()
+        val result = decode(zipBytes(listOf("manifest.json" to json.toByteArray())))
+
+        assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
+    }
+
+    @Test
+    fun `decode rejects duplicate apple music ids in the manifest`() {
+        val entries = JSONArray()
+        listOf(
+            entry(appleMusicId = 1L, fileId = "lyrics_a", ttml = ttml1),
+            entry(appleMusicId = 1L, fileId = "lyrics_b", ttml = ttml2),
+        ).forEach { e ->
+            entries.put(
+                JSONObject().apply {
+                    put("appleMusicId", e.appleMusicId)
+                    put("displayName", e.displayName)
+                    put("fileId", e.fileId)
+                    put("sizeBytes", e.sizeBytes)
+                    put("sha256", e.sha256)
+                    put("source", e.source)
+                    put("enabled", e.enabled)
+                },
+            )
+        }
+        val json = JSONObject().apply { put("version", 1); put("entries", entries) }.toString()
+        val result = decode(zipBytes(listOf("manifest.json" to json.toByteArray())))
+
+        assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
+    }
+
+    @Test
+    fun `decode rejects directory entries`() {
+        val out = ByteArrayOutputStream()
+        ZipOutputStream(out).use { zip ->
+            zip.putNextEntry(ZipEntry("lyrics_dir/"))
+            zip.closeEntry()
+        }
+
+        val result = decode(out.toByteArray())
+
+        assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
+    }
+
+    @Test
+    fun `decode rejects path traversal file names`() {
+        listOf(
+            "../evil.txt",
+            "sub/dir/file",
+            "lyrics_ok/../../evil",
+        ).forEach { name ->
+            val result = decode(zipBytes(listOf(name to ttml1.toByteArray(Charsets.UTF_8))))
+            assertTrue("name $name should be rejected", result is CustomLyricsBackupDecodeResult.Rejected)
+        }
+    }
+
+    @Test
+    fun `decode rejects duplicate file names`() {
+        val bytes = ttml1.toByteArray(Charsets.UTF_8)
+
+        val result = decode(zipWithDuplicateName("lyrics_a", bytes, bytes))
+
+        assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
+    }
+
+    @Test
+    fun `decode rejects duplicate manifest json`() {
+        val json = CustomLyricsManifestCodec.encode(CustomLyricsManifest.empty()).toByteArray()
+
+        val result = decode(zipWithDuplicateName("manifest.json", json, json))
+
+        assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
+    }
+
+    @Test
+    fun `decode rejects a file missing from the zip`() {
+        val manifest = CustomLyricsManifest(
+            listOf(
+                entry(appleMusicId = 1L, fileId = "lyrics_a", ttml = ttml1),
+                entry(appleMusicId = 2L, fileId = "lyrics_b", ttml = ttml2),
+            ),
+        )
+        val result = decode(
+            zipBytes(
+                listOf(
+                    "manifest.json" to manifestJson(manifest),
+                    "lyrics_a" to ttml1.toByteArray(Charsets.UTF_8),
+                ),
+            ),
+        )
+
+        assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
+    }
+
+    @Test
+    fun `decode rejects a file extra to the manifest`() {
+        val manifest = CustomLyricsManifest(listOf(entry(appleMusicId = 1L, fileId = "lyrics_a", ttml = ttml1)))
+        val result = decode(
+            zipBytes(
+                listOf(
+                    "manifest.json" to manifestJson(manifest),
+                    "lyrics_a" to ttml1.toByteArray(Charsets.UTF_8),
+                    "lyrics_c" to ttml2.toByteArray(Charsets.UTF_8),
+                ),
+            ),
+        )
+
+        assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
+    }
+
+    @Test
+    fun `decode rejects shared manifest file ids even when zip file count matches`() {
+        val sharedA = entry(appleMusicId = 1L, fileId = "lyrics_a", ttml = ttml1)
+        val sharedB = entry(appleMusicId = 2L, fileId = "lyrics_a", ttml = ttml1)
+        val manifest = CustomLyricsManifest(listOf(sharedA, sharedB))
+
+        val result = decode(
+            zipBytes(
+                listOf(
+                    "manifest.json" to manifestJson(manifest),
+                    "lyrics_a" to ttml1.toByteArray(Charsets.UTF_8),
+                    "lyrics_extra" to ttml2.toByteArray(Charsets.UTF_8),
+                ),
+            ),
+        )
+
+        assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
+    }
+
+    @Test
+    fun `decode rejects an entry whose size does not match the manifest`() {
+        val bytes = ttml1.toByteArray(Charsets.UTF_8)
+        val mismatched = entry(appleMusicId = 1L, fileId = "lyrics_a", ttml = ttml1)
+            .copy(sizeBytes = bytes.size.toLong() + 1)
+        val result = decode(
+            zipBytes(
+                listOf(
+                    "manifest.json" to manifestJson(CustomLyricsManifest(listOf(mismatched))),
+                    "lyrics_a" to bytes,
+                ),
+            ),
+        )
+
+        assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
+    }
+
+    @Test
+    fun `decode rejects an entry whose hash does not match the manifest`() {
+        val bytes = ttml1.toByteArray(Charsets.UTF_8)
+        val mismatched = entry(appleMusicId = 1L, fileId = "lyrics_a", ttml = ttml1)
+            .copy(sha256 = "0".repeat(64))
+        val result = decode(
+            zipBytes(
+                listOf(
+                    "manifest.json" to manifestJson(CustomLyricsManifest(listOf(mismatched))),
+                    "lyrics_a" to bytes,
+                ),
+            ),
+        )
+
+        assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
+    }
+
+    @Test
+    fun `decode rejects an entry that fails the ttml policy`() {
+        val bytes = "not ttml".toByteArray(Charsets.UTF_8)
+        val rejected = CustomLyricsEntry(
+            appleMusicId = 1L,
+            displayName = "Song",
+            fileId = "lyrics_a",
+            sizeBytes = bytes.size.toLong(),
+            sha256 = CustomLyricsFilePolicy.sha256(bytes),
+            source = CustomLyricsSources.MANUAL,
+        )
+        val result = decode(
+            zipBytes(
+                listOf(
+                    "manifest.json" to manifestJson(CustomLyricsManifest(listOf(rejected))),
+                    "lyrics_a" to bytes,
+                ),
+            ),
+        )
+
+        assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
+    }
+
+    @Test
+    fun `decode rejects an oversize entry (zip bomb per entry bound)`() {
+        val result = decode(zipBytes(listOf("lyrics_big" to ByteArray(512 * 1024 + 1))))
+
+        assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
+    }
+
+    @Test
+    fun `decode rejects too many zip entries`() {
+        val bytes = ttml1.toByteArray(Charsets.UTF_8)
+        val result = decode(zipBytes((1..34).map { "lyrics_$it" to bytes }))
+
+        assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
+    }
+
+    private fun decode(zip: ByteArray): CustomLyricsBackupDecodeResult =
+        CustomLyricsBackupCodec.decode(ByteArrayInputStream(zip))
+
+    private fun zipBytes(entries: List<Pair<String, ByteArray>>): ByteArray {
+        val out = ByteArrayOutputStream()
+        ZipOutputStream(out).use { zip ->
+            entries.forEach { (name, bytes) ->
+                zip.putNextEntry(ZipEntry(name))
+                zip.write(bytes)
+                zip.closeEntry()
+            }
+        }
+        return out.toByteArray()
+    }
+
+    /**
+     * Builds a zip with several entries sharing [name]. ZipOutputStream
+     * refuses duplicate names, so the ZIP is assembled by hand (little-endian
+     * layout, STORED method, real CRC32s).
+     */
+    private fun zipWithDuplicateName(name: String, vararg datas: ByteArray): ByteArray {
+        val nameBytes = name.toByteArray(Charsets.UTF_8)
+        val out = ByteArrayOutputStream()
+        var offset = 0
+        val centralHeaders = ArrayList<ByteArray>()
+        datas.forEach { data ->
+            val crc = CRC32().apply { update(data) }.value.toInt()
+            val local = ByteBuffer.allocate(30 + nameBytes.size).order(ByteOrder.LITTLE_ENDIAN)
+            local.putInt(0x04034b50)
+            local.putShort(20.toShort()); local.putShort(0); local.putShort(0); local.putShort(0); local.putShort(0)
+            local.putInt(crc); local.putInt(data.size); local.putInt(data.size)
+            local.putShort(nameBytes.size.toShort()); local.putShort(0)
+            local.put(nameBytes)
+            out.write(local.array())
+            out.write(data)
+            val central = ByteBuffer.allocate(46 + nameBytes.size).order(ByteOrder.LITTLE_ENDIAN)
+            central.putInt(0x02014b50)
+            central.putShort(20.toShort()); central.putShort(20.toShort()); central.putShort(0); central.putShort(0)
+            central.putShort(0); central.putShort(0)
+            central.putInt(crc); central.putInt(data.size); central.putInt(data.size)
+            central.putShort(nameBytes.size.toShort()); central.putShort(0); central.putShort(0)
+            central.putShort(0); central.putShort(0); central.putInt(0)
+            central.putInt(offset)
+            central.put(nameBytes)
+            centralHeaders += central.array()
+            offset += local.array().size + data.size
+        }
+        val centralStart = out.size()
+        centralHeaders.forEach { out.write(it) }
+        val eocd = ByteBuffer.allocate(22).order(ByteOrder.LITTLE_ENDIAN)
+        eocd.putInt(0x06054b50)
+        eocd.putShort(0); eocd.putShort(0); eocd.putShort(datas.size.toShort()); eocd.putShort(datas.size.toShort())
+        eocd.putInt(centralHeaders.sumOf { it.size })
+        eocd.putInt(centralStart)
+        eocd.putShort(0)
+        out.write(eocd.array())
+        return out.toByteArray()
+    }
+
+    private fun manifestJson(manifest: CustomLyricsManifest): ByteArray =
+        CustomLyricsManifestCodec.encode(manifest).toByteArray(Charsets.UTF_8)
+
+    private fun entry(appleMusicId: Long, fileId: String, ttml: String): CustomLyricsEntry {
+        val bytes = ttml.toByteArray(Charsets.UTF_8)
+        return CustomLyricsEntry(
+            appleMusicId = appleMusicId,
+            displayName = "Song $appleMusicId",
+            fileId = fileId,
+            sizeBytes = bytes.size.toLong(),
+            sha256 = CustomLyricsFilePolicy.sha256(bytes),
+            source = CustomLyricsSources.MANUAL,
+        )
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/lyrics/CustomLyricsRestoreTransactionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/lyrics/CustomLyricsRestoreTransactionTest.kt
@@ -1,0 +1,206 @@
+package dev.amenhancer.module.lyrics
+
+import dev.amenhancer.module.config.CustomLyricsManifestPolicy
+import dev.amenhancer.module.model.CustomLyricsEntry
+import dev.amenhancer.module.model.CustomLyricsManifest
+import dev.amenhancer.module.model.CustomLyricsSources
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CustomLyricsRestoreTransactionTest {
+    private val ttml = "<tt><body><p><span>word</span></p></body></tt>"
+
+    @Test
+    fun `merging A plus B with backup B plus C yields A B prime C`() {
+        val events = mutableListOf<String>()
+        var published = CustomLyricsManifest.empty()
+        val current = CustomLyricsManifest(
+            listOf(
+                existingEntry(appleMusicId = 1L, fileId = "lyrics_a"),
+                existingEntry(appleMusicId = 2L, fileId = "lyrics_b"),
+            ),
+        )
+        val backup = backup(
+            backupEntry(appleMusicId = 2L, fileId = "lyrics_bb", displayName = "B new") to ttmlBytes(),
+            backupEntry(appleMusicId = 3L, fileId = "lyrics_cc") to ttmlBytes(),
+        )
+
+        val result = transaction(events) { manifest ->
+            events += "publish"
+            published = manifest
+            true
+        }.merge(current, backup)
+
+        assertTrue(result is CustomLyricsRestoreResult.Restored)
+        assertEquals(
+            listOf(1L, 2L, 3L),
+            (result as CustomLyricsRestoreResult.Restored).manifest.entries.map(CustomLyricsEntry::appleMusicId),
+        )
+        assertEquals(
+            listOf("lyrics_a", "lyrics_new1", "lyrics_new2"),
+            published.entries.map(CustomLyricsEntry::fileId),
+        )
+        assertEquals("B new", published.entries[1].displayName)
+        assertEquals(listOf("write:lyrics_new1", "write:lyrics_new2", "publish", "delete:lyrics_b"), events)
+    }
+
+    @Test
+    fun `a write failure deletes only the new files written so far`() {
+        val events = mutableListOf<String>()
+        val current = CustomLyricsManifest(
+            listOf(
+                existingEntry(appleMusicId = 1L, fileId = "lyrics_a"),
+                existingEntry(appleMusicId = 2L, fileId = "lyrics_b"),
+            ),
+        )
+        val backup = backup(
+            backupEntry(appleMusicId = 2L, fileId = "lyrics_bb") to ttmlBytes(),
+            backupEntry(appleMusicId = 3L, fileId = "lyrics_cc") to ttmlBytes(),
+        )
+
+        val result = transaction(
+            events,
+            write = { fileId, _ ->
+                events += "write:$fileId"
+                fileId != "lyrics_new2"
+            },
+        ) { events += "publish"; true }.merge(current, backup)
+
+        assertEquals(CustomLyricsRestoreResult.Failed("无法写入共享歌词文件"), result)
+        assertEquals(
+            listOf(
+                "write:lyrics_new1",
+                "write:lyrics_new2",
+                "delete:lyrics_new2",
+                "delete:lyrics_new1",
+            ),
+            events,
+        )
+    }
+
+    @Test
+    fun `a publish failure deletes all new files and keeps old files`() {
+        val events = mutableListOf<String>()
+        val current = CustomLyricsManifest(
+            listOf(
+                existingEntry(appleMusicId = 1L, fileId = "lyrics_a"),
+                existingEntry(appleMusicId = 2L, fileId = "lyrics_b"),
+            ),
+        )
+        val backup = backup(
+            backupEntry(appleMusicId = 2L, fileId = "lyrics_bb") to ttmlBytes(),
+            backupEntry(appleMusicId = 3L, fileId = "lyrics_cc") to ttmlBytes(),
+        )
+
+        val result = transaction(events) { events += "publish"; false }.merge(current, backup)
+
+        assertEquals(CustomLyricsRestoreResult.Failed("无法发布歌词映射"), result)
+        assertEquals(
+            listOf("write:lyrics_new1", "write:lyrics_new2", "publish", "delete:lyrics_new1", "delete:lyrics_new2"),
+            events,
+        )
+    }
+
+    @Test
+    fun `an empty backup succeeds and leaves the current manifest untouched`() {
+        val events = mutableListOf<String>()
+        val current = CustomLyricsManifest(listOf(existingEntry(appleMusicId = 1L, fileId = "lyrics_a")))
+
+        val result = transaction(events) { events += "publish"; true }
+            .merge(current, backup())
+
+        assertTrue(result is CustomLyricsRestoreResult.Restored)
+        assertEquals(current, (result as CustomLyricsRestoreResult.Restored).manifest)
+        assertTrue(events.isEmpty())
+    }
+
+    @Test
+    fun `a merge exceeding the entry limit fails before any write`() {
+        val events = mutableListOf<String>()
+        val current = CustomLyricsManifest(
+            (1L..CustomLyricsManifestPolicy.MAX_ENTRIES.toLong()).map { existingEntry(it, "lyrics_$it") },
+        )
+        val backup = backup(backupEntry(appleMusicId = 100L, fileId = "lyrics_new") to ttmlBytes())
+
+        val result = transaction(events) { events += "publish"; true }.merge(current, backup)
+
+        assertEquals(CustomLyricsRestoreResult.Failed("合并后歌词映射数量超过上限"), result)
+        assertTrue(events.isEmpty())
+    }
+
+    @Test
+    fun `an invalid generated file id fails before any write`() {
+        val events = mutableListOf<String>()
+        val backup = backup(backupEntry(appleMusicId = 3L, fileId = "lyrics_cc") to ttmlBytes())
+
+        val result = transaction(events, fileIdFactory = { "bad file id!" }) { events += "publish"; true }
+            .merge(CustomLyricsManifest.empty(), backup)
+
+        assertEquals(CustomLyricsRestoreResult.Failed("无法生成歌词文件 ID"), result)
+        assertTrue(events.isEmpty())
+    }
+
+    @Test
+    fun `a generated file id collision fails before any write`() {
+        val events = mutableListOf<String>()
+        val current = CustomLyricsManifest(listOf(existingEntry(1L, "lyrics_taken")))
+        val backup = backup(backupEntry(appleMusicId = 3L, fileId = "lyrics_cc") to ttmlBytes())
+
+        val result = transaction(events, fileIdFactory = { "lyrics_taken" }) { events += "publish"; true }
+            .merge(current, backup)
+
+        assertEquals(CustomLyricsRestoreResult.Failed("无法生成唯一歌词文件 ID"), result)
+        assertTrue(events.isEmpty())
+    }
+
+    private fun transaction(
+        events: MutableList<String>,
+        fileIdFactory: () -> String = defaultFileIdFactory(),
+        write: (String, ByteArray) -> Boolean = { fileId, _ ->
+            events += "write:$fileId"
+            true
+        },
+        publish: (CustomLyricsManifest) -> Boolean,
+    ): CustomLyricsRestoreTransaction = CustomLyricsRestoreTransaction(
+        fileIdFactory = fileIdFactory,
+        writeRemoteFile = write,
+        publishManifest = publish,
+        deleteRemoteFile = { fileId -> events += "delete:$fileId" },
+    )
+
+    private fun defaultFileIdFactory(): () -> String {
+        var next = 0
+        return { next += 1; "lyrics_new$next" }
+    }
+
+    private fun backup(vararg entries: Pair<CustomLyricsEntry, ByteArray>): CustomLyricsBackup =
+        CustomLyricsBackup(
+            manifest = CustomLyricsManifest(entries.map { it.first }),
+            files = entries.associate { it.first.fileId to it.second },
+        )
+
+    private fun backupEntry(
+        appleMusicId: Long,
+        fileId: String,
+        displayName: String = "Song $appleMusicId",
+    ) = CustomLyricsEntry(
+        appleMusicId = appleMusicId,
+        displayName = displayName,
+        fileId = fileId,
+        sizeBytes = ttmlBytes().size.toLong(),
+        sha256 = CustomLyricsFilePolicy.sha256(ttmlBytes()),
+        source = CustomLyricsSources.MANUAL,
+    )
+
+    private fun existingEntry(appleMusicId: Long, fileId: String) = CustomLyricsEntry(
+        appleMusicId = appleMusicId,
+        displayName = "Old song $appleMusicId",
+        fileId = fileId,
+        sizeBytes = ttmlBytes().size.toLong(),
+        sha256 = CustomLyricsFilePolicy.sha256(ttmlBytes()),
+        source = CustomLyricsSources.MANUAL,
+    )
+
+    private fun ttmlBytes(): ByteArray = ttml.toByteArray(Charsets.UTF_8)
+}

--- a/app/src/test/java/dev/amenhancer/module/ui/SettingsUiStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/ui/SettingsUiStructuralRegressionTest.kt
@@ -162,6 +162,27 @@ class SettingsUiStructuralRegressionTest {
     }
 
     @Test
+    fun `backs up and merge restores custom lyrics through transient saf documents`() {
+        val activity = projectFile("app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt")
+
+        assertTrue(activity.contains("fontActionButton(\"备份歌词\""))
+        assertTrue(activity.contains("fontActionButton(\"恢复备份\""))
+        assertTrue(activity.contains("Intent.ACTION_CREATE_DOCUMENT"))
+        assertTrue(activity.contains("CUSTOM_LYRICS_BACKUP_CREATE_REQUEST_CODE"))
+        assertTrue(activity.contains("CUSTOM_LYRICS_BACKUP_RESTORE_REQUEST_CODE"))
+        assertTrue(activity.contains("application/x-zip-compressed"))
+        assertTrue(activity.contains("application/octet-stream"))
+        assertTrue(activity.contains("CustomLyricsManager(snapshot, store).backup(output)"))
+        assertTrue(activity.contains("CustomLyricsManager(snapshot, store).restore(input)"))
+        assertTrue(activity.contains("同 Apple Music ID 的歌词将使用备份版本"))
+        assertTrue(activity.contains("当前独有歌词会保留"))
+        assertTrue(activity.contains("总开关不会改变"))
+        assertTrue(activity.contains("backgroundExecutor.execute"))
+        assertTrue(activity.contains("contentResolver.delete(uri, null, null)"))
+        assertFalse(activity.contains("takePersistableUriPermission"))
+    }
+
+    @Test
     fun `persists non touch blur radius changes without duplicating touch writes`() {
         val activity = projectFile("app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt")
 


### PR DESCRIPTION
## Summary
- export all custom-lyrics mappings and validated TTML files as a bounded ZIP backup
- merge restore backups so same Apple Music IDs are replaced while current-only mappings are preserved
- add backup and restore actions to the custom-lyrics secondary settings page through transient SAF documents

## Safety
- validate archive structure, entry names, counts, decompressed sizes, hashes, and TTML before writing
- write every restored file under a fresh remote file ID, publish the merged manifest once, then retire overwritten files
- roll back newly written files on write or publication failure
- leave the global custom-lyrics enable switch unchanged

## Verification
- full JVM test suite
- Debug and signed Release assembly
- lintVitalRelease
- device-verified backup/restore buttons, create-document filename, and picker flows
- Release candidate SHA-256: 612657DE0B564F0EAE4510DEC30146E145993421EC513180285EBA3FB3B77C77