### PR TITLE
Allow safe fallback from stale Apple Music profiles

### DIFF
--- a/app/src/main/java/dev/amenhancer/module/hook/TargetSymbols.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/TargetSymbols.kt
@@ -120,11 +120,19 @@ internal class TargetClassIndex(private val source: TargetClassSource) {
 internal class TargetSymbolKey<T : Any>(
     val id: String,
     internal val profileCandidates: TargetClassIndex.(AppleMusicProfile?) -> List<T> = { emptyList() },
-    internal val profileBound: Boolean = false,
+    internal val profilePolicy: ProfilePolicy = ProfilePolicy.NO_PROFILE,
     internal val stableCandidates: TargetClassIndex.() -> List<T> = { emptyList() },
     internal val structuralCandidates: TargetClassIndex.() -> List<T>,
     internal val identity: (T) -> String,
 )
+
+internal enum class ProfilePolicy {
+    NO_PROFILE,
+    /** The verified identity is authoritative; a stale profile degrades this symbol. */
+    EXACT_REQUIRED,
+    /** Try the verified identity first, then the symbol's reviewed safe fallback contract. */
+    EXACT_PREFERRED,
+}
 
 internal interface TargetSymbolResolver {
     fun <T : Any> resolve(symbol: TargetSymbolKey<T>): TargetResolution<T>
@@ -146,12 +154,15 @@ internal class IndexedTargetSymbolResolver(
         }
 
     private fun <T : Any> resolveUncached(symbol: TargetSymbolKey<T>): TargetResolution<T> {
-        if (profile != null && symbol.profileBound) {
-            return select(
+        if (profile != null && symbol.profilePolicy != ProfilePolicy.NO_PROFILE) {
+            select(
                 symbol,
                 symbol.profileCandidates(index, profile),
                 SymbolMatch.VERSION_PROFILE,
-            ) ?: TargetResolution.Missing(symbol.id, profile.id)
+            )?.let { return it }
+            if (symbol.profilePolicy == ProfilePolicy.EXACT_REQUIRED) {
+                return TargetResolution.Missing(symbol.id, profile.id)
+            }
         }
         select(symbol, symbol.stableCandidates(index), SymbolMatch.STABLE_NAME)?.let { return it }
         val fallback = distinctCandidates(symbol, symbol.structuralCandidates(index))
@@ -299,6 +310,7 @@ internal object AppleMusicSymbols {
     val PlayerActivity = classSymbol(
         id = "player-activity",
         profileId = TargetSymbolId.PLAYER_ACTIVITY,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
         fallbackName = { it.endsWith(".common.activity.PlayerActivity") },
         contract = { true },
     )
@@ -306,6 +318,7 @@ internal object AppleMusicSymbols {
     val EditorialVideoUrlSelector = methodSymbol(
         id = "editorial-video-url-selector",
         profileOwner = TargetSymbolId.EDITORIAL_VIDEO_OWNER,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
         fallbackOwner = { name ->
             name.startsWith("com.apple.android.music.player.") &&
                 name.substringAfterLast('.').substringBefore('$').length <= 3
@@ -316,6 +329,7 @@ internal object AppleMusicSymbols {
     val LyricsFragment = classSymbol(
         id = "lyrics-fragment",
         profileId = TargetSymbolId.LYRICS_FRAGMENT,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
         fallbackName = { it.endsWith(".PlayerLyricsViewFragment") },
         contract = { true },
     )
@@ -337,6 +351,7 @@ internal object AppleMusicSymbols {
     val LyricsLineVector = classSymbol(
         id = "lyrics-line-vector",
         profileId = TargetSymbolId.LYRICS_LINE_VECTOR,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
         stableName = "com.apple.android.music.ttml.javanative.model.LyricsLineVector",
         fallbackName = { it.endsWith(".ttml.javanative.model.LyricsLineVector") },
         contract = { true },
@@ -345,13 +360,14 @@ internal object AppleMusicSymbols {
     val LyricsSessionProcessor = methodSymbol(
         id = "lyrics-session-processor",
         profileOwner = TargetSymbolId.LYRICS_EVENT_PROCESSOR,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
         fallbackOwner = { it.endsWith(".ttml.SongInfoTimeProcessor") },
         contract = ::isLyricsSessionProcessor,
     )
 
     val LyricsHighlightCallback = TargetSymbolKey(
         id = "lyrics-highlight-callback",
-        profileBound = true,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
         profileCandidates = { profile ->
             val owner = profile?.exactClasses?.get(TargetSymbolId.LYRICS_HIGHLIGHT_CALLBACK_OWNER)
                 ?.let(::load)
@@ -392,6 +408,7 @@ internal object AppleMusicSymbols {
     val LyricsViewModel = classSymbol(
         id = "lyrics-view-model",
         profileId = TargetSymbolId.LYRICS_VIEW_MODEL,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
         stableName = "com.apple.android.music.player.viewmodel.PlayerLyricsViewModel",
         fallbackName = { it.endsWith(".PlayerLyricsViewModel", ignoreCase = true) },
         contract = { true },
@@ -408,6 +425,7 @@ internal object AppleMusicSymbols {
     val SongInfoPtr = classSymbol(
         id = "song-info-ptr",
         profileId = TargetSymbolId.SONG_INFO_PTR,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
         stableName = "com.apple.android.music.ttml.javanative.model.SongInfo\$SongInfoPtr",
         fallbackName = { it.endsWith(".ttml.javanative.model.SongInfo\$SongInfoPtr") },
         contract = ::hasSongInfoPtrContract,
@@ -416,6 +434,7 @@ internal object AppleMusicSymbols {
     val SongInfoNative = classSymbol(
         id = "song-info-native",
         profileId = TargetSymbolId.SONG_INFO_NATIVE,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
         stableName = "com.apple.android.music.ttml.javanative.model.SongInfo\$SongInfoNative",
         fallbackName = { it.endsWith(".ttml.javanative.model.SongInfo\$SongInfoNative") },
         contract = ::hasSongInfoNativeContract,
@@ -424,6 +443,7 @@ internal object AppleMusicSymbols {
     val TtmlParserNative = classSymbol(
         id = "ttml-parser-native",
         profileId = TargetSymbolId.TTML_PARSER_NATIVE,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
         stableName = "com.apple.android.music.ttml.javanative.TTMLParser\$TTMLParserNative",
         fallbackName = { it.endsWith(".ttml.javanative.TTMLParser\$TTMLParserNative") },
         contract = ::hasTtmlParserNativeContract,
@@ -445,7 +465,7 @@ internal object AppleMusicSymbols {
 
     val PlayerMetadataPublishMethod = TargetSymbolKey(
         id = "player-metadata-publish-method",
-        profileBound = true,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
         profileCandidates = { profile ->
             profile?.exactClasses?.get(TargetSymbolId.PLAYER_METADATA_HUB)
                 ?.let(::load)
@@ -471,6 +491,7 @@ internal object AppleMusicSymbols {
     val MetadataToPlaybackItemMethod = methodSymbol(
         id = "metadata-to-playback-item-method",
         profileOwner = TargetSymbolId.METADATA_TO_ITEM_CONVERTER,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
         fallbackOwner = ::isShortPlayerClass,
         contract = ::isMetadataToPlaybackItemMethod,
         structuralContract = ::isStructurallyMetadataToPlaybackItemMethod,
@@ -479,6 +500,7 @@ internal object AppleMusicSymbols {
     val LyricsAvailabilityPredicate = methodSymbol(
         id = "lyrics-availability-predicate",
         profileOwner = TargetSymbolId.LYRICS_AVAILABILITY_OWNER,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
         fallbackOwner = ::isShortPlayerClass,
         contract = ::isLyricsAvailabilityPredicate,
         structuralContract = ::isStructurallyLyricsAvailabilityPredicate,
@@ -487,6 +509,7 @@ internal object AppleMusicSymbols {
     val TtmlSongInfoFromTtml = methodSymbol(
         id = "ttml-song-info-from-ttml",
         profileOwner = TargetSymbolId.TTML_PARSER_NATIVE,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
         fallbackOwner = { it.endsWith(".ttml.javanative.TTMLParser\$TTMLParserNative") },
         contract = ::isTtmlSongInfoFromTtml,
     )
@@ -499,12 +522,13 @@ internal object AppleMusicSymbols {
      * SongInfoPtr whose Adam ID differs — so the incoming pointer can be a
      * stale leftover from a previous song, and this field is the only
      * authoritative song identity for every I2 entry. The contract requires
-     * the exact field name "c" plus the exact declared type, so a same-named
-     * field of another type can never be selected silently.
+     * the exact field name "c" plus the exact declared type. If a profile pin
+     * is stale, structural discovery is restricted to the lyrics fragment's
+     * hierarchy and accepts only a unique BaseContentItem field.
      */
     val LyricsCurrentItemField = TargetSymbolKey(
         id = "lyrics-current-item-field",
-        profileBound = true,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
         profileCandidates = { profile ->
             profile?.exactClasses?.get(TargetSymbolId.LYRICS_CURRENT_ITEM_FIELD)
                 ?.let(::load)
@@ -517,10 +541,7 @@ internal object AppleMusicSymbols {
                 "com.apple.android.music.player.fragment.PlayerLyricsViewFragment",
             )
             if (lyricsFragment == null) {
-                fields(
-                    { it.startsWith("com.apple.android.music.player.fragment.") },
-                    ::isLyricsCurrentItemField,
-                )
+                emptyList()
             } else {
                 val hierarchyFields = fields(
                     { it.startsWith("com.apple.android.music.player.fragment.") },
@@ -539,12 +560,17 @@ internal object AppleMusicSymbols {
 private fun classSymbol(
     id: String,
     profileId: TargetSymbolId? = null,
+    profilePolicy: ProfilePolicy = if (profileId == null) {
+        ProfilePolicy.NO_PROFILE
+    } else {
+        ProfilePolicy.EXACT_REQUIRED
+    },
     stableName: String? = null,
     fallbackName: (String) -> Boolean,
     contract: (Class<*>) -> Boolean,
 ): TargetSymbolKey<Class<*>> = TargetSymbolKey(
     id = id,
-    profileBound = profileId != null,
+    profilePolicy = profilePolicy,
     profileCandidates = { profile ->
         profileId?.let { profile?.exactClasses?.get(it) }
             ?.let(::load)
@@ -562,12 +588,13 @@ private fun classSymbol(
 private fun methodSymbol(
     id: String,
     profileOwner: TargetSymbolId,
+    profilePolicy: ProfilePolicy = ProfilePolicy.EXACT_REQUIRED,
     fallbackOwner: (String) -> Boolean,
     contract: (Method) -> Boolean,
     structuralContract: (Method) -> Boolean = contract,
 ): TargetSymbolKey<Method> = TargetSymbolKey(
     id = id,
-    profileBound = true,
+    profilePolicy = profilePolicy,
     profileCandidates = { profile ->
         profile?.exactClasses?.get(profileOwner)
             ?.let(::load)

--- a/app/src/main/java/dev/amenhancer/module/hook/TargetSymbols.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/TargetSymbols.kt
@@ -549,7 +549,7 @@ internal object AppleMusicSymbols {
                 ).filter { field ->
                     field.declaringClass.isAssignableFrom(lyricsFragment)
                 }
-                hierarchyFields.filter { it.name == "c" }.ifEmpty { hierarchyFields }
+                hierarchyFields
             }
         },
         identity = ::fieldIdentity,

--- a/app/src/test/java/dev/amenhancer/module/hook/TargetSymbolsTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/TargetSymbolsTest.kt
@@ -459,21 +459,108 @@ class TargetSymbolsTest {
     }
 
     @Test
-    fun `a matched profile never guesses when its exact owner is missing`() {
+    fun `exact required profile policy never scans structural candidates`() {
         val source = FakeTargetClassSource(
-            names = listOf("com.apple.android.music.player.fragment.n"),
-            classes = mapOf("com.apple.android.music.player.fragment.n" to n::class.java),
+            names = listOf("com.apple.structural.Decoy"),
+            classes = mapOf("com.apple.structural.Decoy" to FirstFixture::class.java),
         )
         val resolver = IndexedTargetSymbolResolver(
             build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.0", 1580L),
             source = source,
         )
+        val symbol = TargetSymbolKey(
+            id = "exact-required-fixture",
+            profilePolicy = ProfilePolicy.EXACT_REQUIRED,
+            structuralCandidates = { classes({ true }) { true } },
+            identity = { type: Class<*> -> type.name },
+        )
 
-        val resolution = resolver.resolve(AppleMusicSymbols.LyricsCurrentItemField)
+        val resolution = resolver.resolve(symbol)
 
         assertTrue(resolution is TargetResolution.Missing)
         assertEquals(0, source.classNameReads)
-        assertEquals("apple-music-6.5.0-1580", (resolution as TargetResolution.Missing).profileId)
+    }
+
+    @Test
+    fun `ambiguous exact preferred profile candidates never fall through`() {
+        val source = FakeTargetClassSource(
+            names = listOf("com.apple.structural.Fallback"),
+            classes = mapOf("com.apple.structural.Fallback" to ProfileFixture::class.java),
+        )
+        val resolver = IndexedTargetSymbolResolver(
+            build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.0", 1580L),
+            source = source,
+        )
+        val symbol = TargetSymbolKey(
+            id = "ambiguous-preferred-fixture",
+            profilePolicy = ProfilePolicy.EXACT_PREFERRED,
+            profileCandidates = { listOf(FirstFixture::class.java, SecondFixture::class.java) },
+            structuralCandidates = { classes({ true }) { true } },
+            identity = { type: Class<*> -> type.name },
+        )
+
+        val resolution = resolver.resolve(symbol)
+
+        assertTrue(resolution is TargetResolution.Ambiguous)
+        assertEquals(0, source.classNameReads)
+    }
+
+    @Test
+    fun `profile backed symbols declare reviewed fallback policies`() {
+        listOf(
+            AppleMusicSymbols.PlayerController,
+            AppleMusicSymbols.LyricsChromeFragment,
+            AppleMusicSymbols.StackedNavigationMenu,
+            AppleMusicSymbols.LyricsInstallMethod,
+        ).forEach { symbol ->
+            assertEquals(ProfilePolicy.EXACT_REQUIRED, symbol.profilePolicy)
+        }
+        listOf(
+            AppleMusicSymbols.PlayerActivity,
+            AppleMusicSymbols.EditorialVideoUrlSelector,
+            AppleMusicSymbols.LyricsFragment,
+            AppleMusicSymbols.LyricsLineVector,
+            AppleMusicSymbols.LyricsSessionProcessor,
+            AppleMusicSymbols.LyricsHighlightCallback,
+            AppleMusicSymbols.LyricsViewModel,
+            AppleMusicSymbols.SongInfoPtr,
+            AppleMusicSymbols.SongInfoNative,
+            AppleMusicSymbols.TtmlParserNative,
+            AppleMusicSymbols.PlayerMetadataPublishMethod,
+            AppleMusicSymbols.MetadataToPlaybackItemMethod,
+            AppleMusicSymbols.LyricsAvailabilityPredicate,
+            AppleMusicSymbols.TtmlSongInfoFromTtml,
+            AppleMusicSymbols.LyricsCurrentItemField,
+        ).forEach { symbol ->
+            assertEquals(ProfilePolicy.EXACT_PREFERRED, symbol.profilePolicy)
+        }
+        assertEquals(ProfilePolicy.NO_PROFILE, AppleMusicSymbols.RecyclerView.profilePolicy)
+    }
+
+    @Test
+    fun `a matched profile falls back to the verified current item hierarchy when its owner is stale`() {
+        val fragmentName = "com.apple.android.music.player.fragment.PlayerLyricsViewFragment"
+        val currentItemOwner = "com.apple.android.music.player.fragment.z"
+        val source = FakeTargetClassSource(
+            names = listOf(fragmentName, currentItemOwner),
+            classes = mapOf(
+                fragmentName to CurrentLyricsFragmentFixture::class.java,
+                currentItemOwner to RenamedCurrentItemOwnerFixture::class.java,
+            ),
+        )
+        val resolver = IndexedTargetSymbolResolver(
+            build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.1", 1583L),
+            source = source,
+        )
+
+        val resolution = resolver.resolve(AppleMusicSymbols.LyricsCurrentItemField)
+
+        assertTrue(resolution is TargetResolution.Found)
+        resolution as TargetResolution.Found
+        assertEquals(SymbolMatch.STRUCTURAL_FALLBACK, resolution.match)
+        assertEquals("renamedItem", resolution.value.name)
+        assertEquals("apple-music-6.5.1-1583", resolution.profileId)
+        assertEquals(1, source.classNameReads)
     }
 
     @Test
@@ -524,7 +611,7 @@ class TargetSymbolsTest {
     }
 
     @Test
-    fun `unknown version reports ambiguous structural metadata converters`() {
+    fun `matched profile reports ambiguous structural metadata converters`() {
         val source = FakeTargetClassSource(
             names = listOf(
                 "com.apple.android.music.player.X",
@@ -535,12 +622,17 @@ class TargetSymbolsTest {
                 "com.apple.android.music.player.Y" to SecondMetadataConverterFixture::class.java,
             ),
         )
-        val resolver = IndexedTargetSymbolResolver(TargetBuild.UNKNOWN, source)
+        val resolver = IndexedTargetSymbolResolver(
+            TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.1", 1583L),
+            source,
+        )
 
         val resolution = resolver.resolve(AppleMusicSymbols.MetadataToPlaybackItemMethod)
 
         assertTrue(resolution is TargetResolution.Ambiguous)
-        assertEquals(2, (resolution as TargetResolution.Ambiguous).candidates.size)
+        resolution as TargetResolution.Ambiguous
+        assertEquals(2, resolution.candidates.size)
+        assertEquals("apple-music-6.5.1-1583", resolution.profileId)
     }
 
     @Test
@@ -558,7 +650,10 @@ class TargetSymbolsTest {
                 weakAvailability to PrimaryOnlyLyricsAvailabilityFixture::class.java,
             ),
         )
-        val resolver = IndexedTargetSymbolResolver(TargetBuild.UNKNOWN, source)
+        val resolver = IndexedTargetSymbolResolver(
+            TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.1", 1583L),
+            source,
+        )
 
         val publish = resolver.resolve(AppleMusicSymbols.PlayerMetadataPublishMethod)
         val availability = resolver.resolve(AppleMusicSymbols.LyricsAvailabilityPredicate)
@@ -592,7 +687,10 @@ class TargetSymbolsTest {
                 decoyName to DecoyProfileCallback::class.java,
             ),
         )
-        val resolver = IndexedTargetSymbolResolver(TargetBuild.UNKNOWN, source)
+        val resolver = IndexedTargetSymbolResolver(
+            TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.1", 1583L),
+            source,
+        )
 
         val resolution = resolver.resolve(AppleMusicSymbols.LyricsHighlightCallback)
 
@@ -603,27 +701,30 @@ class TargetSymbolsTest {
 
     @Test
     fun `structural ambiguity of the current item field is reported instead of a silent first match`() {
+        val fragmentName = "com.apple.android.music.player.fragment.PlayerLyricsViewFragment"
+        val ownerName = "com.apple.android.music.player.fragment.z"
         val source = FakeTargetClassSource(
-            names = listOf(
-                "com.apple.android.music.player.fragment.m",
-                "com.apple.android.music.player.fragment.n",
-            ),
+            names = listOf(fragmentName, ownerName),
             classes = mapOf(
-                "com.apple.android.music.player.fragment.m" to m::class.java,
-                "com.apple.android.music.player.fragment.n" to n::class.java,
+                fragmentName to AmbiguousLyricsFragmentFixture::class.java,
+                ownerName to AmbiguousCurrentItemOwnerFixture::class.java,
             ),
         )
-        val resolver = IndexedTargetSymbolResolver(TargetBuild.UNKNOWN, source)
+        val resolver = IndexedTargetSymbolResolver(
+            TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.1", 1583L),
+            source,
+        )
 
         val resolution = resolver.resolve(AppleMusicSymbols.LyricsCurrentItemField)
 
         assertTrue(resolution is TargetResolution.Ambiguous)
         resolution as TargetResolution.Ambiguous
         assertEquals(2, resolution.candidates.size)
+        assertEquals("apple-music-6.5.1-1583", resolution.profileId)
         assertTrue(
             resolution.candidates.any { candidate ->
                 candidate.contains(
-                    "com.apple.android.music.player.fragment.m#c:" +
+                    "AmbiguousCurrentItemOwnerFixture#first:" +
                         "com.apple.android.music.model.BaseContentItem",
                 )
             },
@@ -632,10 +733,14 @@ class TargetSymbolsTest {
 
     @Test
     fun `structural fallback uniquely finds the current item field`() {
-        val ownerName = "com.apple.android.music.player.fragment.m"
+        val fragmentName = "com.apple.android.music.player.fragment.PlayerLyricsViewFragment"
+        val ownerName = "com.apple.android.music.player.fragment.z"
         val source = FakeTargetClassSource(
-            names = listOf(ownerName),
-            classes = mapOf(ownerName to m::class.java),
+            names = listOf(fragmentName, ownerName),
+            classes = mapOf(
+                fragmentName to CurrentLyricsFragmentFixture::class.java,
+                ownerName to RenamedCurrentItemOwnerFixture::class.java,
+            ),
         )
         val resolver = IndexedTargetSymbolResolver(TargetBuild.UNKNOWN, source)
 
@@ -643,7 +748,7 @@ class TargetSymbolsTest {
 
         assertTrue(resolution is TargetResolution.Found)
         assertEquals(SymbolMatch.STRUCTURAL_FALLBACK, (resolution as TargetResolution.Found).match)
-        assertEquals("c", resolution.value.name)
+        assertEquals("renamedItem", resolution.value.name)
         assertEquals(BaseContentItem::class.java, resolution.value.type)
     }
 
@@ -698,6 +803,13 @@ private open class RenamedCurrentItemOwnerFixture {
 }
 
 private class CurrentLyricsFragmentFixture : RenamedCurrentItemOwnerFixture()
+
+private open class AmbiguousCurrentItemOwnerFixture {
+    val first: BaseContentItem = BaseContentItem()
+    val second: BaseContentItem = BaseContentItem()
+}
+
+private class AmbiguousLyricsFragmentFixture : AmbiguousCurrentItemOwnerFixture()
 
 private class RenamedPlayerMetadataHubFixture {
     @Suppress("UNUSED_PARAMETER")

--- a/app/src/test/java/dev/amenhancer/module/hook/TargetSymbolsTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/TargetSymbolsTest.kt
@@ -732,6 +732,30 @@ class TargetSymbolsTest {
     }
 
     @Test
+    fun `stale profile rejects an old c field beside a renamed current item field`() {
+        val fragmentName = "com.apple.android.music.player.fragment.PlayerLyricsViewFragment"
+        val ownerName = "com.apple.android.music.player.fragment.z"
+        val source = FakeTargetClassSource(
+            names = listOf(fragmentName, ownerName),
+            classes = mapOf(
+                fragmentName to MixedCurrentItemFragmentFixture::class.java,
+                ownerName to MixedCurrentItemOwnerFixture::class.java,
+            ),
+        )
+        val resolver = IndexedTargetSymbolResolver(
+            TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.1", 1583L),
+            source,
+        )
+
+        val resolution = resolver.resolve(AppleMusicSymbols.LyricsCurrentItemField)
+
+        assertTrue(resolution is TargetResolution.Ambiguous)
+        resolution as TargetResolution.Ambiguous
+        assertEquals(2, resolution.candidates.size)
+        assertEquals("apple-music-6.5.1-1583", resolution.profileId)
+    }
+
+    @Test
     fun `structural fallback uniquely finds the current item field`() {
         val fragmentName = "com.apple.android.music.player.fragment.PlayerLyricsViewFragment"
         val ownerName = "com.apple.android.music.player.fragment.z"
@@ -810,6 +834,13 @@ private open class AmbiguousCurrentItemOwnerFixture {
 }
 
 private class AmbiguousLyricsFragmentFixture : AmbiguousCurrentItemOwnerFixture()
+
+private open class MixedCurrentItemOwnerFixture {
+    val c: BaseContentItem = BaseContentItem()
+    val renamedItem: BaseContentItem = BaseContentItem()
+}
+
+private class MixedCurrentItemFragmentFixture : MixedCurrentItemOwnerFixture()
 
 private class RenamedPlayerMetadataHubFixture {
     @Suppress("UNUSED_PARAMETER")


### PR DESCRIPTION
## Summary
- replace the all-or-nothing profile gate with per-symbol policies
- keep weak targets such as I2, player controller, lyrics chrome, and Hd.b exact-required
- let stable and corroborated targets recover through reviewed fallback contracts when a profile pin is stale
- require current-item fallback candidates to belong to the PlayerLyricsViewFragment hierarchy
- preserve fail-closed ambiguity handling

## Testing
- .\gradlew.bat test assembleDebug assembleRelease lintVitalRelease --offline
- git diff --check
- installed the release on Apple Music 6.5.1/1583 and verified the current-song request receiver still registers after restart