### PR TITLE
Deepen Apple Music hook target symbols

### DIFF
--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicBidirectionalLyricBlurTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicBidirectionalLyricBlurTarget.kt
@@ -27,12 +27,22 @@ internal class AppleMusicBidirectionalLyricBlurTarget(
         val vectorResolution = symbols.resolve(AppleMusicSymbols.LyricsLineVector)
         val sessionResolution = symbols.resolve(AppleMusicSymbols.LyricsSessionProcessor)
         val callbackResolution = symbols.resolve(AppleMusicSymbols.LyricsHighlightCallback)
-        val viewModelResolution = symbols.resolve(AppleMusicSymbols.LyricsViewModel)
+        val notifyWordHighlightResolution = symbols.resolve(
+            AppleMusicSymbols.LyricsViewModelNotifyWordHighlight,
+        )
+        val setCurrentHighlightedLineResolution = symbols.resolve(
+            AppleMusicSymbols.LyricsViewModelSetCurrentHighlightedLine,
+        )
         val callback = callbackResolution.valueOrNull()
-        val viewModel = viewModelResolution.valueOrNull()
-        if (callback == null && viewModel == null) {
+        val notifyWordHighlight = notifyWordHighlightResolution.valueOrNull()
+        val setCurrentHighlightedLine = setCurrentHighlightedLineResolution.valueOrNull()
+        if (callback == null && notifyWordHighlight == null && setCurrentHighlightedLine == null) {
             return TargetCapabilityInstall.Degraded(
-                listOf(callbackResolution, viewModelResolution).joinToString { it.summary },
+                listOf(
+                    callbackResolution,
+                    notifyWordHighlightResolution,
+                    setCurrentHighlightedLineResolution,
+                ).joinToString { it.summary },
             )
         }
 
@@ -48,13 +58,14 @@ internal class AppleMusicBidirectionalLyricBlurTarget(
         hookSessionProcessor(sessionResolution.valueOrNull(), runtime)
         hookHighlightCallback(callback, vectorResolution.valueOrNull(), highlights)
         hookLyricsFragment(fragmentClass, runtime)
-        hookViewModel(viewModel, highlights)
+        hookViewModel(notifyWordHighlight, setCurrentHighlightedLine, highlights)
 
         val optionalFailures = listOf(
             vectorResolution,
             sessionResolution,
             callbackResolution,
-            viewModelResolution,
+            notifyWordHighlightResolution,
+            setCurrentHighlightedLineResolution,
         ).filterNot { it is TargetResolution.Found<*> }
         return if (optionalFailures.isEmpty()) {
             TargetCapabilityInstall.Active(
@@ -169,21 +180,18 @@ internal class AppleMusicBidirectionalLyricBlurTarget(
                 }
             }
 
-    private fun hookViewModel(vmClass: Class<*>?, highlights: LyricHighlightEventRouter) {
-        if (vmClass == null) {
-            Log.w(TAG, "VM symbol was unavailable")
+    private fun hookViewModel(
+        notifyWordHighlight: Method?,
+        setCurrentHighlightedLine: Method?,
+        highlights: LyricHighlightEventRouter,
+    ) {
+        if (notifyWordHighlight == null && setCurrentHighlightedLine == null) {
+            Log.w(TAG, "VM method symbols were unavailable")
             return
         }
         try {
-            Log.i(TAG, "Found VM")
-            vmClass.declaredMethods.forEach { method ->
-                val parameters = method.parameterTypes
-                if (
-                    parameters.size == 4 &&
-                    parameters[0] == Int::class.javaPrimitiveType &&
-                    parameters[3] == Boolean::class.javaPrimitiveType
-                ) {
-                    ModernXposedRuntime.hookMethod(method, object : XC_MethodHook() {
+            if (notifyWordHighlight != null) {
+                ModernXposedRuntime.hookMethod(notifyWordHighlight, object : XC_MethodHook() {
                         override fun beforeHookedMethod(param: MethodHookParam) {
                             highlights.onFourArgumentViewModelEvent(
                                 lineId = param.args[0] as Int,
@@ -191,21 +199,13 @@ internal class AppleMusicBidirectionalLyricBlurTarget(
                             )
                         }
                     })
-                }
             }
-            vmClass.declaredMethods.forEach { method ->
-                val parameters = method.parameterTypes
-                if (
-                    parameters.size == 1 &&
-                    parameters[0] == Int::class.javaPrimitiveType &&
-                    method.returnType == Void.TYPE
-                ) {
-                    ModernXposedRuntime.hookMethod(method, object : XC_MethodHook() {
+            if (setCurrentHighlightedLine != null) {
+                ModernXposedRuntime.hookMethod(setCurrentHighlightedLine, object : XC_MethodHook() {
                         override fun beforeHookedMethod(param: MethodHookParam) {
                             highlights.onSingleArgumentViewModelEvent(param.args[0] as Int)
                         }
                     })
-                }
             }
         } catch (t: Throwable) {
             Log.w(TAG, "VM hook failed: ${t.message}")

--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
@@ -266,51 +266,67 @@ internal class AppleMusicDualPaneTarget(
     private val anchorResizeListeners = WeakHashMap<View, View.OnLayoutChangeListener>()
 
     override fun install(): TargetCapabilityInstall {
-        val controllerResolution = symbols.resolve(AppleMusicSymbols.PlayerController)
-        val controller = controllerResolution.valueOrNull()
-            ?: return TargetCapabilityInstall.Degraded(controllerResolution.summary)
-        val controllerHooks = installControllerHooks(controller)
-        val navigationMenuResolution = symbols.resolve(AppleMusicSymbols.StackedNavigationMenu)
+        val controllerInitializeResolution = symbols.resolve(AppleMusicSymbols.PlayerControllerInitialize)
+        val controllerCreateViewResolution = symbols.resolve(AppleMusicSymbols.PlayerControllerCreateView)
+        val controllerSelectPaneResolution = symbols.resolve(AppleMusicSymbols.PlayerControllerSelectPane)
+        val controllerHooks = installControllerHooks(
+            controllerInitializeResolution.valueOrNull(),
+            controllerCreateViewResolution.valueOrNull(),
+            controllerSelectPaneResolution.valueOrNull(),
+        )
+        val navigationMenuResolution = symbols.resolve(AppleMusicSymbols.StackedNavigationMenuOnMeasure)
         val navigationMenuMeasureHooks = installStackedBottomNavigationMenuMeasureHook(
             navigationMenuResolution.valueOrNull(),
         )
-        val activityResolution = symbols.resolve(AppleMusicSymbols.PlayerActivity)
-        val chromeHooks = activityResolution.valueOrNull()?.let { activityClass ->
-            installNativeStackedNavigationHolderHook(activityClass)
-        } ?: 0
+        val activityResolution = symbols.resolve(AppleMusicSymbols.PlayerActivityCreateStackedNavigationHolder)
+        val chromeHooks = installNativeStackedNavigationHolderHook(activityResolution.valueOrNull())
         val lyricsFragmentResolution = symbols.resolve(AppleMusicSymbols.LyricsFragment)
         val lyricsFragmentClass = lyricsFragmentResolution.valueOrNull()
-        val lyricsChromeResolution = symbols.resolve(AppleMusicSymbols.LyricsChromeFragment)
-        val lyricsChromeHooks = lyricsChromeResolution.valueOrNull()?.let { chromeClass ->
-            lyricsFragmentClass?.let { lyricsClass ->
-                installLandscapeLyricsChromeHook(chromeClass, lyricsClass)
-            }
-        } ?: 0
-        val lyricsMetricsHooks = lyricsFragmentClass?.let(::installLandscapeLyricsMetricsHook) ?: 0
-        val lyricsTypographyHooks = lyricsFragmentClass?.let(::installLandscapeLyricsTypographyHook) ?: 0
+        val lyricsChromeResolution = symbols.resolve(AppleMusicSymbols.LyricsChromeAnimate)
+        val lyricsChromeHooks = installLandscapeLyricsChromeHook(
+            lyricsChromeResolution.valueOrNull(),
+            lyricsFragmentClass,
+        )
+        val lyricsMetricsResolution = symbols.resolve(AppleMusicSymbols.LyricsFragmentUpdateMetrics)
+        val lyricsMetricsHooks = installLandscapeLyricsMetricsHook(lyricsMetricsResolution.valueOrNull())
+        val lyricsTypographyResolution = symbols.resolve(AppleMusicSymbols.LyricsFragmentOnResume)
+        val lyricsTypographyHooks = installLandscapeLyricsTypographyHook(
+            lyricsTypographyResolution.valueOrNull(),
+        )
+        val failures = listOf(
+            controllerInitializeResolution,
+            controllerCreateViewResolution,
+            controllerSelectPaneResolution,
+            navigationMenuResolution,
+            activityResolution,
+            lyricsFragmentResolution,
+            lyricsChromeResolution,
+            lyricsMetricsResolution,
+            lyricsTypographyResolution,
+        ).filterNot { it is TargetResolution.Found<*> }
+        val failureSummary = failures.takeIf(List<*>::isNotEmpty)
+            ?.joinToString(prefix = "; ") { it.summary }
+            .orEmpty()
         if (
-            controllerHooks == 0 ||
+            controllerHooks != 3 ||
+            navigationMenuMeasureHooks == 0 ||
             chromeHooks == 0 ||
             lyricsChromeHooks == 0 ||
             lyricsMetricsHooks == 0 ||
-            lyricsTypographyHooks == 0
+            lyricsTypographyHooks == 0 ||
+            failures.isNotEmpty()
         ) {
             return TargetCapabilityInstall.Degraded(
-                "Installed controller=$controllerHooks chrome=$chromeHooks lyricsChrome=$lyricsChromeHooks " +
-                    "lyricsMetrics=$lyricsMetricsHooks lyricsTypography=$lyricsTypographyHooks hook(s); " +
-                    listOf(
-                        navigationMenuResolution,
-                        activityResolution,
-                        lyricsFragmentResolution,
-                        lyricsChromeResolution,
-                    ).filterNot { it is TargetResolution.Found<*> }
-                        .joinToString { it.summary },
+                "Installed controller=$controllerHooks navigationMeasure=$navigationMenuMeasureHooks " +
+                    "chrome=$chromeHooks lyricsChrome=$lyricsChromeHooks " +
+                    "lyricsMetrics=$lyricsMetricsHooks lyricsTypography=$lyricsTypographyHooks hook(s)" +
+                    failureSummary,
             )
         }
         return TargetCapabilityInstall.Active(
             "Installed player controller and chrome hooks; " +
                 "stackedNavigationMenuMeasure=$navigationMenuMeasureHooks; " +
-                controllerResolution.summary,
+                controllerInitializeResolution.summary,
         )
     }
 
@@ -321,15 +337,8 @@ internal class AppleMusicDualPaneTarget(
      * the cached 40dp spec even when the public parent becomes full-width.
      * Feed the exact same 56dp height into that direct menu on every measure.
      */
-    private fun installStackedBottomNavigationMenuMeasureHook(menuClass: Class<*>?): Int {
-        menuClass ?: return 0
-        val onMeasure = menuClass.declaredMethods.firstOrNull { method ->
-            method.name == "onMeasure" &&
-                !Modifier.isStatic(method.modifiers) &&
-                method.returnType == Void.TYPE &&
-                method.parameterTypes.size == 2 &&
-                method.parameterTypes.all { it == Int::class.javaPrimitiveType }
-        } ?: return 0
+    private fun installStackedBottomNavigationMenuMeasureHook(onMeasure: Method?): Int {
+        onMeasure ?: return 0
         return if (hook(onMeasure, object : XC_MethodHook() {
                 override fun beforeHookedMethod(param: MethodHookParam) {
                     val menu = param.thisObject as? View ?: return
@@ -370,13 +379,8 @@ internal class AppleMusicDualPaneTarget(
      * owned by dual-pane rather than future-blur: disabling blur must not
      * shrink the tablet player back to the stock 24sp size.
      */
-    private fun installLandscapeLyricsTypographyHook(lyricsFragmentClass: Class<*>): Int {
-        val onResume = lyricsFragmentClass.declaredMethods.firstOrNull { method ->
-            method.name == "onResume" &&
-                !Modifier.isStatic(method.modifiers) &&
-                method.returnType == Void.TYPE &&
-                method.parameterTypes.isEmpty()
-        } ?: return 0
+    private fun installLandscapeLyricsTypographyHook(onResume: Method?): Int {
+        onResume ?: return 0
         return if (hook(onResume, object : XC_MethodHook() {
                 override fun afterHookedMethod(param: MethodHookParam) {
                     param.thisObject?.let { fragment ->
@@ -399,17 +403,11 @@ internal class AppleMusicDualPaneTarget(
      * lyrics pane without touching the left player pane.
      */
     private fun installLandscapeLyricsChromeHook(
-        chromeClass: Class<*>,
-        lyricsFragmentClass: Class<*>,
+        animateChrome: Method?,
+        lyricsFragmentClass: Class<*>?,
     ): Int {
-        val animateChrome = chromeClass.declaredMethods.firstOrNull { method ->
-            method.name == "a2" &&
-                !Modifier.isStatic(method.modifiers) &&
-                method.returnType == Void.TYPE &&
-                method.parameterTypes.size == 2 &&
-                method.parameterTypes[0] == Int::class.javaPrimitiveType &&
-                method.parameterTypes[1] == IntArray::class.java
-        } ?: return 0
+        animateChrome ?: return 0
+        lyricsFragmentClass ?: return 0
         return if (hook(animateChrome, object : XC_MethodHook() {
                 override fun beforeHookedMethod(param: MethodHookParam) {
                     val fragment = param.thisObject ?: return
@@ -437,13 +435,8 @@ internal class AppleMusicDualPaneTarget(
      * all of its normal calculations, then remove the same control height and
      * refresh the same RecyclerView it refreshes in j2().
      */
-    private fun installLandscapeLyricsMetricsHook(lyricsFragmentClass: Class<*>): Int {
-        val updateMetrics = lyricsFragmentClass.declaredMethods.firstOrNull { method ->
-            method.name == "j2" &&
-                !Modifier.isStatic(method.modifiers) &&
-                method.returnType == Boolean::class.javaPrimitiveType &&
-                method.parameterTypes.isEmpty()
-        } ?: return 0
+    private fun installLandscapeLyricsMetricsHook(updateMetrics: Method?): Int {
+        updateMetrics ?: return 0
         return if (hook(updateMetrics, object : XC_MethodHook() {
                 override fun afterHookedMethod(param: MethodHookParam) {
                     val fragment = param.thisObject ?: return
@@ -573,14 +566,12 @@ internal class AppleMusicDualPaneTarget(
         RightLyricsPaneLayout.reapplyVerticalGradientEdges(gradients)
     }
 
-    private fun installControllerHooks(controller: Class<*>): Int {
+    private fun installControllerHooks(
+        initialize: Method?,
+        createView: Method?,
+        selectPane: Method?,
+    ): Int {
         var hooks = 0
-        val initialize = controller.declaredMethods.firstOrNull { method ->
-            method.name == "w1" &&
-                !Modifier.isStatic(method.modifiers) &&
-                method.returnType == Void.TYPE &&
-                method.parameterTypes.singleOrNull()?.name?.endsWith(".BagConfig") == true
-        }
         if (initialize != null && hook(initialize, object : XC_MethodHook() {
                 override fun afterHookedMethod(param: MethodHookParam) {
                     val controllerInstance = param.thisObject ?: return
@@ -595,16 +586,6 @@ internal class AppleMusicDualPaneTarget(
         // The modified APK's transaction is still the model; onCreateView's
         // result is the first deterministic moment at which its two target
         // containers can be resolved by the child FragmentManager.
-        val createView = controller.declaredMethods.firstOrNull { method ->
-            method.name == "onCreateView" &&
-                !Modifier.isStatic(method.modifiers) &&
-                View::class.java.isAssignableFrom(method.returnType) &&
-                method.parameterTypes.map { it.name } == listOf(
-                "android.view.LayoutInflater",
-                "android.view.ViewGroup",
-                "android.os.Bundle",
-            )
-        }
         if (createView != null && hook(createView, object : XC_MethodHook() {
                 override fun afterHookedMethod(param: MethodHookParam) {
                     val controllerInstance = param.thisObject ?: return
@@ -615,14 +596,6 @@ internal class AppleMusicDualPaneTarget(
             hooks += 1
         }
 
-        val selectPane = controller.declaredMethods.firstOrNull { method ->
-            method.name == "F1" &&
-                !Modifier.isStatic(method.modifiers) &&
-                method.returnType == Void.TYPE &&
-                method.parameterTypes.size == 2 &&
-                method.parameterTypes[0].isEnum &&
-                method.parameterTypes[1] == Bundle::class.java
-        }
         if (selectPane != null && hook(selectPane, object : XC_MethodHook() {
                 override fun beforeHookedMethod(param: MethodHookParam) {
                     val requested = param.args.firstOrNull() as? Enum<*> ?: return
@@ -642,13 +615,9 @@ internal class AppleMusicDualPaneTarget(
      * tablet holder. The native object then owns slide interpolation, peek
      * height, navigation translation, colors and system-bar transitions.
      */
-    private fun installNativeStackedNavigationHolderHook(activityClass: Class<*>): Int {
-        val method = activityClass.declaredMethods.firstOrNull { method ->
-            method.name == "k1" &&
-                !Modifier.isStatic(method.modifiers) &&
-                method.parameterTypes.isEmpty() &&
-                method.returnType.name == "com.apple.android.music.common.activity.PlayerActivity\$m"
-        } ?: return 0
+    private fun installNativeStackedNavigationHolderHook(method: Method?): Int {
+        method ?: return 0
+        val activityClass = method.declaringClass
         val holderClass = activityClass.declaredClasses.firstOrNull { nested ->
             nested.simpleName == "StackedBottomNavigationHolder" ||
                 nested.declaredConstructors.any { constructor ->

--- a/app/src/main/java/dev/amenhancer/module/hook/TargetSymbols.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/TargetSymbols.kt
@@ -307,12 +307,47 @@ internal object AppleMusicSymbols {
         }
     }
 
+    val PlayerControllerInitialize = methodSymbol(
+        id = "player-controller-initialize",
+        profileOwner = TargetSymbolId.PLAYER_CONTROLLER,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
+        fallbackOwner = { it.startsWith("com.apple.android.music.player.fragment.") },
+        contract = ::isPlayerControllerInitialize,
+        structuralContract = ::isStructuralPlayerControllerInitialize,
+    )
+
+    val PlayerControllerCreateView = methodSymbol(
+        id = "player-controller-create-view",
+        profileOwner = TargetSymbolId.PLAYER_CONTROLLER,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
+        fallbackOwner = { it.startsWith("com.apple.android.music.player.fragment.") },
+        contract = ::isPlayerControllerCreateView,
+        structuralContract = ::isStructuralPlayerControllerCreateView,
+    )
+
+    val PlayerControllerSelectPane = methodSymbol(
+        id = "player-controller-select-pane",
+        profileOwner = TargetSymbolId.PLAYER_CONTROLLER,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
+        fallbackOwner = { it.startsWith("com.apple.android.music.player.fragment.") },
+        contract = ::isPlayerControllerSelectPane,
+        structuralContract = ::isStructuralPlayerControllerSelectPane,
+    )
+
     val PlayerActivity = classSymbol(
         id = "player-activity",
         profileId = TargetSymbolId.PLAYER_ACTIVITY,
         profilePolicy = ProfilePolicy.EXACT_PREFERRED,
         fallbackName = { it.endsWith(".common.activity.PlayerActivity") },
         contract = { true },
+    )
+
+    val PlayerActivityCreateStackedNavigationHolder = methodSymbol(
+        id = "player-activity-create-stacked-navigation-holder",
+        profileOwner = TargetSymbolId.PLAYER_ACTIVITY,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
+        fallbackOwner = { it.endsWith(".common.activity.PlayerActivity") },
+        contract = ::isPlayerActivityCreateStackedNavigationHolder,
     )
 
     val EditorialVideoUrlSelector = methodSymbol(
@@ -334,11 +369,36 @@ internal object AppleMusicSymbols {
         contract = { true },
     )
 
+    val LyricsFragmentOnResume = methodSymbol(
+        id = "lyrics-fragment-on-resume",
+        profileOwner = TargetSymbolId.LYRICS_FRAGMENT,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
+        fallbackOwner = { it.endsWith(".PlayerLyricsViewFragment") },
+        contract = ::isLyricsFragmentOnResume,
+    )
+
+    val LyricsFragmentUpdateMetrics = methodSymbol(
+        id = "lyrics-fragment-update-metrics",
+        profileOwner = TargetSymbolId.LYRICS_FRAGMENT,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
+        fallbackOwner = { it.endsWith(".PlayerLyricsViewFragment") },
+        contract = ::isLyricsFragmentUpdateMetrics,
+    )
+
     val LyricsChromeFragment = classSymbol(
         id = "lyrics-chrome-fragment",
         profileId = TargetSymbolId.LYRICS_CHROME,
         fallbackName = { it.startsWith("com.apple.android.music.player.fragment.") },
         contract = ::hasLyricsChromeContract,
+    )
+
+    val LyricsChromeAnimate = methodSymbol(
+        id = "lyrics-chrome-animate",
+        profileOwner = TargetSymbolId.LYRICS_CHROME,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
+        fallbackOwner = { it.startsWith("com.apple.android.music.player.fragment.") },
+        contract = ::isLyricsChromeAnimate,
+        structuralContract = ::isStructuralLyricsChromeAnimate,
     )
 
     val RecyclerView = classSymbol(
@@ -414,12 +474,36 @@ internal object AppleMusicSymbols {
         contract = { true },
     )
 
+    val LyricsViewModelNotifyWordHighlight = methodSymbol(
+        id = "lyrics-view-model-notify-word-highlight",
+        profileOwner = TargetSymbolId.LYRICS_VIEW_MODEL,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
+        fallbackOwner = { it.endsWith(".PlayerLyricsViewModel", ignoreCase = true) },
+        contract = ::isLyricsViewModelNotifyWordHighlight,
+    )
+
+    val LyricsViewModelSetCurrentHighlightedLine = methodSymbol(
+        id = "lyrics-view-model-set-current-highlighted-line",
+        profileOwner = TargetSymbolId.LYRICS_VIEW_MODEL,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
+        fallbackOwner = { it.endsWith(".PlayerLyricsViewModel", ignoreCase = true) },
+        contract = ::isLyricsViewModelSetCurrentHighlightedLine,
+    )
+
     val StackedNavigationMenu = classSymbol(
         id = "stacked-navigation-menu",
         profileId = TargetSymbolId.STACKED_NAVIGATION_MENU,
         stableName = "Hd.b",
         fallbackName = { false },
         contract = ::hasStackedNavigationMenuContract,
+    )
+
+    val StackedNavigationMenuOnMeasure = methodSymbol(
+        id = "stacked-navigation-menu-on-measure",
+        profileOwner = TargetSymbolId.STACKED_NAVIGATION_MENU,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
+        fallbackOwner = { it == "Hd.b" },
+        contract = ::isStackedNavigationMenuOnMeasure,
     )
 
     val SongInfoPtr = classSymbol(
@@ -467,11 +551,13 @@ internal object AppleMusicSymbols {
         id = "player-metadata-publish-method",
         profilePolicy = ProfilePolicy.EXACT_PREFERRED,
         profileCandidates = { profile ->
-            profile?.exactClasses?.get(TargetSymbolId.PLAYER_METADATA_HUB)
-                ?.let(::load)
-                ?.declaredMethods
-                ?.filter(::isPlayerMetadataPublishMethod)
-                .orEmpty()
+            runCatching {
+                profile?.exactClasses?.get(TargetSymbolId.PLAYER_METADATA_HUB)
+                    ?.let(::load)
+                    ?.declaredMethods
+                    ?.filter(::isPlayerMetadataPublishMethod)
+                    .orEmpty()
+            }.getOrDefault(emptyList())
         },
         structuralCandidates = {
             val metadataType = metadataConverterCandidates().singleOrNull()
@@ -530,11 +616,13 @@ internal object AppleMusicSymbols {
         id = "lyrics-current-item-field",
         profilePolicy = ProfilePolicy.EXACT_PREFERRED,
         profileCandidates = { profile ->
-            profile?.exactClasses?.get(TargetSymbolId.LYRICS_CURRENT_ITEM_FIELD)
-                ?.let(::load)
-                ?.declaredFields
-                ?.filter(::isLyricsCurrentItemField)
-                .orEmpty()
+            runCatching {
+                profile?.exactClasses?.get(TargetSymbolId.LYRICS_CURRENT_ITEM_FIELD)
+                    ?.let(::load)
+                    ?.declaredFields
+                    ?.filter(::isLyricsCurrentItemField)
+                    .orEmpty()
+            }.getOrDefault(emptyList())
         },
         structuralCandidates = {
             val lyricsFragment = load(
@@ -572,14 +660,18 @@ private fun classSymbol(
     id = id,
     profilePolicy = profilePolicy,
     profileCandidates = { profile ->
-        profileId?.let { profile?.exactClasses?.get(it) }
-            ?.let(::load)
-            ?.takeIf(contract)
-            ?.let(::listOf)
-            .orEmpty()
+        runCatching {
+            profileId?.let { profile?.exactClasses?.get(it) }
+                ?.let(::load)
+                ?.takeIf(contract)
+                ?.let(::listOf)
+                .orEmpty()
+        }.getOrDefault(emptyList())
     },
     stableCandidates = {
-        stableName?.let(::load)?.takeIf(contract)?.let(::listOf).orEmpty()
+        runCatching {
+            stableName?.let(::load)?.takeIf(contract)?.let(::listOf).orEmpty()
+        }.getOrDefault(emptyList())
     },
     structuralCandidates = { classes(fallbackName, contract) },
     identity = { it.name },
@@ -596,25 +688,23 @@ private fun methodSymbol(
     id = id,
     profilePolicy = profilePolicy,
     profileCandidates = { profile ->
-        profile?.exactClasses?.get(profileOwner)
-            ?.let(::load)
-            ?.declaredMethods
-            ?.filter(contract)
-            .orEmpty()
+        runCatching {
+            profile?.exactClasses?.get(profileOwner)
+                ?.let(::load)
+                ?.declaredMethods
+                ?.filter(contract)
+                .orEmpty()
+        }.getOrDefault(emptyList())
     },
     structuralCandidates = { methods(fallbackOwner, structuralContract) },
     identity = ::methodIdentity,
 )
 
 private fun hasLyricsChromeContract(candidate: Class<*>): Boolean =
+    candidate.declaredMethods.any(::isLyricsChromeAnimate) && hasLyricsChromeViewContract(candidate)
+
+private fun hasLyricsChromeViewContract(candidate: Class<*>): Boolean =
     candidate.declaredMethods.any { method ->
-        method.name == "a2" &&
-            !Modifier.isStatic(method.modifiers) &&
-            method.returnType == Void.TYPE &&
-            method.parameterTypes.contentEquals(
-                arrayOf(Int::class.javaPrimitiveType, IntArray::class.java),
-            )
-    } && candidate.declaredMethods.any { method ->
         method.name == "f2" &&
             !Modifier.isStatic(method.modifiers) &&
             View::class.java.isAssignableFrom(method.returnType) &&
@@ -630,6 +720,100 @@ private fun hasStackedNavigationMenuContract(candidate: Class<*>): Boolean =
                 arrayOf(Int::class.javaPrimitiveType, Int::class.javaPrimitiveType),
             )
     }
+
+private fun isPlayerControllerInitialize(method: Method): Boolean =
+    !Modifier.isStatic(method.modifiers) &&
+        method.name == "w1" &&
+        method.returnType == Void.TYPE &&
+        method.parameterTypes.singleOrNull()?.name?.endsWith(".BagConfig") == true
+
+private fun isStructuralPlayerControllerInitialize(method: Method): Boolean =
+    isPlayerControllerInitialize(method) && hasPlayerControllerHookContract(method.declaringClass)
+
+private fun isPlayerControllerCreateView(method: Method): Boolean =
+    !Modifier.isStatic(method.modifiers) &&
+        method.name == "onCreateView" &&
+        View::class.java.isAssignableFrom(method.returnType) &&
+        method.parameterTypes.map { it.name } == listOf(
+        "android.view.LayoutInflater",
+        "android.view.ViewGroup",
+        "android.os.Bundle",
+    )
+
+private fun isStructuralPlayerControllerCreateView(method: Method): Boolean =
+    isPlayerControllerCreateView(method) && hasPlayerControllerHookContract(method.declaringClass)
+
+private fun isPlayerControllerSelectPane(method: Method): Boolean =
+    !Modifier.isStatic(method.modifiers) &&
+        method.name == "F1" &&
+        method.returnType == Void.TYPE &&
+        method.parameterTypes.size == 2 &&
+        method.parameterTypes[0].isEnum &&
+        method.parameterTypes[1].name == "android.os.Bundle"
+
+private fun isStructuralPlayerControllerSelectPane(method: Method): Boolean =
+    isPlayerControllerSelectPane(method) && hasPlayerControllerHookContract(method.declaringClass)
+
+private fun hasPlayerControllerHookContract(candidate: Class<*>): Boolean =
+    candidate.declaredMethods.any(::isPlayerControllerInitialize) &&
+        candidate.declaredMethods.any(::isPlayerControllerCreateView) &&
+        candidate.declaredMethods.any(::isPlayerControllerSelectPane)
+
+private fun isPlayerActivityCreateStackedNavigationHolder(method: Method): Boolean =
+    !Modifier.isStatic(method.modifiers) &&
+        method.name == "k1" &&
+        method.parameterTypes.isEmpty() &&
+        method.returnType.name == "com.apple.android.music.common.activity.PlayerActivity\$m"
+
+private fun isLyricsFragmentOnResume(method: Method): Boolean =
+    !Modifier.isStatic(method.modifiers) &&
+        method.name == "onResume" &&
+        method.returnType == Void.TYPE &&
+        method.parameterTypes.isEmpty()
+
+private fun isLyricsFragmentUpdateMetrics(method: Method): Boolean =
+    !Modifier.isStatic(method.modifiers) &&
+        method.name == "j2" &&
+        method.returnType == Boolean::class.javaPrimitiveType &&
+        method.parameterTypes.isEmpty()
+
+private fun isLyricsChromeAnimate(method: Method): Boolean =
+    !Modifier.isStatic(method.modifiers) &&
+        method.name == "a2" &&
+        method.returnType == Void.TYPE &&
+        method.parameterTypes.contentEquals(
+            arrayOf(Int::class.javaPrimitiveType, IntArray::class.java),
+        )
+
+private fun isStructuralLyricsChromeAnimate(method: Method): Boolean =
+    isLyricsChromeAnimate(method) && hasLyricsChromeViewContract(method.declaringClass)
+
+private fun isStackedNavigationMenuOnMeasure(method: Method): Boolean =
+    !Modifier.isStatic(method.modifiers) &&
+        method.name == "onMeasure" &&
+        method.returnType == Void.TYPE &&
+        method.parameterTypes.contentEquals(
+            arrayOf(Int::class.javaPrimitiveType, Int::class.javaPrimitiveType),
+        )
+
+private fun isLyricsViewModelNotifyWordHighlight(method: Method): Boolean =
+    !Modifier.isStatic(method.modifiers) &&
+        method.name == "notifyWordHighlight" &&
+        method.returnType == Void.TYPE &&
+        method.parameterTypes.contentEquals(
+            arrayOf(
+                Int::class.javaPrimitiveType,
+                Int::class.javaPrimitiveType,
+                Int::class.javaPrimitiveType,
+                Boolean::class.javaPrimitiveType,
+            ),
+        )
+
+private fun isLyricsViewModelSetCurrentHighlightedLine(method: Method): Boolean =
+    !Modifier.isStatic(method.modifiers) &&
+        method.name == "setCurrentHighlightedLine" &&
+        method.returnType == Void.TYPE &&
+        method.parameterTypes.contentEquals(arrayOf(Int::class.javaPrimitiveType))
 
 private fun isEditorialVideoUrlSelector(method: Method): Boolean =
     Modifier.isStatic(method.modifiers) &&

--- a/app/src/test/java/com/apple/android/music/common/activity/PlayerActivity.kt
+++ b/app/src/test/java/com/apple/android/music/common/activity/PlayerActivity.kt
@@ -1,0 +1,5 @@
+package com.apple.android.music.common.activity
+
+class PlayerActivity {
+    class m
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/DualPaneStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/DualPaneStructuralRegressionTest.kt
@@ -42,6 +42,26 @@ class DualPaneStructuralRegressionTest {
     }
 
     @Test
+    fun `resolves every dual pane hook entry through target symbols`() {
+        listOf(
+            "PlayerControllerInitialize",
+            "PlayerControllerCreateView",
+            "PlayerControllerSelectPane",
+            "PlayerActivityCreateStackedNavigationHolder",
+            "StackedNavigationMenuOnMeasure",
+            "LyricsFragmentOnResume",
+            "LyricsChromeAnimate",
+            "LyricsFragmentUpdateMetrics",
+        ).forEach { symbol ->
+            assertTrue(source.contains("AppleMusicSymbols.$symbol"))
+        }
+        listOf("w1", "onCreateView", "F1", "k1", "onMeasure", "onResume", "a2", "j2")
+            .forEach { methodName ->
+                assertFalse(source.contains("method.name == \"$methodName\""))
+            }
+    }
+
+    @Test
     fun `does not reparent the player root into a linear layout`() {
         assertFalse(source.contains("parent.removeViewAt(index)"))
         assertFalse(source.contains("paneContainer.addView(root"))
@@ -98,10 +118,9 @@ class DualPaneStructuralRegressionTest {
 
     @Test
     fun `feeds the direct Material menu the modified first-measure height`() {
-        assertTrue(source.contains("AppleMusicSymbols.StackedNavigationMenu"))
+        assertTrue(source.contains("AppleMusicSymbols.StackedNavigationMenuOnMeasure"))
         assertTrue(source.contains("navigationMenuResolution.valueOrNull()"))
         assertFalse(source.contains("\"Hd.b\""))
-        assertTrue(source.contains("method.name == \"onMeasure\""))
         assertTrue(source.contains("View.MeasureSpec.makeMeasureSpec("))
         assertTrue(source.contains("View.MeasureSpec.EXACTLY"))
         assertTrue(source.contains("navigation.id != bottomNavigationId"))
@@ -200,8 +219,7 @@ class DualPaneStructuralRegressionTest {
     @Test
     fun `mirrors modified landscape lyrics chrome suppression`() {
         assertTrue(source.contains("installLandscapeLyricsChromeHook"))
-        assertTrue(source.contains("method.name == \"a2\""))
-        assertTrue(source.contains("IntArray::class.java"))
+        assertTrue(source.contains("AppleMusicSymbols.LyricsChromeAnimate"))
         assertTrue(source.contains("ModernXposedRuntime.callMethod(fragment, \"f2\") as? View"))
         assertTrue(source.contains("suppressed duplicate lyrics pane chrome"))
         assertTrue(source.contains("param.result = null"))
@@ -210,7 +228,7 @@ class DualPaneStructuralRegressionTest {
     @Test
     fun `mirrors modified landscape lyrics metrics correction`() {
         assertTrue(source.contains("installLandscapeLyricsMetricsHook"))
-        assertTrue(source.contains("method.name == \"j2\""))
+        assertTrue(source.contains("AppleMusicSymbols.LyricsFragmentUpdateMetrics"))
         assertTrue(source.contains("alignSynchronizedLyricsHighlightAnchor"))
         assertTrue(source.contains("TabletLyricAnchorPolicy.highlightOffset"))
         assertTrue(source.contains("listOf(\"z0\", \"A0\")"))
@@ -241,8 +259,8 @@ class DualPaneStructuralRegressionTest {
 
     @Test
     fun `returns the official stacked holder before the flat holder can be constructed`() {
-        assertTrue(source.contains("installNativeStackedNavigationHolderHook(activityClass)"))
-        assertTrue(source.contains("method.name == \"k1\""))
+        assertTrue(source.contains("AppleMusicSymbols.PlayerActivityCreateStackedNavigationHolder"))
+        assertTrue(source.contains("installNativeStackedNavigationHolderHook(activityResolution.valueOrNull())"))
         assertTrue(source.contains("nested.simpleName == \"StackedBottomNavigationHolder\""))
         assertTrue(source.contains("override fun beforeHookedMethod(param: MethodHookParam)"))
         assertTrue(source.contains("constructor.newInstance(activity, navigationRoot, behavior)"))

--- a/app/src/test/java/dev/amenhancer/module/hook/FutureLyricBlurStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/FutureLyricBlurStructuralRegressionTest.kt
@@ -114,6 +114,15 @@ class FutureLyricBlurStructuralRegressionTest {
         assertTrue(targetSource.contains("view.javaClass == recyclerViewClass"))
     }
 
+    @Test
+    fun `resolves both view model highlight entries through target symbols`() {
+        assertTrue(targetSource.contains("AppleMusicSymbols.LyricsViewModelNotifyWordHighlight"))
+        assertTrue(targetSource.contains("AppleMusicSymbols.LyricsViewModelSetCurrentHighlightedLine"))
+        val hookViewModel = targetSource.substringAfter("private fun hookViewModel(")
+            .substringBefore("private companion object")
+        assertFalse(hookViewModel.contains("declaredMethods"))
+    }
+
     private fun sourceFile(name: String): File = sequenceOf(
         File("src/main/java/dev/amenhancer/module/hook/$name"),
         File("app/src/main/java/dev/amenhancer/module/hook/$name"),

--- a/app/src/test/java/dev/amenhancer/module/hook/TargetSymbolsTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/TargetSymbolsTest.kt
@@ -1,5 +1,9 @@
 package dev.amenhancer.module.hook
 
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 import com.apple.android.music.model.BaseContentItem
 import com.apple.android.music.player.fragment.m
 import com.apple.android.music.player.fragment.mWrongType
@@ -70,6 +74,188 @@ class TargetSymbolsTest {
         assertEquals(SymbolMatch.VERSION_PROFILE, (resolution as TargetResolution.Found).match)
         assertEquals("processEvents", resolution.value.name)
         assertEquals(0, source.classNameReads)
+    }
+
+    @Test
+    fun `650 profile resolves every dual pane and view model hook entry without scanning dex`() {
+        val source = FakeTargetClassSource(
+            classes = mapOf(
+                "com.apple.android.music.player.fragment.w0" to DualPaneControllerFixture::class.java,
+                "com.apple.android.music.common.activity.PlayerActivity" to DualPaneActivityFixture::class.java,
+                "com.apple.android.music.player.fragment.PlayerLyricsViewFragment" to
+                    DualPaneLyricsFragmentFixture::class.java,
+                "com.apple.android.music.player.fragment.e" to DualPaneLyricsChromeFixture::class.java,
+                "com.apple.android.music.player.viewmodel.PlayerLyricsViewModel" to
+                    LyricsViewModelHookFixture::class.java,
+                "Hd.b" to ProfileFixture::class.java,
+            ),
+        )
+        val resolver = IndexedTargetSymbolResolver(
+            build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.0", 1580L),
+            source = source,
+        )
+
+        val resolutions = listOf(
+            resolver.resolve(AppleMusicSymbols.StackedNavigationMenuOnMeasure),
+            resolver.resolve(AppleMusicSymbols.LyricsFragmentOnResume),
+            resolver.resolve(AppleMusicSymbols.LyricsChromeAnimate),
+            resolver.resolve(AppleMusicSymbols.LyricsFragmentUpdateMetrics),
+            resolver.resolve(AppleMusicSymbols.PlayerControllerInitialize),
+            resolver.resolve(AppleMusicSymbols.PlayerControllerCreateView),
+            resolver.resolve(AppleMusicSymbols.PlayerControllerSelectPane),
+            resolver.resolve(AppleMusicSymbols.PlayerActivityCreateStackedNavigationHolder),
+            resolver.resolve(AppleMusicSymbols.LyricsViewModelNotifyWordHighlight),
+            resolver.resolve(AppleMusicSymbols.LyricsViewModelSetCurrentHighlightedLine),
+        )
+
+        resolutions.forEach { resolution ->
+            assertTrue(resolution is TargetResolution.Found)
+            assertEquals(SymbolMatch.VERSION_PROFILE, (resolution as TargetResolution.Found).match)
+        }
+        assertEquals(
+            listOf(
+                "onMeasure",
+                "onResume",
+                "a2",
+                "j2",
+                "w1",
+                "onCreateView",
+                "F1",
+                "k1",
+                "notifyWordHighlight",
+                "setCurrentHighlightedLine",
+            ),
+            resolutions.map { (it as TargetResolution.Found).value.name },
+        )
+        assertEquals(0, source.classNameReads)
+    }
+
+    @Test
+    fun `651 profile resolves migrated dual pane and view model owners without scanning dex`() {
+        val source = FakeTargetClassSource(
+            classes = mapOf(
+                "com.apple.android.music.player.fragment.q0" to DualPaneControllerFixture::class.java,
+                "com.apple.android.music.common.activity.PlayerActivity" to DualPaneActivityFixture::class.java,
+                "com.apple.android.music.player.fragment.PlayerLyricsViewFragment" to
+                    DualPaneLyricsFragmentFixture::class.java,
+                "com.apple.android.music.player.fragment.d" to DualPaneLyricsChromeFixture::class.java,
+                "com.apple.android.music.player.viewmodel.PlayerLyricsViewModel" to
+                    LyricsViewModelHookFixture::class.java,
+                "Hd.b" to ProfileFixture::class.java,
+            ),
+        )
+        val resolver = IndexedTargetSymbolResolver(
+            build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.1", 1583L),
+            source = source,
+        )
+
+        listOf(
+            resolver.resolve(AppleMusicSymbols.StackedNavigationMenuOnMeasure),
+            resolver.resolve(AppleMusicSymbols.LyricsFragmentOnResume),
+            resolver.resolve(AppleMusicSymbols.LyricsChromeAnimate),
+            resolver.resolve(AppleMusicSymbols.LyricsFragmentUpdateMetrics),
+            resolver.resolve(AppleMusicSymbols.PlayerControllerInitialize),
+            resolver.resolve(AppleMusicSymbols.PlayerControllerCreateView),
+            resolver.resolve(AppleMusicSymbols.PlayerControllerSelectPane),
+            resolver.resolve(AppleMusicSymbols.PlayerActivityCreateStackedNavigationHolder),
+            resolver.resolve(AppleMusicSymbols.LyricsViewModelNotifyWordHighlight),
+            resolver.resolve(AppleMusicSymbols.LyricsViewModelSetCurrentHighlightedLine),
+        ).forEach { resolution ->
+            assertTrue(resolution is TargetResolution.Found)
+            assertEquals(SymbolMatch.VERSION_PROFILE, (resolution as TargetResolution.Found).match)
+            assertEquals("apple-music-6.5.1-1583", resolution.profileId)
+        }
+        assertEquals(0, source.classNameReads)
+    }
+
+    @Test
+    fun `controller fallback rejects an isolated same shaped hook entry`() {
+        val name = "com.apple.android.music.player.fragment.DecoyController"
+        val resolver = IndexedTargetSymbolResolver(
+            TargetBuild.UNKNOWN,
+            FakeTargetClassSource(
+                names = listOf(name),
+                classes = mapOf(name to ControllerInitializeOnlyFixture::class.java),
+            ),
+        )
+
+        assertTrue(
+            resolver.resolve(AppleMusicSymbols.PlayerControllerInitialize) is TargetResolution.Missing,
+        )
+    }
+
+    @Test
+    fun `lyrics chrome fallback requires the sibling view contract`() {
+        val name = "com.apple.android.music.player.fragment.DecoyChrome"
+        val resolver = IndexedTargetSymbolResolver(
+            TargetBuild.UNKNOWN,
+            FakeTargetClassSource(
+                names = listOf(name),
+                classes = mapOf(name to DualPaneLyricsChromeFixture::class.java),
+            ),
+        )
+
+        assertTrue(resolver.resolve(AppleMusicSymbols.LyricsChromeAnimate) is TargetResolution.Missing)
+    }
+
+    @Test
+    fun `unknown build resolves the unique view model hook entries structurally`() {
+        val name = "com.apple.android.music.player.viewmodel.PlayerLyricsViewModel"
+        val resolver = IndexedTargetSymbolResolver(
+            TargetBuild.UNKNOWN,
+            FakeTargetClassSource(
+                names = listOf(name),
+                classes = mapOf(name to LyricsViewModelHookFixture::class.java),
+            ),
+        )
+
+        val notify = resolver.resolve(AppleMusicSymbols.LyricsViewModelNotifyWordHighlight)
+        val current = resolver.resolve(AppleMusicSymbols.LyricsViewModelSetCurrentHighlightedLine)
+
+        assertEquals(SymbolMatch.STRUCTURAL_FALLBACK, (notify as TargetResolution.Found).match)
+        assertEquals("notifyWordHighlight", notify.value.name)
+        assertEquals(SymbolMatch.STRUCTURAL_FALLBACK, (current as TargetResolution.Found).match)
+        assertEquals("setCurrentHighlightedLine", current.value.name)
+    }
+
+    @Test
+    fun `view model hook entries report missing when their contracts are absent`() {
+        val name = "com.apple.android.music.player.viewmodel.PlayerLyricsViewModel"
+        val resolver = IndexedTargetSymbolResolver(
+            TargetBuild.UNKNOWN,
+            FakeTargetClassSource(
+                names = listOf(name),
+                classes = mapOf(name to BrokenLyricsViewModelHookFixture::class.java),
+            ),
+        )
+
+        assertTrue(
+            resolver.resolve(AppleMusicSymbols.LyricsViewModelNotifyWordHighlight) is TargetResolution.Missing,
+        )
+        assertTrue(
+            resolver.resolve(AppleMusicSymbols.LyricsViewModelSetCurrentHighlightedLine) is TargetResolution.Missing,
+        )
+    }
+
+    @Test
+    fun `view model hook entry ambiguity reports every matching owner`() {
+        val first = "com.apple.first.PlayerLyricsViewModel"
+        val second = "com.apple.second.PlayerLyricsViewModel"
+        val resolver = IndexedTargetSymbolResolver(
+            TargetBuild.UNKNOWN,
+            FakeTargetClassSource(
+                names = listOf(first, second),
+                classes = mapOf(
+                    first to LyricsViewModelHookFixture::class.java,
+                    second to SecondLyricsViewModelHookFixture::class.java,
+                ),
+            ),
+        )
+
+        val resolution = resolver.resolve(AppleMusicSymbols.LyricsViewModelNotifyWordHighlight)
+
+        assertTrue(resolution is TargetResolution.Ambiguous)
+        assertEquals(2, (resolution as TargetResolution.Ambiguous).candidates.size)
     }
 
     @Test
@@ -531,6 +717,16 @@ class TargetSymbolsTest {
             AppleMusicSymbols.LyricsAvailabilityPredicate,
             AppleMusicSymbols.TtmlSongInfoFromTtml,
             AppleMusicSymbols.LyricsCurrentItemField,
+            AppleMusicSymbols.StackedNavigationMenuOnMeasure,
+            AppleMusicSymbols.LyricsFragmentOnResume,
+            AppleMusicSymbols.LyricsChromeAnimate,
+            AppleMusicSymbols.LyricsFragmentUpdateMetrics,
+            AppleMusicSymbols.PlayerControllerInitialize,
+            AppleMusicSymbols.PlayerControllerCreateView,
+            AppleMusicSymbols.PlayerControllerSelectPane,
+            AppleMusicSymbols.PlayerActivityCreateStackedNavigationHolder,
+            AppleMusicSymbols.LyricsViewModelNotifyWordHighlight,
+            AppleMusicSymbols.LyricsViewModelSetCurrentHighlightedLine,
         ).forEach { symbol ->
             assertEquals(ProfilePolicy.EXACT_PREFERRED, symbol.profilePolicy)
         }
@@ -951,6 +1147,58 @@ private class ProfileFixture {
     @Suppress("UNUSED_PARAMETER")
     fun onMeasure(width: Int, height: Int) = Unit
 }
+
+private class BagConfig
+
+private enum class PlayerPane
+
+private class DualPaneControllerFixture {
+    @Suppress("UNUSED_PARAMETER")
+    fun w1(config: BagConfig) = Unit
+
+    @Suppress("UNUSED_PARAMETER")
+    fun onCreateView(inflater: LayoutInflater, container: ViewGroup, state: Bundle): View =
+        throw UnsupportedOperationException()
+
+    @Suppress("UNUSED_PARAMETER")
+    fun F1(pane: PlayerPane, state: Bundle) = Unit
+}
+
+private class ControllerInitializeOnlyFixture {
+    @Suppress("UNUSED_PARAMETER")
+    fun w1(config: BagConfig) = Unit
+}
+
+private class DualPaneActivityFixture {
+    fun k1(): com.apple.android.music.common.activity.PlayerActivity.m =
+        com.apple.android.music.common.activity.PlayerActivity.m()
+}
+
+private class DualPaneLyricsFragmentFixture {
+    fun onResume() = Unit
+    fun j2(): Boolean = false
+}
+
+private class DualPaneLyricsChromeFixture {
+    @Suppress("UNUSED_PARAMETER")
+    fun a2(mode: Int, values: IntArray) = Unit
+}
+
+private class LyricsViewModelHookFixture {
+    @Suppress("UNUSED_PARAMETER")
+    fun notifyWordHighlight(lineId: Int, word: Int, character: Int, isBackground: Boolean) = Unit
+
+    @Suppress("UNUSED_PARAMETER")
+    fun setCurrentHighlightedLine(lineId: Int) = Unit
+}
+
+private class SecondLyricsViewModelHookFixture {
+    @Suppress("UNUSED_PARAMETER")
+    fun notifyWordHighlight(lineId: Int, word: Int, character: Int, isBackground: Boolean) = Unit
+}
+
+private class BrokenLyricsViewModelHookFixture
+
 private class ProfileVector
 private class ProfileCallback {
     @Suppress("UNUSED_PARAMETER")


### PR DESCRIPTION
## Summary
- resolve eight dual-pane hook entries and two lyric ViewModel entries through independent target symbols
- preserve partial installation while reporting missing or ambiguous entries as degraded
- tighten structural fallback contracts to reject unique-but-wrong owners
- cover Apple Music 6.5.0 and 6.5.1 profiles, fallback, missing, and ambiguity

## Verification
- ./gradlew.bat test assembleDebug assembleRelease lintVitalRelease --no-daemon
- release APK installed successfully on the connected device
- Apple Music restarted successfully after installation