### PR TITLE
Adapt target symbols for Apple Music 6.5.1

### DIFF
--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
@@ -186,7 +186,7 @@ internal data class AlphaGradientEdgeFieldProfile(
     val requiredIntegers: List<String>,
 )
 
-/** Resolves the two Apple Music 6.5.0 AlphaGradientFrameLayout obfuscation variants. */
+/** Resolves the verified Apple Music AlphaGradientFrameLayout obfuscation variants. */
 internal object AlphaGradientEdgeFieldProfiles {
     private val profiles = listOf(
         AlphaGradientEdgeFieldProfile(
@@ -223,7 +223,7 @@ internal data class LyricsLayoutFieldProfile(
     val synchronizedMetrics: List<String>,
 )
 
-/** Resolves PlayerLyricsViewFragment fields in official and adapted Apple Music 6.5.0 builds. */
+/** Resolves PlayerLyricsViewFragment fields in the verified Apple Music builds. */
 internal object LyricsLayoutFieldProfiles {
     private val profiles = listOf(
         LyricsLayoutFieldProfile(

--- a/app/src/main/java/dev/amenhancer/module/hook/TargetSymbols.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/TargetSymbols.kt
@@ -120,6 +120,7 @@ internal class TargetClassIndex(private val source: TargetClassSource) {
 internal class TargetSymbolKey<T : Any>(
     val id: String,
     internal val profileCandidates: TargetClassIndex.(AppleMusicProfile?) -> List<T> = { emptyList() },
+    internal val profileBound: Boolean = false,
     internal val stableCandidates: TargetClassIndex.() -> List<T> = { emptyList() },
     internal val structuralCandidates: TargetClassIndex.() -> List<T>,
     internal val identity: (T) -> String,
@@ -145,7 +146,13 @@ internal class IndexedTargetSymbolResolver(
         }
 
     private fun <T : Any> resolveUncached(symbol: TargetSymbolKey<T>): TargetResolution<T> {
-        select(symbol, symbol.profileCandidates(index, profile), SymbolMatch.VERSION_PROFILE)?.let { return it }
+        if (profile != null && symbol.profileBound) {
+            return select(
+                symbol,
+                symbol.profileCandidates(index, profile),
+                SymbolMatch.VERSION_PROFILE,
+            ) ?: TargetResolution.Missing(symbol.id, profile.id)
+        }
         select(symbol, symbol.stableCandidates(index), SymbolMatch.STABLE_NAME)?.let { return it }
         val fallback = distinctCandidates(symbol, symbol.structuralCandidates(index))
         return when (fallback.size) {
@@ -234,10 +241,44 @@ private object AppleMusicProfiles {
         ),
     )
 
-    fun match(build: TargetBuild): AppleMusicProfile? = appleMusic650.takeIf {
-        build.packageName == ModuleConstants.TARGET_PACKAGE &&
-            build.versionName == "6.5.0" &&
-            build.versionCode == 1580L
+    private val appleMusic651 = AppleMusicProfile(
+        id = "apple-music-6.5.1-1583",
+        exactClasses = mapOf(
+            TargetSymbolId.PLAYER_CONTROLLER to "com.apple.android.music.player.fragment.q0",
+            TargetSymbolId.PLAYER_ACTIVITY to "com.apple.android.music.common.activity.PlayerActivity",
+            TargetSymbolId.EDITORIAL_VIDEO_OWNER to "com.apple.android.music.player.f1",
+            TargetSymbolId.LYRICS_FRAGMENT to "com.apple.android.music.player.fragment.PlayerLyricsViewFragment",
+            TargetSymbolId.LYRICS_CHROME to "com.apple.android.music.player.fragment.d",
+            TargetSymbolId.LYRICS_LINE_VECTOR to
+                "com.apple.android.music.ttml.javanative.model.LyricsLineVector",
+            TargetSymbolId.LYRICS_EVENT_PROCESSOR to
+                "com.apple.android.music.ttml.SongInfoTimeProcessor",
+            TargetSymbolId.LYRICS_HIGHLIGHT_CALLBACK_OWNER to
+                "com.apple.android.music.ttml.SongInfoTimeProcessor\$processEvents\$lineEventCallback\$1",
+            TargetSymbolId.LYRICS_VIEW_MODEL to
+                "com.apple.android.music.player.viewmodel.PlayerLyricsViewModel",
+            TargetSymbolId.STACKED_NAVIGATION_MENU to "Hd.b",
+            TargetSymbolId.SONG_INFO_PTR to
+                "com.apple.android.music.ttml.javanative.model.SongInfo\$SongInfoPtr",
+            TargetSymbolId.SONG_INFO_NATIVE to
+                "com.apple.android.music.ttml.javanative.model.SongInfo\$SongInfoNative",
+            TargetSymbolId.TTML_PARSER_NATIVE to
+                "com.apple.android.music.ttml.javanative.TTMLParser\$TTMLParserNative",
+            TargetSymbolId.LYRICS_CURRENT_ITEM_FIELD to
+                "com.apple.android.music.player.fragment.l",
+            TargetSymbolId.PLAYER_METADATA_HUB to "com.apple.android.music.player.f",
+            TargetSymbolId.METADATA_TO_ITEM_CONVERTER to "com.apple.android.music.player.O",
+            TargetSymbolId.LYRICS_AVAILABILITY_OWNER to "com.apple.android.music.player.e1",
+        ),
+    )
+
+    fun match(build: TargetBuild): AppleMusicProfile? {
+        if (build.packageName != ModuleConstants.TARGET_PACKAGE) return null
+        return when {
+            build.versionName == "6.5.0" && build.versionCode == 1580L -> appleMusic650
+            build.versionName == "6.5.1" && build.versionCode == 1583L -> appleMusic651
+            else -> null
+        }
     }
 }
 
@@ -249,6 +290,7 @@ internal object AppleMusicSymbols {
     ) { candidate ->
         candidate.declaredMethods.any { method ->
             method.name == "w1" &&
+                !Modifier.isStatic(method.modifiers) &&
                 method.returnType == Void.TYPE &&
                 method.parameterTypes.singleOrNull()?.name?.endsWith(".BagConfig") == true
         }
@@ -309,6 +351,7 @@ internal object AppleMusicSymbols {
 
     val LyricsHighlightCallback = TargetSymbolKey(
         id = "lyrics-highlight-callback",
+        profileBound = true,
         profileCandidates = { profile ->
             val owner = profile?.exactClasses?.get(TargetSymbolId.LYRICS_HIGHLIGHT_CALLBACK_OWNER)
                 ?.let(::load)
@@ -336,7 +379,9 @@ internal object AppleMusicSymbols {
                 emptyList()
             } else {
                 methods(
-                    namePredicate = { it.startsWith("com.apple.") },
+                    namePredicate = {
+                        it.startsWith("com.apple.android.music.ttml.SongInfoTimeProcessor\$")
+                    },
                     contract = { method -> isLyricsHighlightCallback(method, vector) },
                 )
             }
@@ -348,15 +393,16 @@ internal object AppleMusicSymbols {
         id = "lyrics-view-model",
         profileId = TargetSymbolId.LYRICS_VIEW_MODEL,
         stableName = "com.apple.android.music.player.viewmodel.PlayerLyricsViewModel",
-        fallbackName = { it.contains("PlayerLyricsViewModel", ignoreCase = true) },
+        fallbackName = { it.endsWith(".PlayerLyricsViewModel", ignoreCase = true) },
         contract = { true },
     )
 
     val StackedNavigationMenu = classSymbol(
         id = "stacked-navigation-menu",
         profileId = TargetSymbolId.STACKED_NAVIGATION_MENU,
+        stableName = "Hd.b",
         fallbackName = { false },
-        contract = { true },
+        contract = ::hasStackedNavigationMenuContract,
     )
 
     val SongInfoPtr = classSymbol(
@@ -397,25 +443,45 @@ internal object AppleMusicSymbols {
         contract = ::isLyricsInstallMethod,
     )
 
-    val PlayerMetadataPublishMethod = methodSymbol(
+    val PlayerMetadataPublishMethod = TargetSymbolKey(
         id = "player-metadata-publish-method",
-        profileOwner = TargetSymbolId.PLAYER_METADATA_HUB,
-        fallbackOwner = { it == "com.apple.android.music.player.f" },
-        contract = ::isPlayerMetadataPublishMethod,
+        profileBound = true,
+        profileCandidates = { profile ->
+            profile?.exactClasses?.get(TargetSymbolId.PLAYER_METADATA_HUB)
+                ?.let(::load)
+                ?.declaredMethods
+                ?.filter(::isPlayerMetadataPublishMethod)
+                .orEmpty()
+        },
+        structuralCandidates = {
+            val metadataType = metadataConverterCandidates().singleOrNull()
+                ?.parameterTypes
+                ?.singleOrNull()
+            if (metadataType == null) {
+                emptyList()
+            } else {
+                methods(::isShortPlayerClass) { method ->
+                    isStructuralPlayerMetadataPublishMethod(method, metadataType)
+                }
+            }
+        },
+        identity = ::methodIdentity,
     )
 
     val MetadataToPlaybackItemMethod = methodSymbol(
         id = "metadata-to-playback-item-method",
         profileOwner = TargetSymbolId.METADATA_TO_ITEM_CONVERTER,
-        fallbackOwner = { it == "com.apple.android.music.player.P" },
+        fallbackOwner = ::isShortPlayerClass,
         contract = ::isMetadataToPlaybackItemMethod,
+        structuralContract = ::isStructurallyMetadataToPlaybackItemMethod,
     )
 
     val LyricsAvailabilityPredicate = methodSymbol(
         id = "lyrics-availability-predicate",
         profileOwner = TargetSymbolId.LYRICS_AVAILABILITY_OWNER,
-        fallbackOwner = { it.startsWith("com.apple.android.music.player.") },
+        fallbackOwner = ::isShortPlayerClass,
         contract = ::isLyricsAvailabilityPredicate,
+        structuralContract = ::isStructurallyLyricsAvailabilityPredicate,
     )
 
     val TtmlSongInfoFromTtml = methodSymbol(
@@ -436,11 +502,36 @@ internal object AppleMusicSymbols {
      * the exact field name "c" plus the exact declared type, so a same-named
      * field of another type can never be selected silently.
      */
-    val LyricsCurrentItemField = fieldSymbol(
+    val LyricsCurrentItemField = TargetSymbolKey(
         id = "lyrics-current-item-field",
-        profileOwner = TargetSymbolId.LYRICS_CURRENT_ITEM_FIELD,
-        fallbackOwner = { it.startsWith("com.apple.android.music.player.fragment.") },
-        contract = ::isLyricsCurrentItemField,
+        profileBound = true,
+        profileCandidates = { profile ->
+            profile?.exactClasses?.get(TargetSymbolId.LYRICS_CURRENT_ITEM_FIELD)
+                ?.let(::load)
+                ?.declaredFields
+                ?.filter(::isLyricsCurrentItemField)
+                .orEmpty()
+        },
+        structuralCandidates = {
+            val lyricsFragment = load(
+                "com.apple.android.music.player.fragment.PlayerLyricsViewFragment",
+            )
+            if (lyricsFragment == null) {
+                fields(
+                    { it.startsWith("com.apple.android.music.player.fragment.") },
+                    ::isLyricsCurrentItemField,
+                )
+            } else {
+                val hierarchyFields = fields(
+                    { it.startsWith("com.apple.android.music.player.fragment.") },
+                    ::isStructurallyLyricsCurrentItemField,
+                ).filter { field ->
+                    field.declaringClass.isAssignableFrom(lyricsFragment)
+                }
+                hierarchyFields.filter { it.name == "c" }.ifEmpty { hierarchyFields }
+            }
+        },
+        identity = ::fieldIdentity,
     )
 
 }
@@ -453,6 +544,7 @@ private fun classSymbol(
     contract: (Class<*>) -> Boolean,
 ): TargetSymbolKey<Class<*>> = TargetSymbolKey(
     id = id,
+    profileBound = profileId != null,
     profileCandidates = { profile ->
         profileId?.let { profile?.exactClasses?.get(it) }
             ?.let(::load)
@@ -472,8 +564,10 @@ private fun methodSymbol(
     profileOwner: TargetSymbolId,
     fallbackOwner: (String) -> Boolean,
     contract: (Method) -> Boolean,
+    structuralContract: (Method) -> Boolean = contract,
 ): TargetSymbolKey<Method> = TargetSymbolKey(
     id = id,
+    profileBound = true,
     profileCandidates = { profile ->
         profile?.exactClasses?.get(profileOwner)
             ?.let(::load)
@@ -481,39 +575,33 @@ private fun methodSymbol(
             ?.filter(contract)
             .orEmpty()
     },
-    structuralCandidates = { methods(fallbackOwner, contract) },
+    structuralCandidates = { methods(fallbackOwner, structuralContract) },
     identity = ::methodIdentity,
-)
-
-private fun fieldSymbol(
-    id: String,
-    profileOwner: TargetSymbolId,
-    fallbackOwner: (String) -> Boolean,
-    contract: (Field) -> Boolean,
-): TargetSymbolKey<Field> = TargetSymbolKey(
-    id = id,
-    profileCandidates = { profile ->
-        profile?.exactClasses?.get(profileOwner)
-            ?.let(::load)
-            ?.declaredFields
-            ?.filter(contract)
-            .orEmpty()
-    },
-    structuralCandidates = { fields(fallbackOwner, contract) },
-    identity = ::fieldIdentity,
 )
 
 private fun hasLyricsChromeContract(candidate: Class<*>): Boolean =
     candidate.declaredMethods.any { method ->
         method.name == "a2" &&
+            !Modifier.isStatic(method.modifiers) &&
             method.returnType == Void.TYPE &&
             method.parameterTypes.contentEquals(
                 arrayOf(Int::class.javaPrimitiveType, IntArray::class.java),
             )
     } && candidate.declaredMethods.any { method ->
         method.name == "f2" &&
+            !Modifier.isStatic(method.modifiers) &&
             View::class.java.isAssignableFrom(method.returnType) &&
             method.parameterTypes.isEmpty()
+    }
+
+private fun hasStackedNavigationMenuContract(candidate: Class<*>): Boolean =
+    candidate.declaredMethods.any { method ->
+        method.name == "onMeasure" &&
+            !Modifier.isStatic(method.modifiers) &&
+            method.returnType == Void.TYPE &&
+            method.parameterTypes.contentEquals(
+                arrayOf(Int::class.javaPrimitiveType, Int::class.javaPrimitiveType),
+            )
     }
 
 private fun isEditorialVideoUrlSelector(method: Method): Boolean =
@@ -568,11 +656,34 @@ private fun isMetadataToPlaybackItemMethod(method: Method): Boolean =
         method.parameterTypes.singleOrNull()?.name == "v3.v" &&
         method.returnType.name == "com.apple.android.music.model.PlaybackItem"
 
+private fun isStructurallyMetadataToPlaybackItemMethod(method: Method): Boolean =
+    Modifier.isStatic(method.modifiers) &&
+        method.parameterTypes.singleOrNull()?.isPrimitive == false &&
+        method.returnType.name == "com.apple.android.music.model.PlaybackItem" &&
+        method.declaringClass.declaredMethods.any { sibling ->
+            Modifier.isStatic(sibling.modifiers) &&
+                sibling.parameterTypes.contentEquals(method.parameterTypes) &&
+                sibling.returnType.name == "com.apple.android.music.model.BaseContentItem"
+        }
+
 private fun isLyricsAvailabilityPredicate(method: Method): Boolean =
     Modifier.isStatic(method.modifiers) &&
         method.name == "i" &&
         method.returnType == Boolean::class.javaPrimitiveType &&
         method.parameterTypes.singleOrNull()?.name == "com.apple.android.music.model.PlaybackItem"
+
+private fun isStructurallyLyricsAvailabilityPredicate(method: Method): Boolean =
+    Modifier.isStatic(method.modifiers) &&
+        method.returnType == Boolean::class.javaPrimitiveType &&
+        method.parameterTypes.singleOrNull()?.name == "com.apple.android.music.model.PlaybackItem" &&
+        method.declaringClass.declaredMethods.any { sibling ->
+            Modifier.isStatic(sibling.modifiers) &&
+                sibling.returnType == Boolean::class.javaPrimitiveType &&
+                sibling.parameterTypes.size == 2 &&
+                sibling.parameterTypes.all {
+                    it.name == "com.apple.android.music.model.PlaybackItem"
+                }
+        }
 
 private fun isTtmlSongInfoFromTtml(method: Method): Boolean =
     !Modifier.isStatic(method.modifiers) &&
@@ -584,6 +695,29 @@ private fun isLyricsCurrentItemField(field: Field): Boolean =
     !Modifier.isStatic(field.modifiers) &&
         field.name == "c" &&
         field.type.name == "com.apple.android.music.model.BaseContentItem"
+
+private fun isStructurallyLyricsCurrentItemField(field: Field): Boolean =
+    !Modifier.isStatic(field.modifiers) &&
+        field.type.name == "com.apple.android.music.model.BaseContentItem"
+
+private fun TargetClassIndex.metadataConverterCandidates(): List<Method> =
+    methods(::isShortPlayerClass, ::isStructurallyMetadataToPlaybackItemMethod)
+
+private fun isStructuralPlayerMetadataPublishMethod(method: Method, metadataType: Class<*>): Boolean =
+    !Modifier.isStatic(method.modifiers) &&
+        method.name != "onMediaMetadataChanged" &&
+        method.returnType == Void.TYPE &&
+        method.parameterTypes.singleOrNull() == metadataType &&
+        method.declaringClass.declaredMethods.any { sibling ->
+            !Modifier.isStatic(sibling.modifiers) &&
+                sibling.name == "onMediaMetadataChanged" &&
+                sibling.returnType == Void.TYPE &&
+                sibling.parameterTypes.singleOrNull() == metadataType
+        }
+
+private fun isShortPlayerClass(name: String): Boolean =
+    name.startsWith("com.apple.android.music.player.") &&
+        name.substringAfterLast('.').substringBefore('$').length <= 3
 
 private fun hasSongInfoPtrContract(candidate: Class<*>): Boolean =
     candidate.declaredMethods.any { method ->

--- a/app/src/test/java/dev/amenhancer/module/hook/TargetSymbolsTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/TargetSymbolsTest.kt
@@ -73,7 +73,7 @@ class TargetSymbolsTest {
     }
 
     @Test
-    fun `unknown build does not trust the 650 exact profile`() {
+    fun `unknown build resolves the verified stable menu without trusting the 650 profile`() {
         val source = FakeTargetClassSource(classes = mapOf("Hd.b" to ProfileFixture::class.java))
         val resolver = IndexedTargetSymbolResolver(
             build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.6.0", 1600L),
@@ -82,13 +82,15 @@ class TargetSymbolsTest {
 
         val resolution = resolver.resolve(AppleMusicSymbols.StackedNavigationMenu)
 
-        assertTrue(resolution is TargetResolution.Missing)
-        assertEquals(1, source.classNameReads)
-        assertNull(source.loadCounts["Hd.b"])
+        assertTrue(resolution is TargetResolution.Found)
+        assertEquals(SymbolMatch.STABLE_NAME, (resolution as TargetResolution.Found).match)
+        assertNull(resolution.profileId)
+        assertEquals(0, source.classNameReads)
+        assertEquals(1, source.loadCounts["Hd.b"])
     }
 
     @Test
-    fun `mismatched version name does not trust a reused version code`() {
+    fun `mismatched version name uses stable discovery instead of a reused profile`() {
         val source = FakeTargetClassSource(classes = mapOf("Hd.b" to ProfileFixture::class.java))
         val resolver = IndexedTargetSymbolResolver(
             build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.1", 1580L),
@@ -97,8 +99,10 @@ class TargetSymbolsTest {
 
         val resolution = resolver.resolve(AppleMusicSymbols.StackedNavigationMenu)
 
-        assertTrue(resolution is TargetResolution.Missing)
-        assertNull(source.loadCounts["Hd.b"])
+        assertTrue(resolution is TargetResolution.Found)
+        assertEquals(SymbolMatch.STABLE_NAME, (resolution as TargetResolution.Found).match)
+        assertNull(resolution.profileId)
+        assertEquals(1, source.loadCounts["Hd.b"])
     }
 
     @Test
@@ -256,6 +260,38 @@ class TargetSymbolsTest {
     }
 
     @Test
+    fun `651 profile resolves the migrated custom lyrics identity funnel without scanning dex`() {
+        val source = FakeTargetClassSource(
+            classes = mapOf(
+                "com.apple.android.music.player.fragment.l" to CurrentItem651Fixture::class.java,
+                "com.apple.android.music.player.f" to PlayerMetadataHubFixture::class.java,
+                "com.apple.android.music.player.O" to MetadataConverterFixture::class.java,
+                "com.apple.android.music.player.e1" to LyricsAvailabilityFixture::class.java,
+            ),
+        )
+        val resolver = IndexedTargetSymbolResolver(
+            build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.1", 1583L),
+            source = source,
+        )
+
+        val currentItem = resolver.resolve(AppleMusicSymbols.LyricsCurrentItemField)
+        val publish = resolver.resolve(AppleMusicSymbols.PlayerMetadataPublishMethod)
+        val converter = resolver.resolve(AppleMusicSymbols.MetadataToPlaybackItemMethod)
+        val availability = resolver.resolve(AppleMusicSymbols.LyricsAvailabilityPredicate)
+
+        listOf(currentItem, publish, converter, availability).forEach { resolution ->
+            assertTrue(resolution is TargetResolution.Found)
+            assertEquals(SymbolMatch.VERSION_PROFILE, (resolution as TargetResolution.Found).match)
+            assertEquals("apple-music-6.5.1-1583", resolution.profileId)
+        }
+        assertEquals("c", (currentItem as TargetResolution.Found).value.name)
+        assertEquals("g", (publish as TargetResolution.Found).value.name)
+        assertEquals("b", (converter as TargetResolution.Found).value.name)
+        assertEquals("i", (availability as TargetResolution.Found).value.name)
+        assertEquals(0, source.classNameReads)
+    }
+
+    @Test
     fun `structural fallback never mistakes same-shaped R2 for I2`() {
         val fragmentName = "com.apple.android.music.player.fragment.PlayerLyricsViewFragment"
         val source = FakeTargetClassSource(
@@ -400,7 +436,16 @@ class TargetSymbolsTest {
     @Test
     fun `a contract broken current item field stays missing under the profile`() {
         val ownerName = "com.apple.android.music.player.fragment.m"
-        val source = FakeTargetClassSource(classes = mapOf(ownerName to mWrongType::class.java))
+        val source = FakeTargetClassSource(
+            names = listOf(
+                ownerName,
+                "com.apple.android.music.player.fragment.n",
+            ),
+            classes = mapOf(
+                ownerName to mWrongType::class.java,
+                "com.apple.android.music.player.fragment.n" to n::class.java,
+            ),
+        )
         val resolver = IndexedTargetSymbolResolver(
             build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.0", 1580L),
             source = source,
@@ -409,7 +454,151 @@ class TargetSymbolsTest {
         val resolution = resolver.resolve(AppleMusicSymbols.LyricsCurrentItemField)
 
         assertTrue(resolution is TargetResolution.Missing)
+        assertEquals(0, source.classNameReads)
         assertNull(source.loadCounts["com.apple.android.music.model.BaseContentItem"])
+    }
+
+    @Test
+    fun `a matched profile never guesses when its exact owner is missing`() {
+        val source = FakeTargetClassSource(
+            names = listOf("com.apple.android.music.player.fragment.n"),
+            classes = mapOf("com.apple.android.music.player.fragment.n" to n::class.java),
+        )
+        val resolver = IndexedTargetSymbolResolver(
+            build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.0", 1580L),
+            source = source,
+        )
+
+        val resolution = resolver.resolve(AppleMusicSymbols.LyricsCurrentItemField)
+
+        assertTrue(resolution is TargetResolution.Missing)
+        assertEquals(0, source.classNameReads)
+        assertEquals("apple-music-6.5.0-1580", (resolution as TargetResolution.Missing).profileId)
+    }
+
+    @Test
+    fun `unknown minor version discovers the migrated lyrics identity funnel by contract`() {
+        val fragmentName = "com.apple.android.music.player.fragment.PlayerLyricsViewFragment"
+        val currentItemOwner = "com.apple.android.music.player.fragment.z"
+        val metadataHub = "com.apple.android.music.player.y"
+        val metadataConverter = "com.apple.android.music.player.X"
+        val availabilityOwner = "com.apple.android.music.player.z1"
+        val source = FakeTargetClassSource(
+            names = listOf(
+                fragmentName,
+                currentItemOwner,
+                metadataHub,
+                metadataConverter,
+                availabilityOwner,
+                "com.apple.android.music.player.fragment.n",
+            ),
+            classes = mapOf(
+                fragmentName to CurrentLyricsFragmentFixture::class.java,
+                currentItemOwner to RenamedCurrentItemOwnerFixture::class.java,
+                metadataHub to RenamedPlayerMetadataHubFixture::class.java,
+                metadataConverter to RenamedMetadataConverterFixture::class.java,
+                availabilityOwner to RenamedLyricsAvailabilityFixture::class.java,
+                "com.apple.android.music.player.fragment.n" to n::class.java,
+            ),
+        )
+        val resolver = IndexedTargetSymbolResolver(
+            build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.2", 1590L),
+            source = source,
+        )
+
+        val currentItem = resolver.resolve(AppleMusicSymbols.LyricsCurrentItemField)
+        val publish = resolver.resolve(AppleMusicSymbols.PlayerMetadataPublishMethod)
+        val converter = resolver.resolve(AppleMusicSymbols.MetadataToPlaybackItemMethod)
+        val availability = resolver.resolve(AppleMusicSymbols.LyricsAvailabilityPredicate)
+
+        listOf(currentItem, publish, converter, availability).forEach { resolution ->
+            assertTrue(resolution is TargetResolution.Found)
+            assertEquals(SymbolMatch.STRUCTURAL_FALLBACK, (resolution as TargetResolution.Found).match)
+            assertNull(resolution.profileId)
+        }
+        assertEquals("renamedItem", (currentItem as TargetResolution.Found).value.name)
+        assertEquals("publish", (publish as TargetResolution.Found).value.name)
+        assertEquals("convert", (converter as TargetResolution.Found).value.name)
+        assertEquals("available", (availability as TargetResolution.Found).value.name)
+        assertEquals(1, source.classNameReads)
+    }
+
+    @Test
+    fun `unknown version reports ambiguous structural metadata converters`() {
+        val source = FakeTargetClassSource(
+            names = listOf(
+                "com.apple.android.music.player.X",
+                "com.apple.android.music.player.Y",
+            ),
+            classes = mapOf(
+                "com.apple.android.music.player.X" to RenamedMetadataConverterFixture::class.java,
+                "com.apple.android.music.player.Y" to SecondMetadataConverterFixture::class.java,
+            ),
+        )
+        val resolver = IndexedTargetSymbolResolver(TargetBuild.UNKNOWN, source)
+
+        val resolution = resolver.resolve(AppleMusicSymbols.MetadataToPlaybackItemMethod)
+
+        assertTrue(resolution is TargetResolution.Ambiguous)
+        assertEquals(2, (resolution as TargetResolution.Ambiguous).candidates.size)
+    }
+
+    @Test
+    fun `structural funnel rejects primary shapes without corroborating members`() {
+        val validConverter = "com.apple.android.music.player.X"
+        val weakConverter = "com.apple.android.music.player.Y"
+        val weakHub = "com.apple.android.music.player.z"
+        val weakAvailability = "com.apple.android.music.player.z1"
+        val source = FakeTargetClassSource(
+            names = listOf(validConverter, weakConverter, weakHub, weakAvailability),
+            classes = mapOf(
+                validConverter to RenamedMetadataConverterFixture::class.java,
+                weakConverter to PrimaryOnlyMetadataConverterFixture::class.java,
+                weakHub to PrimaryOnlyMetadataHubFixture::class.java,
+                weakAvailability to PrimaryOnlyLyricsAvailabilityFixture::class.java,
+            ),
+        )
+        val resolver = IndexedTargetSymbolResolver(TargetBuild.UNKNOWN, source)
+
+        val publish = resolver.resolve(AppleMusicSymbols.PlayerMetadataPublishMethod)
+        val availability = resolver.resolve(AppleMusicSymbols.LyricsAvailabilityPredicate)
+
+        assertTrue(publish is TargetResolution.Missing)
+        assertTrue(availability is TargetResolution.Missing)
+
+        val weakConverterResolver = IndexedTargetSymbolResolver(
+            TargetBuild.UNKNOWN,
+            FakeTargetClassSource(
+                names = listOf(weakConverter),
+                classes = mapOf(weakConverter to PrimaryOnlyMetadataConverterFixture::class.java),
+            ),
+        )
+        assertTrue(
+            weakConverterResolver.resolve(AppleMusicSymbols.MetadataToPlaybackItemMethod) is
+                TargetResolution.Missing,
+        )
+    }
+
+    @Test
+    fun `highlight callback structural fallback stays inside the session processor owner`() {
+        val vectorName = "com.apple.android.music.ttml.javanative.model.LyricsLineVector"
+        val callbackName = "com.apple.android.music.ttml.SongInfoTimeProcessor\$renamedCallback"
+        val decoyName = "com.apple.android.music.unrelated.Callback"
+        val source = FakeTargetClassSource(
+            names = listOf(vectorName, callbackName, decoyName),
+            classes = mapOf(
+                vectorName to ProfileVector::class.java,
+                callbackName to ProfileCallback::class.java,
+                decoyName to DecoyProfileCallback::class.java,
+            ),
+        )
+        val resolver = IndexedTargetSymbolResolver(TargetBuild.UNKNOWN, source)
+
+        val resolution = resolver.resolve(AppleMusicSymbols.LyricsHighlightCallback)
+
+        assertTrue(resolution is TargetResolution.Found)
+        assertEquals(SymbolMatch.STRUCTURAL_FALLBACK, (resolution as TargetResolution.Found).match)
+        assertNull(source.loadCounts[decoyName])
     }
 
     @Test
@@ -500,6 +689,89 @@ private class LyricsAvailabilityFixture {
     }
 }
 
+private class CurrentItem651Fixture {
+    val c: BaseContentItem = BaseContentItem()
+}
+
+private open class RenamedCurrentItemOwnerFixture {
+    val renamedItem: BaseContentItem = BaseContentItem()
+}
+
+private class CurrentLyricsFragmentFixture : RenamedCurrentItemOwnerFixture()
+
+private class RenamedPlayerMetadataHubFixture {
+    @Suppress("UNUSED_PARAMETER")
+    fun publish(metadata: v3.v) = Unit
+
+    @Suppress("UNUSED_PARAMETER")
+    fun onMediaMetadataChanged(metadata: v3.v) = Unit
+}
+
+private class RenamedMetadataConverterFixture {
+    companion object {
+        @JvmStatic
+        @Suppress("UNUSED_PARAMETER")
+        fun convert(metadata: v3.v): com.apple.android.music.model.PlaybackItem =
+            com.apple.android.music.model.PlaybackItem()
+
+        @JvmStatic
+        @Suppress("UNUSED_PARAMETER")
+        fun extract(metadata: v3.v): BaseContentItem = BaseContentItem()
+    }
+}
+
+private class SecondMetadataConverterFixture {
+    companion object {
+        @JvmStatic
+        @Suppress("UNUSED_PARAMETER")
+        fun transform(metadata: OtherMetadata): com.apple.android.music.model.PlaybackItem =
+            com.apple.android.music.model.PlaybackItem()
+
+        @JvmStatic
+        @Suppress("UNUSED_PARAMETER")
+        fun extract(metadata: OtherMetadata): BaseContentItem = BaseContentItem()
+    }
+}
+
+private class OtherMetadata
+
+private class PrimaryOnlyMetadataConverterFixture {
+    companion object {
+        @JvmStatic
+        @Suppress("UNUSED_PARAMETER")
+        fun convert(metadata: v3.v): com.apple.android.music.model.PlaybackItem =
+            com.apple.android.music.model.PlaybackItem()
+    }
+}
+
+private class PrimaryOnlyMetadataHubFixture {
+    @Suppress("UNUSED_PARAMETER")
+    fun publish(metadata: v3.v) = Unit
+}
+
+private class PrimaryOnlyLyricsAvailabilityFixture {
+    companion object {
+        @JvmStatic
+        @Suppress("UNUSED_PARAMETER")
+        fun available(item: com.apple.android.music.model.PlaybackItem): Boolean = false
+    }
+}
+
+private class RenamedLyricsAvailabilityFixture {
+    companion object {
+        @JvmStatic
+        @Suppress("UNUSED_PARAMETER")
+        fun available(item: com.apple.android.music.model.PlaybackItem): Boolean = false
+
+        @JvmStatic
+        @Suppress("UNUSED_PARAMETER")
+        fun changed(
+            first: com.apple.android.music.model.PlaybackItem,
+            second: com.apple.android.music.model.PlaybackItem,
+        ): Boolean = false
+    }
+}
+
 private class TtmlParserNativeFixture {
     @Suppress("UNUSED_PARAMETER")
     fun songInfoFromTTML(ttml: String): SongInfo.SongInfoPtr = SongInfo.SongInfoPtr()
@@ -532,9 +804,16 @@ private class FakeTargetClassSource(
     }
 }
 
-private class ProfileFixture
+private class ProfileFixture {
+    @Suppress("UNUSED_PARAMETER")
+    fun onMeasure(width: Int, height: Int) = Unit
+}
 private class ProfileVector
 private class ProfileCallback {
+    @Suppress("UNUSED_PARAMETER")
+    fun call(time: Long, lines: ProfileVector, position: Long) = Unit
+}
+private class DecoyProfileCallback {
     @Suppress("UNUSED_PARAMETER")
     fun call(time: Long, lines: ProfileVector, position: Long) = Unit
 }


### PR DESCRIPTION
## Summary
- add the verified Apple Music 6.5.1/1583 target profile
- add fail-closed structural discovery for compatible unknown minor versions
- correct the 6.5.1 current-item owner to player.fragment.l and restore current-song ID requests
- narrow callback and metadata discovery to corroborated contracts

## Testing
- .\gradlew.bat test assembleDebug assembleRelease lintVitalRelease --offline
- git diff --check
- installed the release on Apple Music 6.5.1/1583 and verified the current-song request receiver registers after restart