### PR TITLE
Fix lyric blur highlight states

### DIFF
--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicBidirectionalLyricBlurTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicBidirectionalLyricBlurTarget.kt
@@ -237,6 +237,8 @@ internal class AppleMusicLyricBlurTargetAccess(
 
     override fun isRecyclerView(view: View): Boolean = view.javaClass == recyclerViewClass
 
+    override fun isInstrumentalRow(view: View): Boolean = InstrumentalRowIdentity.matches(view)
+
     override fun adapterPosition(view: View): Int = try {
         (adapterPositionAccessor?.invoke(null, view) as? Int) ?: -1
     } catch (_: Throwable) {

--- a/app/src/main/java/dev/amenhancer/module/hook/BidirectionalBlurPolicy.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/BidirectionalBlurPolicy.kt
@@ -25,6 +25,21 @@ internal object BidirectionalBlurPolicy {
             .orEmpty()
     }
 
+    fun selectInstrumentalGapAnchor(
+        active: Set<Int>,
+        isGap: Boolean,
+        instrumentalPositions: List<Int>,
+    ): Int {
+        if (active.isNotEmpty() && !isGap) return -1
+        val referencePosition = active.maxOrNull()
+        return instrumentalPositions
+            .asSequence()
+            .filter { position -> position >= 0 }
+            .minByOrNull { position ->
+                referencePosition?.let { reference -> abs(position - reference) } ?: 0
+            } ?: -1
+    }
+
     fun targetRadius(position: Int, highlighted: Set<Int>): Float {
         if (highlighted.isEmpty()) return BLUR_MAX
         if (position in highlighted) return 0f

--- a/app/src/main/java/dev/amenhancer/module/hook/BidirectionalBlurPolicy.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/BidirectionalBlurPolicy.kt
@@ -10,10 +10,12 @@ internal object BidirectionalBlurPolicy {
     private val FUTURE_RADII_BY_DISTANCE = floatArrayOf(0f, 8f, 13f, 17f, BLUR_MAX)
     const val TRANSITION_DURATION_MS = 300L
 
-    fun resolveHighlights(current: Set<Int>, incoming: Set<Int>): Set<Int> =
-        (incoming.takeIf { it.isNotEmpty() } ?: current).toSet()
-
-    fun resolveDisplayHighlights(active: Set<Int>, visiblePositions: List<Int>): Set<Int> {
+    fun resolveDisplayHighlights(
+        active: Set<Int>,
+        visiblePositions: List<Int>,
+        gapAnchorPosition: Int = -1,
+    ): Set<Int> {
+        if (gapAnchorPosition >= 0) return setOf(gapAnchorPosition)
         if (active.isNotEmpty()) return active.toSet()
         return visiblePositions
             .asSequence()

--- a/app/src/main/java/dev/amenhancer/module/hook/InstrumentalRowIdentity.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/InstrumentalRowIdentity.kt
@@ -1,0 +1,16 @@
+package dev.amenhancer.module.hook
+
+import android.view.View
+import java.util.Collections
+import java.util.WeakHashMap
+
+/** Process-local semantic identity for inflated instrumental lyric rows. */
+internal object InstrumentalRowIdentity {
+    private val rows = Collections.synchronizedMap(WeakHashMap<View, Boolean>())
+
+    fun mark(view: View) {
+        rows[view] = true
+    }
+
+    fun matches(view: View): Boolean = rows.containsKey(view)
+}

--- a/app/src/main/java/dev/amenhancer/module/hook/LyricBlurRenderer.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/LyricBlurRenderer.kt
@@ -32,6 +32,10 @@ internal class LyricBlurRenderer {
             .toList()
             .forEach(::clear)
         targets.forEach { (view, target) ->
+            if (target <= 0f) {
+                clear(view)
+                return@forEach
+            }
             val state = transitions[view]
             val current = state?.radiusAt(now) ?: 0f
             if (state != null && state.targetRadius == target) return@forEach

--- a/app/src/main/java/dev/amenhancer/module/hook/LyricHighlightSession.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/LyricHighlightSession.kt
@@ -4,32 +4,57 @@ package dev.amenhancer.module.hook
 internal class LyricHighlightSession {
     private var token: Any? = null
     private val highlightedLineIds = mutableSetOf<Int>()
+    private val completedOverlapLineIds = mutableSetOf<Int>()
+    private var gap = false
 
     @Synchronized
     fun enter(newToken: Any): Boolean {
         if (token === newToken) return false
         token = newToken
         highlightedLineIds.clear()
+        completedOverlapLineIds.clear()
+        gap = false
         return true
     }
 
     @Synchronized
     fun update(incoming: Set<Int>): Set<Int> {
-        val resolved = BidirectionalBlurPolicy.resolveHighlights(
-            current = highlightedLineIds,
-            incoming = incoming,
-        )
+        if (incoming.isEmpty()) {
+            gap = true
+            return snapshotLocked()
+        }
+        gap = false
+        if (incoming == highlightedLineIds) return snapshotLocked()
+        val completedOverlap = if (
+            highlightedLineIds.size > 1 && highlightedLineIds.containsAll(incoming)
+        ) {
+            val firstIncoming = incoming.min()
+            (highlightedLineIds - incoming).filterTo(mutableSetOf()) { lineId ->
+                lineId < firstIncoming
+            }
+        } else {
+            emptySet()
+        }
+        completedOverlapLineIds.clear()
+        completedOverlapLineIds.addAll(completedOverlap)
         highlightedLineIds.clear()
-        highlightedLineIds.addAll(resolved)
-        return highlightedLineIds.toSet()
+        highlightedLineIds.addAll(incoming)
+        return snapshotLocked()
     }
 
     @Synchronized
     fun replace(lineId: Int) {
+        gap = false
+        completedOverlapLineIds.clear()
         highlightedLineIds.clear()
         highlightedLineIds.add(lineId)
     }
 
     @Synchronized
-    fun snapshot(): Set<Int> = highlightedLineIds.toSet()
+    fun snapshot(): Set<Int> = snapshotLocked()
+
+    @Synchronized
+    fun isGap(): Boolean = gap
+
+    private fun snapshotLocked(): Set<Int> = highlightedLineIds + completedOverlapLineIds
 }

--- a/app/src/main/java/dev/amenhancer/module/hook/LyricsTypefaceSession.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/LyricsTypefaceSession.kt
@@ -23,6 +23,8 @@ import java.util.concurrent.Executors
 
 /** The verified Apple Music layout names that may contain player lyric text. */
 internal object LyricsTypefaceLayoutContract {
+    const val INSTRUMENTAL_LAYOUT_NAME = "lyrics_line_instrumental"
+
     val layoutNames: List<String> = listOf(
         "lyrics_line",
         "lyrics_line_karaoke",
@@ -35,7 +37,7 @@ internal object LyricsTypefaceLayoutContract {
         "lyrics_bg_translation_line_karaoke",
         "lyrics_word_karaoke_bg",
         "lyrics_word_pronunciation_bg",
-        "lyrics_line_instrumental",
+        INSTRUMENTAL_LAYOUT_NAME,
     )
 }
 
@@ -95,6 +97,9 @@ internal class LyricsTypefaceSession {
         }
         LyricsTypefaceLayoutContract.layoutNames.forEach { layoutName ->
             LayoutInflationRegistry.register(layoutName) { root ->
+                if (layoutName == LyricsTypefaceLayoutContract.INSTRUMENTAL_LAYOUT_NAME) {
+                    InstrumentalRowIdentity.mark(root)
+                }
                 applyToLyricsLayout(root)
                 installRowLayoutChangeObserver(root)
             }

--- a/app/src/main/java/dev/amenhancer/module/hook/OpenSourceLyricBlurPort.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/OpenSourceLyricBlurPort.kt
@@ -14,6 +14,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver
 import android.widget.ImageView
+import kotlin.math.abs
 
 /**
  * Target-independent AMLyricBlur runtime.
@@ -234,17 +235,35 @@ internal class OpenSourceLyricBlurPort(
     ) {
         val rv = getRv() as? ViewGroup ?: return
         val visibleRows = ArrayList<Pair<View, Int>>(rv.childCount)
+        val instrumentalRows = ArrayList<Pair<View, Int>>(1)
 
         for (i in 0 until rv.childCount) {
             val child = rv.getChildAt(i) ?: continue
-            if (!isLyricsLine(child)) continue
             val adapterPos = targetAccess.adapterPosition(child)
+            if (targetAccess.isInstrumentalRow(child)) {
+                instrumentalRows += child to adapterPos
+                continue
+            }
+            if (!isLyricsLine(child)) continue
             visibleRows += child to adapterPos
         }
         val activeIds = highlightSession.snapshot()
+        val gapAnchorPosition = if (highlightSession.isGap()) {
+            val referencePosition = activeIds.maxOrNull()
+            instrumentalRows
+                .asSequence()
+                .map { (_, position) -> position }
+                .filter { position -> position >= 0 }
+                .minByOrNull { position ->
+                    referencePosition?.let { reference -> abs(position - reference) } ?: 0
+                } ?: -1
+        } else {
+            -1
+        }
         val effectiveIds = BidirectionalBlurPolicy.resolveDisplayHighlights(
             active = activeIds,
             visiblePositions = visibleRows.map { (_, position) -> position },
+            gapAnchorPosition = gapAnchorPosition,
         )
         val useTabletEdges = TabletModeQualifier.isEligible(rv.context)
         val targets = LinkedHashMap<View, Float>(visibleRows.size)
@@ -265,8 +284,13 @@ internal class OpenSourceLyricBlurPort(
             } else {
                 0f
             }
-            targets[child] = TabletLyricVisualPolicy.mergeBlurRadius(focusBlur, edgeBlur)
+            targets[child] = TabletLyricVisualPolicy.mergeBlurRadius(
+                focusBlurRadius = focusBlur,
+                edgeBlurRadius = edgeBlur,
+                isHighlighted = includeFocus && adapterPos in effectiveIds,
+            )
         }
+        instrumentalRows.forEach { (view, _) -> blurRenderer.clear(view) }
         if (immediate) {
             blurRenderer.applyImmediately(targets)
         } else {
@@ -302,5 +326,6 @@ internal interface LyricBlurRuntime {
 
 internal interface LyricBlurTargetAccess {
     fun isRecyclerView(view: View): Boolean
+    fun isInstrumentalRow(view: View): Boolean
     fun adapterPosition(view: View): Int
 }

--- a/app/src/main/java/dev/amenhancer/module/hook/OpenSourceLyricBlurPort.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/OpenSourceLyricBlurPort.kt
@@ -14,7 +14,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver
 import android.widget.ImageView
-import kotlin.math.abs
 
 /**
  * Target-independent AMLyricBlur runtime.
@@ -248,18 +247,11 @@ internal class OpenSourceLyricBlurPort(
             visibleRows += child to adapterPos
         }
         val activeIds = highlightSession.snapshot()
-        val gapAnchorPosition = if (highlightSession.isGap()) {
-            val referencePosition = activeIds.maxOrNull()
-            instrumentalRows
-                .asSequence()
-                .map { (_, position) -> position }
-                .filter { position -> position >= 0 }
-                .minByOrNull { position ->
-                    referencePosition?.let { reference -> abs(position - reference) } ?: 0
-                } ?: -1
-        } else {
-            -1
-        }
+        val gapAnchorPosition = BidirectionalBlurPolicy.selectInstrumentalGapAnchor(
+            active = activeIds,
+            isGap = highlightSession.isGap(),
+            instrumentalPositions = instrumentalRows.map { (_, position) -> position },
+        )
         val effectiveIds = BidirectionalBlurPolicy.resolveDisplayHighlights(
             active = activeIds,
             visiblePositions = visibleRows.map { (_, position) -> position },

--- a/app/src/main/java/dev/amenhancer/module/hook/TabletLyricVisualPolicy.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/TabletLyricVisualPolicy.kt
@@ -35,7 +35,10 @@ internal object TabletLyricVisualPolicy {
         return targetPx / scaledDensity
     }
 
-    fun mergeBlurRadius(focusBlurRadius: Float, edgeBlurRadius: Float): Float =
-        max(focusBlurRadius, edgeBlurRadius)
+    fun mergeBlurRadius(
+        focusBlurRadius: Float,
+        edgeBlurRadius: Float,
+        isHighlighted: Boolean = false,
+    ): Float = if (isHighlighted) 0f else max(focusBlurRadius, edgeBlurRadius)
     private const val EDGE_MAX_BLUR_PX = 5f
 }

--- a/app/src/test/java/dev/amenhancer/module/hook/BidirectionalBlurPolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/BidirectionalBlurPolicyTest.kt
@@ -5,16 +5,6 @@ import org.junit.Test
 
 class BidirectionalBlurPolicyTest {
     @Test
-    fun `ordinary lyric gap retains the last non-empty highlight until replacement`() {
-        val active = BidirectionalBlurPolicy.resolveHighlights(emptySet(), setOf(46))
-        val gap = BidirectionalBlurPolicy.resolveHighlights(active, emptySet())
-        val next = BidirectionalBlurPolicy.resolveHighlights(gap, setOf(47))
-
-        assertEquals(setOf(46), gap)
-        assertEquals(setOf(47), next)
-    }
-
-    @Test
     fun `intro without an active highlight focuses the earliest visible lyric row`() {
         assertEquals(
             setOf(0),
@@ -28,6 +18,26 @@ class BidirectionalBlurPolicyTest {
             BidirectionalBlurPolicy.resolveDisplayHighlights(
                 active = setOf(8),
                 visiblePositions = listOf(0, 1, 2),
+            ),
+        )
+    }
+
+    @Test
+    fun `an active instrumental gap anchors blur at the three-dot row`() {
+        assertEquals(
+            setOf(5),
+            BidirectionalBlurPolicy.resolveDisplayHighlights(
+                active = setOf(4),
+                visiblePositions = listOf(3, 4, 6),
+                gapAnchorPosition = 5,
+            ),
+        )
+        assertEquals(
+            setOf(4),
+            BidirectionalBlurPolicy.resolveDisplayHighlights(
+                active = setOf(4),
+                visiblePositions = listOf(3, 4, 6),
+                gapAnchorPosition = -1,
             ),
         )
     }

--- a/app/src/test/java/dev/amenhancer/module/hook/BidirectionalBlurPolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/BidirectionalBlurPolicyTest.kt
@@ -43,6 +43,34 @@ class BidirectionalBlurPolicyTest {
     }
 
     @Test
+    fun `instrumental rows anchor both pre-callback intros and explicit gaps`() {
+        assertEquals(
+            0,
+            BidirectionalBlurPolicy.selectInstrumentalGapAnchor(
+                active = emptySet(),
+                isGap = false,
+                instrumentalPositions = listOf(0),
+            ),
+        )
+        assertEquals(
+            5,
+            BidirectionalBlurPolicy.selectInstrumentalGapAnchor(
+                active = setOf(4),
+                isGap = true,
+                instrumentalPositions = listOf(5),
+            ),
+        )
+        assertEquals(
+            -1,
+            BidirectionalBlurPolicy.selectInstrumentalGapAnchor(
+                active = setOf(4),
+                isGap = false,
+                instrumentalPositions = listOf(5),
+            ),
+        )
+    }
+
+    @Test
     fun `highlighted row is clear and surrounding rows follow open source directional blur`() {
         val highlighted = setOf(10)
 

--- a/app/src/test/java/dev/amenhancer/module/hook/FutureLyricBlurStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/FutureLyricBlurStructuralRegressionTest.kt
@@ -59,15 +59,18 @@ class FutureLyricBlurStructuralRegressionTest {
     }
 
     @Test
-    fun `manual lyric scrolling restores blur after one second`() {
-        assertTrue(portSource.contains("SCROLL_RESTORE_DELAY_MS = 1_000L"))
-        assertTrue(portSource.contains("postDelayed(restoreBlurRunnable, SCROLL_RESTORE_DELAY_MS)"))
+    fun `highlighted rows clear immediately while nonzero blur still animates`() {
+        val compactRenderer = rendererSource.replace(Regex("\\s+"), " ")
+
+        assertTrue(compactRenderer.contains("if (target <= 0f) { clear(view) return@forEach }"))
+        assertTrue(rendererSource.contains("Transition("))
+        assertTrue(rendererSource.contains("scheduleFrame()"))
     }
 
     @Test
-    fun `scroll restore keeps only the current lyric line clear`() {
-        assertFalse(portSource.contains("previousHighlightIds"))
-        assertFalse(portSource.contains("highlightedLineIds +"))
+    fun `manual lyric scrolling restores blur after one second`() {
+        assertTrue(portSource.contains("SCROLL_RESTORE_DELAY_MS = 1_000L"))
+        assertTrue(portSource.contains("postDelayed(restoreBlurRunnable, SCROLL_RESTORE_DELAY_MS)"))
     }
 
     @Test

--- a/app/src/test/java/dev/amenhancer/module/hook/LyricBlurRadiusOffsetStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/LyricBlurRadiusOffsetStructuralRegressionTest.kt
@@ -18,8 +18,8 @@ class LyricBlurRadiusOffsetStructuralRegressionTest {
 
         assertTrue(target.contains("TargetConfigClient.currentSettings().lyricBlurRadiusOffsetPx"))
         assertTrue(runtime.contains("BidirectionalBlurPolicy.applyRadiusOffset("))
-        assertTrue(runtime.contains(
-            "TabletLyricVisualPolicy.mergeBlurRadius(focusBlur, edgeBlur)",
-        ))
+        assertTrue(runtime.contains("TabletLyricVisualPolicy.mergeBlurRadius("))
+        assertTrue(runtime.contains("isHighlighted = includeFocus && adapterPos in effectiveIds"))
+        assertTrue(runtime.contains("applyBlur(includeFocus = false, immediate = true)"))
     }
 }

--- a/app/src/test/java/dev/amenhancer/module/hook/LyricHighlightSessionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/LyricHighlightSessionTest.kt
@@ -16,6 +16,76 @@ class LyricHighlightSessionTest {
 
         assertFalse(session.enter(song))
         assertEquals(setOf(46), session.update(emptySet()))
+        assertTrue(session.isGap())
+    }
+
+    @Test
+    fun `non-empty highlights song changes and fallback events leave gap state`() {
+        val session = LyricHighlightSession()
+
+        session.update(emptySet())
+        session.update(setOf(46))
+        assertFalse(session.isGap())
+
+        session.update(emptySet())
+        session.replace(47)
+        assertFalse(session.isGap())
+
+        session.update(emptySet())
+        session.enter(Any())
+        assertFalse(session.isGap())
+    }
+
+    @Test
+    fun `one callback snapshot keeps every highlighted row clear`() {
+        val session = LyricHighlightSession()
+
+        assertEquals(setOf(46, 47), session.update(setOf(46, 47)))
+        assertEquals(0f, BidirectionalBlurPolicy.targetRadius(46, session.snapshot()))
+        assertEquals(0f, BidirectionalBlurPolicy.targetRadius(47, session.snapshot()))
+    }
+
+    @Test
+    fun `each non-empty callback replaces the complete highlight snapshot`() {
+        val session = LyricHighlightSession()
+
+        session.update(setOf(46))
+
+        assertEquals(setOf(47), session.update(setOf(47)))
+        assertEquals(13f, BidirectionalBlurPolicy.targetRadius(46, session.snapshot()))
+    }
+
+    @Test
+    fun `a line leaving a real multi-highlight snapshot stays clear until the next event`() {
+        val session = LyricHighlightSession()
+
+        session.update(setOf(5, 6))
+
+        assertEquals(setOf(5, 6), session.update(setOf(6)))
+        assertEquals(0f, BidirectionalBlurPolicy.targetRadius(5, session.snapshot()))
+        assertEquals(0f, BidirectionalBlurPolicy.targetRadius(6, session.snapshot()))
+        assertEquals(setOf(5, 6), session.update(setOf(6)))
+    }
+
+    @Test
+    fun `the next distinct highlight snapshot retires a completed overlap`() {
+        val session = LyricHighlightSession()
+
+        session.update(setOf(5, 6))
+        session.update(setOf(6))
+
+        assertEquals(setOf(6, 7), session.update(setOf(6, 7)))
+        assertEquals(13f, BidirectionalBlurPolicy.targetRadius(5, session.snapshot()))
+    }
+
+    @Test
+    fun `seeking backward never retains a departed future line`() {
+        val session = LyricHighlightSession()
+
+        session.update(setOf(5, 6))
+
+        assertEquals(setOf(5), session.update(setOf(5)))
+        assertEquals(8f, BidirectionalBlurPolicy.targetRadius(6, session.snapshot()))
     }
 
     @Test
@@ -36,7 +106,7 @@ class LyricHighlightSessionTest {
     fun `fallback replacement keeps only the latest lyric line clear`() {
         val session = LyricHighlightSession()
 
-        session.replace(46)
+        session.update(setOf(45))
         session.replace(47)
 
         assertEquals(setOf(47), session.snapshot())

--- a/app/src/test/java/dev/amenhancer/module/hook/TabletLyricVisualPolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/TabletLyricVisualPolicyTest.kt
@@ -14,7 +14,10 @@ class TabletLyricVisualPolicyTest {
         assertEquals(0f, edge, TOLERANCE)
         assertEquals(
             12f,
-            TabletLyricVisualPolicy.mergeBlurRadius(focusBlurRadius = 12f, edge),
+            TabletLyricVisualPolicy.mergeBlurRadius(
+                focusBlurRadius = 12f,
+                edgeBlurRadius = edge,
+            ),
             TOLERANCE,
         )
     }
@@ -40,6 +43,19 @@ class TabletLyricVisualPolicyTest {
             TabletLyricVisualPolicy.mergeBlurRadius(
                 focusBlurRadius = 16f,
                 edgeBlurRadius = edgeAt(rowCenterPx = 50f),
+            ),
+            TOLERANCE,
+        )
+    }
+
+    @Test
+    fun `highlighted rows stay clear even inside the tablet edge field`() {
+        assertEquals(
+            0f,
+            TabletLyricVisualPolicy.mergeBlurRadius(
+                focusBlurRadius = 0f,
+                edgeBlurRadius = edgeAt(rowCenterPx = 0f),
+                isHighlighted = true,
             ),
             TOLERANCE,
         )


### PR DESCRIPTION
## Summary
- keep all visually active overlap lines clear without retaining ordinary previous lyrics
- clear highlighted rows immediately and prevent tablet edge blur from overriding them
- anchor empty instrumental gaps to the verified three-dot row while preserving the long-intro fallback
- add regression coverage for overlap, seek direction, gap state, and blur rendering

## Validation
- `gradlew test assembleDebug assembleRelease lintVitalRelease --offline`
- `git diff --check`
- verified on Apple Music 6.5.1/1583 on phone and tablet layouts
- user confirmed dual highlights, bidirectional blur, and instrumental three-dot gaps render correctly