### PR TITLE
feat: remove custom lyrics mapping limit

### DIFF
--- a/app/src/main/java/dev/amenhancer/module/config/ConfigStore.kt
+++ b/app/src/main/java/dev/amenhancer/module/config/ConfigStore.kt
@@ -2,6 +2,7 @@ package dev.amenhancer.module.config
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.os.ParcelFileDescriptor
 import dev.amenhancer.module.ModuleApplication
 import dev.amenhancer.module.XposedServiceSnapshot
 import dev.amenhancer.module.model.CustomLyricsManifest
@@ -14,10 +15,47 @@ class ConfigStore(context: Context) {
         LEGACY_PREFERENCES_NAME,
         Context.MODE_PRIVATE,
     )
+    @Volatile
+    private var cachedIndex: CachedIndex? = null
     fun settings(): ModuleSettings = settings(ModuleApplication.serviceSnapshot)
 
-    internal fun settings(snapshot: XposedServiceSnapshot): ModuleSettings =
-        ModuleSettingsSchema.decode((snapshot.preferences ?: legacyPreferences).all)
+    internal fun settings(snapshot: XposedServiceSnapshot): ModuleSettings {
+        val preferences = snapshot.preferences ?: legacyPreferences
+        return ModuleSettingsSchema.decode(preferences.all)
+    }
+
+    internal fun settingsWithCustomLyrics(snapshot: XposedServiceSnapshot): ModuleSettings {
+        val preferences = snapshot.preferences ?: legacyPreferences
+        val values = preferences.all
+        val base = ModuleSettingsSchema.decode(values)
+        val pointer = ModuleSettingsSchema.decodeIndexPointer(values)
+        val cacheKey = IndexCacheKey(
+            pointer = pointer,
+            legacyManifest = if (pointer == null) {
+                ModuleSettingsSchema.legacyCustomLyricsManifestRaw(values)
+            } else {
+                null
+            },
+        )
+        val manifest = cachedIndex
+            ?.takeIf { it.key == cacheKey }
+            ?.manifest
+            ?: CustomLyricsIndexRepository.state(values) { fileId ->
+                snapshot.openRemoteFile(fileId)?.let { ParcelFileDescriptor.AutoCloseInputStream(it) }
+            }.let { state ->
+                if (state.canCommit) cachedIndex = CachedIndex(cacheKey, state.manifest)
+                state.manifest
+            }
+        return base.copy(customLyricsManifest = manifest)
+    }
+
+    /** Current index state (pointer + resolved manifest) for settings-process mutations. */
+    internal fun indexState(snapshot: XposedServiceSnapshot): CustomLyricsIndexState {
+        val preferences = snapshot.preferences ?: legacyPreferences
+        return CustomLyricsIndexRepository.state(preferences.all) { fileId ->
+            snapshot.openRemoteFile(fileId)?.let { ParcelFileDescriptor.AutoCloseInputStream(it) }
+        }
+    }
 
     fun saveSettings(settings: ModuleSettings): Boolean {
         val preferences = ModuleApplication.serviceSnapshot.preferences ?: return false
@@ -43,8 +81,9 @@ class ConfigStore(context: Context) {
         )
     }
 
-    internal fun saveCustomLyricsManifest(
-        manifest: CustomLyricsManifest,
+    /** Atomic pointer publication; the index file must already be written. */
+    internal fun publishIndexPointer(
+        pointer: CustomLyricsIndexPointer,
         snapshot: XposedServiceSnapshot = ModuleApplication.serviceSnapshot,
     ): Boolean {
         if (!snapshot.isRemoteFileAvailable || !ModuleApplication.isCurrentSnapshot(snapshot)) {
@@ -53,12 +92,22 @@ class ConfigStore(context: Context) {
         val preferences = snapshot.preferences ?: return false
         return writeValues(
             preferences,
-            ModuleSettingsSchema.encodeCustomLyricsManifest(manifest),
+            ModuleSettingsSchema.encodeIndexPointer(pointer),
             synchronous = true,
         )
     }
 
     companion object {
+        private data class IndexCacheKey(
+            val pointer: CustomLyricsIndexPointer?,
+            val legacyManifest: String?,
+        )
+
+        private data class CachedIndex(
+            val key: IndexCacheKey,
+            val manifest: CustomLyricsManifest,
+        )
+
         fun migrateLegacyPreferences(context: Context, destination: SharedPreferences) {
             val legacy = context.getSharedPreferences(
                 LEGACY_PREFERENCES_NAME,

--- a/app/src/main/java/dev/amenhancer/module/config/CustomLyricsIndexPointer.kt
+++ b/app/src/main/java/dev/amenhancer/module/config/CustomLyricsIndexPointer.kt
@@ -1,0 +1,13 @@
+package dev.amenhancer.module.config
+
+/**
+ * Small remote-preference pointer to the remote index file. The pointer is
+ * published atomically after the new index file is written; readers trust it
+ * only when the file's size and SHA-256 match.
+ */
+internal data class CustomLyricsIndexPointer(
+    val fileId: String,
+    val generation: Long,
+    val sha256: String,
+    val sizeBytes: Long,
+)

--- a/app/src/main/java/dev/amenhancer/module/config/CustomLyricsIndexRepository.kt
+++ b/app/src/main/java/dev/amenhancer/module/config/CustomLyricsIndexRepository.kt
@@ -1,0 +1,139 @@
+package dev.amenhancer.module.config
+
+import dev.amenhancer.module.lyrics.CustomLyricsFilePolicy
+import dev.amenhancer.module.model.CustomLyricsManifest
+import java.io.InputStream
+
+/** Current index state: the published pointer (may be stale) plus the resolved manifest. */
+internal data class CustomLyricsIndexState(
+    val pointer: CustomLyricsIndexPointer?,
+    val manifest: CustomLyricsManifest,
+    val canCommit: Boolean = true,
+)
+
+internal sealed interface CustomLyricsIndexCommitResult {
+    data class Committed(
+        val pointer: CustomLyricsIndexPointer,
+        val manifest: CustomLyricsManifest,
+    ) : CustomLyricsIndexCommitResult
+
+    data class Failed(val message: String) : CustomLyricsIndexCommitResult
+}
+
+/**
+ * Extensible remote-file index repository. The whole manifest lives in one
+ * remote index file; remote preferences carry only a small pointer
+ * (fileId/generation/sha256/sizeBytes). Every mutation commits atomically:
+ * write the new index file, synchronously publish the pointer, then
+ * best-effort delete the old index file. A failed pointer publication keeps
+ * the old pointer and deletes the new file.
+ */
+internal class CustomLyricsIndexRepository(
+    private val newIndexFileId: () -> String,
+    private val openFile: (String) -> InputStream?,
+    private val writeRemoteFile: (String, ByteArray) -> Boolean,
+    private val publishPointer: (CustomLyricsIndexPointer) -> Boolean,
+    private val deleteRemoteFile: (String) -> Unit,
+    private val maxIndexBytes: Int = CustomLyricsManifestPolicy.MAX_INDEX_BYTES,
+) {
+    fun state(preferences: Map<String, *>): CustomLyricsIndexState =
+        Companion.state(preferences, openFile)
+
+    fun commit(
+        state: CustomLyricsIndexState,
+        next: CustomLyricsManifest,
+        allowRecovery: Boolean = false,
+    ): CustomLyricsIndexCommitResult {
+        if (!state.canCommit && !allowRecovery) {
+            return CustomLyricsIndexCommitResult.Failed("歌词索引文件不可读，无法修改")
+        }
+        val encoded = CustomLyricsManifestCodec.encode(next).toByteArray(Charsets.UTF_8)
+        if (encoded.size > maxIndexBytes) {
+            return CustomLyricsIndexCommitResult.Failed("歌词索引超出大小上限")
+        }
+        val fileId = runCatching(newIndexFileId).getOrNull()
+            ?: return CustomLyricsIndexCommitResult.Failed("无法生成歌词索引文件 ID")
+        if (!CustomLyricsManifestPolicy.isValidFileId(fileId)) {
+            return CustomLyricsIndexCommitResult.Failed("生成的歌词索引文件 ID 无效")
+        }
+        if (!runCatching { writeRemoteFile(fileId, encoded) }.getOrDefault(false)) {
+            runCatching { deleteRemoteFile(fileId) }
+            return CustomLyricsIndexCommitResult.Failed("无法写入共享歌词索引文件")
+        }
+        val pointer = CustomLyricsIndexPointer(
+            fileId = fileId,
+            generation = (state.pointer?.generation ?: 0L) + 1L,
+            sha256 = CustomLyricsFilePolicy.sha256(encoded),
+            sizeBytes = encoded.size.toLong(),
+        )
+        if (!runCatching { publishPointer(pointer) }.getOrDefault(false)) {
+            runCatching { deleteRemoteFile(fileId) }
+            return CustomLyricsIndexCommitResult.Failed("无法发布歌词索引")
+        }
+        state.pointer?.fileId
+            ?.takeIf { it != fileId }
+            ?.let { oldFileId -> runCatching { deleteRemoteFile(oldFileId) } }
+        return CustomLyricsIndexCommitResult.Committed(pointer, next)
+    }
+
+    companion object {
+        /**
+         * Resolves the current manifest: a verifiable published pointer wins;
+         * otherwise the legacy v1 preference string is used; otherwise empty.
+         */
+        fun state(
+            preferences: Map<String, *>,
+            openFile: (String) -> InputStream?,
+        ): CustomLyricsIndexState {
+            val pointer = ModuleSettingsSchema.decodeIndexPointer(preferences)
+            if (pointer != null) {
+                val bytes = readIndexBytes(pointer.fileId, openFile)
+                if (
+                    bytes != null &&
+                    bytes.size.toLong() == pointer.sizeBytes &&
+                    CustomLyricsFilePolicy.sha256(bytes)
+                        .equals(pointer.sha256, ignoreCase = true)
+                ) {
+                    val decoded = CustomLyricsManifestCodec.decodeIndexFile(
+                        bytes.toString(Charsets.UTF_8),
+                    )
+                    if (decoded != null) return CustomLyricsIndexState(pointer, decoded)
+                }
+                return CustomLyricsIndexState(
+                    pointer = pointer,
+                    manifest = CustomLyricsManifest.empty(),
+                    canCommit = false,
+                )
+            }
+            if (ModuleSettingsSchema.hasIndexPointerValues(preferences)) {
+                return CustomLyricsIndexState(
+                    pointer = null,
+                    manifest = CustomLyricsManifest.empty(),
+                    canCommit = false,
+                )
+            }
+            return CustomLyricsIndexState(
+                pointer = pointer,
+                manifest = ModuleSettingsSchema.decodeLegacyCustomLyricsManifest(preferences),
+            )
+        }
+
+        /** Read-only resolution for processes that never write the index. */
+        fun resolve(
+            preferences: Map<String, *>,
+            openFile: (String) -> InputStream?,
+        ): CustomLyricsManifest = state(preferences, openFile).manifest
+
+        private fun readIndexBytes(
+            fileId: String,
+            openFile: (String) -> InputStream?,
+        ): ByteArray? = runCatching {
+            openFile(fileId)?.use { input ->
+                CustomLyricsFilePolicy.readBounded(
+                    input,
+                    CustomLyricsManifestPolicy.MAX_INDEX_BYTES,
+                )
+            }
+        }.getOrNull()
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/config/CustomLyricsManifestCodec.kt
+++ b/app/src/main/java/dev/amenhancer/module/config/CustomLyricsManifestCodec.kt
@@ -6,7 +6,12 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 
-/** JSON codec for the manifest only; TTML remains in remote files. */
+/**
+ * JSON codec for the manifest only; TTML remains in remote files. Version 2
+ * payloads live in the remote index file; version 1 payloads are the legacy
+ * `custom_lyrics_manifest` preference string and stay readable until the
+ * first write migrates them.
+ */
 internal object CustomLyricsManifestCodec {
     fun encode(manifest: CustomLyricsManifest): String {
         val safe = CustomLyricsManifestPolicy.sanitize(manifest)
@@ -28,36 +33,22 @@ internal object CustomLyricsManifestCodec {
         }.toString()
     }
 
+    /** Tolerant decode for preference strings: accepts current and legacy v1 payloads. */
     fun decode(raw: String): CustomLyricsManifest = runCatching {
         val root = JSONObject(raw)
-        if (root.optInt(KEY_VERSION, 0) != VERSION) return@runCatching CustomLyricsManifest.empty()
-        val entries = root.optJSONArray(KEY_ENTRIES) ?: return@runCatching CustomLyricsManifest.empty()
-        val parsed = buildList {
-            for (index in 0 until entries.length()) {
-                val entry = entries.optJSONObject(index) ?: continue
-                add(
-                    CustomLyricsEntry(
-                        appleMusicId = entry.optLong(KEY_APPLE_MUSIC_ID, 0L),
-                        displayName = entry.optString(KEY_DISPLAY_NAME),
-                        fileId = entry.optString(KEY_FILE_ID),
-                        sizeBytes = entry.optLong(KEY_SIZE_BYTES, 0L),
-                        sha256 = entry.optString(KEY_SHA256),
-                        source = entry.optString(KEY_SOURCE),
-                        enabled = entry.optBoolean(KEY_ENABLED, false),
-                    ),
-                )
-            }
+        if (!isSupportedVersion(root.optInt(KEY_VERSION, 0))) {
+            return@runCatching CustomLyricsManifest.empty()
         }
-        CustomLyricsManifestPolicy.sanitize(CustomLyricsManifest(parsed))
+        val entries = root.optJSONArray(KEY_ENTRIES) ?: return@runCatching CustomLyricsManifest.empty()
+        CustomLyricsManifestPolicy.sanitize(CustomLyricsManifest(parseEntries(entries)))
     }.getOrDefault(CustomLyricsManifest.empty())
 
     /**
-     * Strict decode for backup restore: returns null unless the version
-     * matches exactly, the entries array parses cleanly, and every entry
-     * survives policy sanitization unchanged. A corrupt or foreign-version
-     * manifest is never treated as a valid empty backup.
+     * Strict decode of the remote index file: returns null unless the payload
+     * is exactly a version 2 index document. An empty version 2 index is
+     * authoritative, so it returns an empty manifest instead of null.
      */
-    fun decodeStrict(raw: String): CustomLyricsManifest? {
+    fun decodeIndexFile(raw: String): CustomLyricsManifest? {
         val root = try {
             JSONObject(raw)
         } catch (e: JSONException) {
@@ -65,25 +56,55 @@ internal object CustomLyricsManifestCodec {
         }
         if (root.optInt(KEY_VERSION, 0) != VERSION) return null
         val entries = root.optJSONArray(KEY_ENTRIES) ?: return null
-        if (entries.length() > CustomLyricsManifestPolicy.MAX_ENTRIES) return null
+        return CustomLyricsManifestPolicy.sanitize(CustomLyricsManifest(parseEntries(entries)))
+    }
+
+    /**
+     * Strict decode for backup restore: returns null unless the version
+     * matches exactly, the entries array parses cleanly, and every entry
+     * survives policy sanitization unchanged. A corrupt or foreign-version
+     * manifest is never treated as a valid empty backup. Version 1 backups
+     * written before the index repository remain restorable.
+     */
+    fun decodeStrict(raw: String): CustomLyricsManifest? {
+        val root = try {
+            JSONObject(raw)
+        } catch (e: JSONException) {
+            return null
+        }
+        if (!isSupportedVersion(root.optInt(KEY_VERSION, 0))) return null
+        val entries = root.optJSONArray(KEY_ENTRIES) ?: return null
         val parsed = mutableListOf<CustomLyricsEntry>()
         for (index in 0 until entries.length()) {
             val entry = entries.optJSONObject(index) ?: return null
-            parsed += CustomLyricsEntry(
-                appleMusicId = entry.optLong(KEY_APPLE_MUSIC_ID, 0L),
-                displayName = entry.optString(KEY_DISPLAY_NAME),
-                fileId = entry.optString(KEY_FILE_ID),
-                sizeBytes = entry.optLong(KEY_SIZE_BYTES, 0L),
-                sha256 = entry.optString(KEY_SHA256),
-                source = entry.optString(KEY_SOURCE),
-                enabled = entry.optBoolean(KEY_ENABLED, false),
-            )
+            parsed += parseEntry(entry)
         }
         val sanitized = CustomLyricsManifestPolicy.sanitize(CustomLyricsManifest(parsed))
         return sanitized.takeIf { it.entries.size == parsed.size }
     }
 
-    private const val VERSION = 1
+    private fun isSupportedVersion(version: Int): Boolean =
+        version == VERSION || version == LEGACY_VERSION
+
+    private fun parseEntries(entries: JSONArray): List<CustomLyricsEntry> = buildList {
+        for (index in 0 until entries.length()) {
+            val entry = entries.optJSONObject(index) ?: continue
+            add(parseEntry(entry))
+        }
+    }
+
+    private fun parseEntry(entry: JSONObject): CustomLyricsEntry = CustomLyricsEntry(
+        appleMusicId = entry.optLong(KEY_APPLE_MUSIC_ID, 0L),
+        displayName = entry.optString(KEY_DISPLAY_NAME),
+        fileId = entry.optString(KEY_FILE_ID),
+        sizeBytes = entry.optLong(KEY_SIZE_BYTES, 0L),
+        sha256 = entry.optString(KEY_SHA256),
+        source = entry.optString(KEY_SOURCE),
+        enabled = entry.optBoolean(KEY_ENABLED, false),
+    )
+
+    private const val VERSION = 2
+    private const val LEGACY_VERSION = 1
     private const val KEY_VERSION = "version"
     private const val KEY_ENTRIES = "entries"
     private const val KEY_APPLE_MUSIC_ID = "appleMusicId"

--- a/app/src/main/java/dev/amenhancer/module/config/CustomLyricsManifestPolicy.kt
+++ b/app/src/main/java/dev/amenhancer/module/config/CustomLyricsManifestPolicy.kt
@@ -5,9 +5,10 @@ import dev.amenhancer.module.model.CustomLyricsEntry
 import dev.amenhancer.module.model.CustomLyricsManifest
 import dev.amenhancer.module.model.CustomLyricsSources
 
-/** Validates the small cross-process index without trusting remote preferences. */
+/** Validates the cross-process index without trusting remote preferences. */
 internal object CustomLyricsManifestPolicy {
-    const val MAX_ENTRIES = 32
+    /** Upper bound for the remote index file that carries the whole manifest. */
+    const val MAX_INDEX_BYTES = 8 * 1024 * 1024
 
     private val fileIdPattern = Regex("[A-Za-z0-9_-]{1,96}")
     private val sha256Pattern = Regex("[0-9a-fA-F]{64}")
@@ -21,12 +22,14 @@ internal object CustomLyricsManifestPolicy {
         val entries = linkedMapOf<Long, CustomLyricsEntry>()
         manifest.entries.forEach { raw ->
             val entry = sanitizeEntry(raw) ?: return@forEach
-            if (entries.size < MAX_ENTRIES && entry.appleMusicId !in entries) {
+            if (entry.appleMusicId !in entries) {
                 entries[entry.appleMusicId] = entry
             }
         }
         return CustomLyricsManifest(entries.values.toList())
     }
+
+    fun isValidSha256(sha256: String): Boolean = sha256Pattern.matches(sha256)
 
     fun sanitizeDisplayName(displayName: String): String = displayName
         .filterNot(Char::isISOControl)
@@ -41,7 +44,7 @@ internal object CustomLyricsManifestPolicy {
         if (raw.appleMusicId <= 0L) return null
         if (!isValidFileId(raw.fileId)) return null
         if (raw.sizeBytes !in 1L..TtmlInputPolicy.MAX_TTML_BYTES.toLong()) return null
-        if (!sha256Pattern.matches(raw.sha256)) return null
+        if (!isValidSha256(raw.sha256)) return null
         if (raw.source !in allowedSources) return null
         return raw.copy(
             displayName = sanitizeDisplayName(raw.displayName),

--- a/app/src/main/java/dev/amenhancer/module/config/ModuleSettingsSchema.kt
+++ b/app/src/main/java/dev/amenhancer/module/config/ModuleSettingsSchema.kt
@@ -73,6 +73,49 @@ internal object ModuleSettingsSchema {
     fun encodeCustomLyricsManifest(manifest: CustomLyricsManifest): Map<String, Any> =
         linkedMapOf(KEY_CUSTOM_LYRICS_MANIFEST to CustomLyricsManifestCodec.encode(manifest))
 
+    /**
+     * Pointer keys point at the remote index file. They are index state, not
+     * settings: never emitted by [encode] or [encodeOrdinarySettings], so an
+     * ordinary settings write can never overwrite a published index pointer.
+     */
+    fun encodeIndexPointer(pointer: CustomLyricsIndexPointer): Map<String, Any> =
+        linkedMapOf(
+            KEY_CUSTOM_LYRICS_INDEX_FILE_ID to pointer.fileId,
+            KEY_CUSTOM_LYRICS_INDEX_GENERATION to pointer.generation,
+            KEY_CUSTOM_LYRICS_INDEX_SHA256 to pointer.sha256,
+            KEY_CUSTOM_LYRICS_INDEX_SIZE_BYTES to pointer.sizeBytes,
+        )
+
+    /** Fails closed: a pointer must be complete, well-formed, and published at least once. */
+    fun decodeIndexPointer(values: Map<String, *>): CustomLyricsIndexPointer? {
+        val fileId = values.string(KEY_CUSTOM_LYRICS_INDEX_FILE_ID)
+        val generation = values.long(KEY_CUSTOM_LYRICS_INDEX_GENERATION)
+        val sha256 = values.string(KEY_CUSTOM_LYRICS_INDEX_SHA256)
+        val sizeBytes = values.long(KEY_CUSTOM_LYRICS_INDEX_SIZE_BYTES)
+        if (generation == null || generation < 1L) return null
+        if (sizeBytes == null || sizeBytes !in 1L..CustomLyricsManifestPolicy.MAX_INDEX_BYTES.toLong()) {
+            return null
+        }
+        if (!CustomLyricsManifestPolicy.isValidFileId(fileId)) return null
+        if (!CustomLyricsManifestPolicy.isValidSha256(sha256)) return null
+        return CustomLyricsIndexPointer(
+            fileId = fileId,
+            generation = generation,
+            sha256 = sha256.lowercase(),
+            sizeBytes = sizeBytes,
+        )
+    }
+
+    fun hasIndexPointerValues(values: Map<String, *>): Boolean =
+        indexPointerKeys.any(values::containsKey)
+
+    /** Legacy v1 preference-string manifest, kept for pre-migration reads. */
+    fun decodeLegacyCustomLyricsManifest(values: Map<String, *>): CustomLyricsManifest =
+        CustomLyricsManifestCodec.decode(values.string(KEY_CUSTOM_LYRICS_MANIFEST))
+
+    fun legacyCustomLyricsManifestRaw(values: Map<String, *>): String =
+        values.string(KEY_CUSTOM_LYRICS_MANIFEST)
+
     private fun Map<String, *>.fontManifest(): LyricsFontManifest {
         val raw = LyricsFontManifest(
             enabled = boolean(KEY_FONT_ENABLED, default = false),
@@ -85,7 +128,7 @@ internal object ModuleSettingsSchema {
     }
 
     private fun Map<String, *>.customLyricsManifest(): CustomLyricsManifest =
-        CustomLyricsManifestCodec.decode(string(KEY_CUSTOM_LYRICS_MANIFEST))
+        decodeLegacyCustomLyricsManifest(this)
 
     private fun Map<String, *>.string(key: String): String = this[key] as? String ?: ""
 
@@ -128,6 +171,13 @@ internal object ModuleSettingsSchema {
         KEY_CUSTOM_LYRICS_MANIFEST,
     )
 
+    private val indexPointerKeys = setOf(
+        KEY_CUSTOM_LYRICS_INDEX_FILE_ID,
+        KEY_CUSTOM_LYRICS_INDEX_GENERATION,
+        KEY_CUSTOM_LYRICS_INDEX_SHA256,
+        KEY_CUSTOM_LYRICS_INDEX_SIZE_BYTES,
+    )
+
     private const val KEY_DUAL_PANE = "dual_pane_enabled"
     private const val KEY_DISABLE_EDITORIAL_VIDEO_ON_TABLET =
         "disable_editorial_video_on_tablet"
@@ -142,5 +192,9 @@ internal object ModuleSettingsSchema {
     private const val KEY_FONT_SIZE_BYTES = "lyrics_font_size_bytes"
     private const val KEY_FONT_SHA256 = "lyrics_font_sha256"
     private const val KEY_CUSTOM_LYRICS_MANIFEST = "custom_lyrics_manifest"
+    private const val KEY_CUSTOM_LYRICS_INDEX_FILE_ID = "custom_lyrics_index_file_id"
+    private const val KEY_CUSTOM_LYRICS_INDEX_GENERATION = "custom_lyrics_index_generation"
+    private const val KEY_CUSTOM_LYRICS_INDEX_SHA256 = "custom_lyrics_index_sha256"
+    private const val KEY_CUSTOM_LYRICS_INDEX_SIZE_BYTES = "custom_lyrics_index_size_bytes"
     private const val KEY_SCHEMA_VERSION = "schema_version"
 }

--- a/app/src/main/java/dev/amenhancer/module/config/TargetConfigClient.kt
+++ b/app/src/main/java/dev/amenhancer/module/config/TargetConfigClient.kt
@@ -3,6 +3,7 @@ package dev.amenhancer.module.config
 import android.content.SharedPreferences
 import android.os.ParcelFileDescriptor
 import dev.amenhancer.module.hook.ModernXposedRuntime
+import dev.amenhancer.module.model.CustomLyricsManifest
 import dev.amenhancer.module.model.FeatureHealth
 import dev.amenhancer.module.model.ModuleSettings
 
@@ -10,10 +11,34 @@ class TargetConfigClient(
     private val preferences: SharedPreferences,
     private val remoteFileOpener: ((String) -> ParcelFileDescriptor)? = null,
 ) {
+    @Volatile
+    private var cachedIndex: CachedIndex? = null
+
     init {
         active = this
     }
+    /** Ordinary feature settings only; never opens the potentially large lyrics index. */
     fun settings(): ModuleSettings = ModuleSettingsSchema.decode(preferences.all)
+
+    /** Background custom-lyrics index read. */
+    fun customLyricsManifest(): CustomLyricsManifest {
+        val values = preferences.all
+        val pointer = ModuleSettingsSchema.decodeIndexPointer(values)
+        val key = IndexCacheKey(
+            pointer = pointer,
+            legacyManifest = if (pointer == null) {
+                ModuleSettingsSchema.legacyCustomLyricsManifestRaw(values)
+            } else {
+                null
+            },
+        )
+        cachedIndex?.takeIf { it.key == key }?.let { return it.manifest }
+        val state = CustomLyricsIndexRepository.state(values) { fileId ->
+            remoteFileOpener?.invoke(fileId)?.let { ParcelFileDescriptor.AutoCloseInputStream(it) }
+        }
+        if (state.canCommit) cachedIndex = CachedIndex(key, state.manifest)
+        return state.manifest
+    }
 
     fun openRemoteFile(name: String): ParcelFileDescriptor? =
         runCatching { remoteFileOpener?.invoke(name) }.getOrNull()
@@ -31,4 +56,14 @@ class TargetConfigClient(
         fun currentSettings(): ModuleSettings = active?.settings()
             ?: ModuleSettings(phoneLiquidGlassEnabled = false)
     }
+
+    private data class IndexCacheKey(
+        val pointer: CustomLyricsIndexPointer?,
+        val legacyManifest: String?,
+    )
+
+    private data class CachedIndex(
+        val key: IndexCacheKey,
+        val manifest: CustomLyricsManifest,
+    )
 }

--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicCustomLyricsTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicCustomLyricsTarget.kt
@@ -4,6 +4,7 @@ import android.os.ParcelFileDescriptor
 import dev.amenhancer.module.config.TargetConfigClient
 import dev.amenhancer.module.lyrics.CustomLyricsFilePolicy
 import dev.amenhancer.module.lyrics.CustomLyricsFileReader
+import dev.amenhancer.module.model.CustomLyricsEntry
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
@@ -67,7 +68,11 @@ internal class AppleMusicCustomLyricsTarget(
             }
         }
         val session = CustomLyricsReplacementSession(
-            manifestProvider = { config.settings().customLyricsManifest },
+            index = CustomLyricsIndexProvider {
+                config.customLyricsManifest().entries.associateBy(
+                    CustomLyricsEntry::appleMusicId,
+                )
+            },
             readTtml = fileReader::read,
             parseTtml = parser::parse,
             isAlive = parser::isAlive,

--- a/app/src/main/java/dev/amenhancer/module/hook/CustomLyricsReplacementSession.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/CustomLyricsReplacementSession.kt
@@ -1,19 +1,34 @@
 package dev.amenhancer.module.hook
 
 import dev.amenhancer.module.model.CustomLyricsEntry
-import dev.amenhancer.module.model.CustomLyricsManifest
 import java.util.LinkedHashMap
 import java.util.concurrent.Executor
 import java.util.concurrent.RejectedExecutionException
-import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Pure-Kotlin seam for the lightweight Apple-Music-ID → entry index consumed
+ * by [CustomLyricsReplacementSession]. Today the remote-preferences manifest
+ * backs it; the unbounded-index task can later swap in a sharded remote-file
+ * index without changing the session. The seam never guesses a remote-file
+ * format — it only promises an in-memory snapshot of the current mappings.
+ */
+internal fun interface CustomLyricsIndexProvider {
+    /** Loads the current index snapshot, or null when the index is unavailable. */
+    fun load(): Map<Long, CustomLyricsEntry>?
+}
 
 /**
  * Resolves only user-published ID mappings. It intentionally has no metadata
  * matching, network, or refresh behavior in the hook path. Remote
  * files and native parsing are prepared off-hook; I2 only consumes a cache.
+ *
+ * The index is loaded off-hook as a lightweight snapshot; lyric bodies and
+ * native parsing are prepared per requested Apple Music ID on a single
+ * background thread, deduplicated by ID. A miss for an unknown ID triggers
+ * one background index refresh to discover mappings published after startup.
  */
 internal class CustomLyricsReplacementSession(
-    private val manifestProvider: () -> CustomLyricsManifest,
+    private val index: CustomLyricsIndexProvider,
     private val readTtml: (CustomLyricsEntry) -> String?,
     private val parseTtml: (String) -> Any?,
     private val isAlive: (Any?) -> Boolean,
@@ -29,23 +44,34 @@ internal class CustomLyricsReplacementSession(
         val sha256: String,
     )
 
+    /**
+     * Bounded, access-order pointer cache whose capacity is independent of
+     * the mapping count; entries that fall out are re-prepared on demand.
+     */
     private val cache = object : LinkedHashMap<CacheKey, Any>(CACHE_CAPACITY, 0.75f, true) {
         override fun removeEldestEntry(eldest: MutableMap.MutableEntry<CacheKey, Any>?): Boolean =
             size > CACHE_CAPACITY
     }
     @Volatile
     private var entriesById: Map<Long, CustomLyricsEntry> = emptyMap()
-    private val preloadQueued = AtomicBoolean(false)
+    private val lock = Any()
+    private val pendingPrepares = mutableSetOf<Long>()
+    private var refreshQueued = false
 
+    /** Queues the initial lightweight index load; never prepares lyric bodies. */
     fun start() {
-        queuePreload()
+        synchronized(lock) {
+            if (refreshQueued) return
+            refreshQueued = true
+            enqueueRefresh()
+        }
     }
 
     fun replacementFor(appleMusicId: Long): Any? {
         if (appleMusicId <= 0L) return null
         readyReplacementFor(appleMusicId)?.let { return it }
-        queuePreload()
-        return null
+        request(appleMusicId, refreshOnUnknown = true)
+        return readyReplacementFor(appleMusicId)
     }
 
     /** Ready cache only; safe for availability predicates and other hot paths. */
@@ -65,66 +91,111 @@ internal class CustomLyricsReplacementSession(
 
     /** Returns a ready pointer or queues off-hook recovery for a known mapping. */
     fun replacementOrPrepareFor(appleMusicId: Long): Any? {
-        if (appleMusicId <= 0L || !entriesById.containsKey(appleMusicId)) return null
+        if (appleMusicId <= 0L || appleMusicId !in entriesById) return null
         readyReplacementFor(appleMusicId)?.let { return it }
-        queuePreload()
-        return null
+        request(appleMusicId, refreshOnUnknown = false)
+        return readyReplacementFor(appleMusicId)
     }
 
-    private fun queuePreload() {
-        if (!preloadQueued.compareAndSet(false, true)) return
-        try {
-            executor.execute {
-                try {
-                    preload()
-                } finally {
-                    preloadQueued.set(false)
+    /**
+     * Deduplicated background request: a known ID queues a single-entry
+     * prepare, an unknown ID queues a single index refresh so mappings
+     * published after startup can be discovered. An unknown ID arriving
+     * while a refresh is already queued is still registered so the in-flight
+     * refresh can resolve it.
+     */
+    private fun request(appleMusicId: Long, refreshOnUnknown: Boolean) {
+        synchronized(lock) {
+            if (appleMusicId in pendingPrepares) return
+            val entry = entriesById[appleMusicId]
+            when {
+                entry != null -> {
+                    pendingPrepares += appleMusicId
+                    enqueuePrepare(appleMusicId)
+                }
+                refreshOnUnknown -> {
+                    pendingPrepares += appleMusicId
+                    if (!refreshQueued) {
+                        refreshQueued = true
+                        enqueueRefresh()
+                    }
                 }
             }
+        }
+    }
+
+    private fun enqueuePrepare(appleMusicId: Long) {
+        try {
+            executor.execute { prepare(appleMusicId) }
         } catch (_: RejectedExecutionException) {
-            preloadQueued.set(false)
-            logger("custom lyrics preloader rejected its task")
+            synchronized(lock) { pendingPrepares.remove(appleMusicId) }
+            logger("custom lyrics prepare was rejected for $appleMusicId")
         }
     }
 
-    private fun preload() {
-        val manifest = runCatching { manifestProvider() }.getOrElse { error ->
-            logger("custom lyrics manifest read failed: $error")
-            return
+    private fun enqueueRefresh() {
+        try {
+            executor.execute { refreshIndex() }
+        } catch (_: RejectedExecutionException) {
+            synchronized(lock) { refreshQueued = false }
+            logger("custom lyrics index refresh was rejected")
         }
-        val entries = manifest.entries
-            .filter(CustomLyricsEntry::enabled)
-            .associateBy(CustomLyricsEntry::appleMusicId)
-        entriesById = entries
-        val activeKeys = entries.values.mapTo(mutableSetOf()) { entry ->
-            CacheKey(entry.appleMusicId, entry.fileId, entry.sha256)
-        }
-        synchronized(cache) {
-            cache.keys.retainAll(activeKeys)
-        }
-        entries.values.forEach(::prepare)
     }
 
-    private fun prepare(entry: CustomLyricsEntry) {
-        val key = CacheKey(entry.appleMusicId, entry.fileId, entry.sha256)
-        synchronized(cache) {
-            cache[key]?.let { cached ->
-                if (isPrepared(cached, entry.appleMusicId)) return
-                cache.remove(key)
+    /** Reloads the lightweight index only; never reads lyric bodies or parses. */
+    private fun refreshIndex() {
+        val loaded = runCatching { index.load() }.getOrElse { error ->
+            logger("custom lyrics index read failed: $error")
+            synchronized(lock) {
+                refreshQueued = false
+                pendingPrepares.clear()
             }
-        }
-        val ttml = runCatching { readTtml(entry) }.getOrNull() ?: return
-        val replacement = runCatching { parseTtml(ttml) }.getOrNull() ?: return
-        if (!isPrepared(replacement, entry.appleMusicId) && !bindAdamId(replacement, entry.appleMusicId)) {
-            logger("custom lyrics parser returned an unusable SongInfoPtr for ${entry.appleMusicId}")
             return
         }
-        if (!isPrepared(replacement, entry.appleMusicId)) {
-            logger("custom lyrics SongInfoPtr Adam ID binding failed for ${entry.appleMusicId}")
-            return
+        val refreshed = loaded.orEmpty().filterValues(CustomLyricsEntry::enabled)
+        val appeared = mutableListOf<Long>()
+        synchronized(lock) {
+            refreshQueued = false
+            entriesById = refreshed
+            val activeKeys = refreshed.values.mapTo(mutableSetOf()) { entry ->
+                CacheKey(entry.appleMusicId, entry.fileId, entry.sha256)
+            }
+            synchronized(cache) {
+                cache.keys.retainAll(activeKeys)
+            }
+            appeared += pendingPrepares.filter { it in refreshed }
+            pendingPrepares.retainAll { it in refreshed }
         }
-        synchronized(cache) {
-            cache[key] = replacement
+        appeared.forEach(::prepare)
+    }
+
+    private fun prepare(appleMusicId: Long) {
+        try {
+            val entry = synchronized(lock) { entriesById[appleMusicId] } ?: return
+            val key = CacheKey(entry.appleMusicId, entry.fileId, entry.sha256)
+            synchronized(cache) {
+                cache[key]?.let { cached ->
+                    if (isPrepared(cached, appleMusicId)) return
+                    cache.remove(key)
+                }
+            }
+            val ttml = runCatching { readTtml(entry) }.getOrNull() ?: return
+            val replacement = runCatching { parseTtml(ttml) }.getOrNull() ?: return
+            if (!isPrepared(replacement, appleMusicId) && !bindAdamId(replacement, appleMusicId)) {
+                logger("custom lyrics parser returned an unusable SongInfoPtr for $appleMusicId")
+                return
+            }
+            if (!isPrepared(replacement, appleMusicId)) {
+                logger("custom lyrics SongInfoPtr Adam ID binding failed for $appleMusicId")
+                return
+            }
+            synchronized(cache) {
+                cache[key] = replacement
+            }
+        } finally {
+            synchronized(lock) {
+                pendingPrepares.remove(appleMusicId)
+            }
         }
     }
 

--- a/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsBackupCodec.kt
+++ b/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsBackupCodec.kt
@@ -4,6 +4,9 @@ import dev.amenhancer.module.config.CustomLyricsManifestCodec
 import dev.amenhancer.module.config.CustomLyricsManifestPolicy
 import dev.amenhancer.module.model.CustomLyricsEntry
 import dev.amenhancer.module.model.CustomLyricsManifest
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
 import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
 import java.io.IOException
@@ -23,28 +26,60 @@ internal sealed interface CustomLyricsBackupDecodeResult {
     data class Rejected(val message: String) : CustomLyricsBackupDecodeResult
 }
 
-/** Decoded backup payload: the manifest plus one validated TTML file per entry. */
+/**
+ * Decoded backup payload: the validated manifest; TTML bodies are delivered
+ * one at a time by [CustomLyricsBackupCodec.decode] and never held together.
+ */
 internal data class CustomLyricsBackup(
     val manifest: CustomLyricsManifest,
-    val files: Map<String, ByteArray>,
 )
 
 /**
- * Bounded ZIP backup format: exactly one [MANIFEST_JSON_NAME] plus one file
- * per manifest entry named by its fileId. Every TTML body passes the same
- * size/hash/TTML-policy validation as [CustomLyricsFileReader]; decode never
- * touches disk and rejects directories, duplicates, missing or extra files,
- * invalid names, unsupported versions, and anything exceeding the size caps.
+ * Streaming bounded ZIP backup format: exactly one [MANIFEST_JSON_NAME] as the
+ * first entry plus one file per manifest entry named by its fileId. At most
+ * one TTML body is in memory at a time: encode reads and validates each
+ * remote file just before writing its ZIP entry; decode delivers each fully
+ * validated file through its [onFile] as the scan proceeds and retains only
+ * the manifest. Every TTML body passes the same size/hash/TTML-policy
+ * validation as [CustomLyricsFileReader]; decode never touches disk and
+ * rejects directories, duplicates, files before the manifest, invalid names,
+ * unsupported versions, missing or extra files, and anything exceeding the
+ * resource guards below.
  */
 internal object CustomLyricsBackupCodec {
 
     private const val MANIFEST_JSON_NAME = "manifest.json"
-    private const val MAX_MANIFEST_JSON_BYTES = 64 * 1024
-    private const val MAX_ZIP_ENTRIES = CustomLyricsManifestPolicy.MAX_ENTRIES + 1
-    private val MAX_TOTAL_TTML_BYTES =
-        TtmlInputPolicy.MAX_TTML_BYTES.toLong() * CustomLyricsManifestPolicy.MAX_ENTRIES
+    private const val VERSION = 2
+    private const val LEGACY_VERSION = 1
+    private const val KEY_VERSION = "version"
+    private const val KEY_ENTRIES = "entries"
+    private const val KEY_APPLE_MUSIC_ID = "appleMusicId"
+    private const val KEY_DISPLAY_NAME = "displayName"
+    private const val KEY_FILE_ID = "fileId"
+    private const val KEY_SIZE_BYTES = "sizeBytes"
+    private const val KEY_SHA256 = "sha256"
+    private const val KEY_SOURCE = "source"
+    private const val KEY_ENABLED = "enabled"
 
-    /** Writes and closes [out]; fails the whole backup if any entry read fails. */
+    /**
+     * Independent resource guards for untrusted backups, not user-facing
+     * feature limits. Any manifest restorable into the 8 MiB index budget
+     * stays far below them: a sanitized entry encodes to at least ~166 JSON
+     * bytes (the SHA-256 alone is 64), so the entry-count guard derived from
+     * that budget with a 128-byte floor can never be hit by a valid backup.
+     */
+    private const val MAX_MANIFEST_JSON_BYTES = 8 * 1024 * 1024
+    private const val MAX_TOTAL_TTML_BYTES = 256L * 1024 * 1024
+    private const val MIN_ENTRY_JSON_BYTES = 128
+    private const val MAX_ZIP_ENTRIES = MAX_MANIFEST_JSON_BYTES / MIN_ENTRY_JSON_BYTES + 1
+
+    /**
+     * Writes and closes [out]; fails the whole backup as soon as any entry
+     * cannot be read or validated. Each TTML body is read, validated, and
+     * written before the next one is read. A failed backup leaves at most a
+     * partial ZIP that decode always rejects, because decode requires every
+     * manifest file to be present.
+     */
     fun encode(
         manifest: CustomLyricsManifest,
         readRemoteFile: (String) -> ByteArray?,
@@ -54,20 +89,29 @@ internal object CustomLyricsBackupCodec {
         if (safe.entries.size != manifest.entries.size) {
             return CustomLyricsBackupEncodeResult.Failed("歌词映射无效，无法备份")
         }
-        val reader = CustomLyricsFileReader(readRemoteFile)
-        val payload = buildList {
-            safe.entries.forEach { entry ->
-                val ttml = reader.read(entry)
-                    ?: return CustomLyricsBackupEncodeResult.Failed("读取歌词文件失败：${entry.displayName}")
-                add(entry to ttml.toByteArray(Charsets.UTF_8))
-            }
+        val manifestBytes = CustomLyricsManifestCodec.encode(safe).toByteArray(Charsets.UTF_8)
+        if (manifestBytes.size > MAX_MANIFEST_JSON_BYTES) {
+            return CustomLyricsBackupEncodeResult.Failed("歌词索引超出备份大小上限")
+        }
+        if (safe.entries.sumOf(CustomLyricsEntry::sizeBytes) > MAX_TOTAL_TTML_BYTES) {
+            return CustomLyricsBackupEncodeResult.Failed("歌词备份总量超过上限")
         }
         return try {
             ZipOutputStream(BufferedOutputStream(out)).use { zip ->
                 zip.putNextEntry(ZipEntry(MANIFEST_JSON_NAME))
-                zip.write(CustomLyricsManifestCodec.encode(safe).toByteArray(Charsets.UTF_8))
+                zip.write(manifestBytes)
                 zip.closeEntry()
-                payload.forEach { (entry, bytes) ->
+                safe.entries.forEach { entry ->
+                    val bytes = runCatching { readRemoteFile(entry.fileId) }.getOrNull()
+                        ?: return CustomLyricsBackupEncodeResult.Failed("读取歌词文件失败：${entry.displayName}")
+                    if (
+                        bytes.size.toLong() != entry.sizeBytes ||
+                        !CustomLyricsFilePolicy.sha256(bytes).equals(entry.sha256, ignoreCase = true) ||
+                        CustomLyricsFilePolicy.inspect(bytes.toString(Charsets.UTF_8))
+                            !is CustomLyricsInspection.Accepted
+                    ) {
+                        return CustomLyricsBackupEncodeResult.Failed("读取歌词文件失败：${entry.displayName}")
+                    }
                     zip.putNextEntry(ZipEntry(entry.fileId))
                     zip.write(bytes)
                     zip.closeEntry()
@@ -79,12 +123,23 @@ internal object CustomLyricsBackupCodec {
         }
     }
 
-    /** Reads and closes [input]; returns only fully validated payloads. */
-    fun decode(input: InputStream): CustomLyricsBackupDecodeResult {
+    /**
+     * Single-pass streaming decode: reads and closes [input], calling [onFile]
+     * once per fully validated TTML file before returning. `manifest.json`
+     * must be the first entry; every file entry is validated against the
+     * manifest (size, SHA-256, TTML policy) before delivery, so [onFile] never
+     * sees unvalidated bytes. Returns only fully validated payloads.
+     */
+    fun decode(
+        input: InputStream,
+        onFile: (fileId: String, bytes: ByteArray) -> Unit,
+    ): CustomLyricsBackupDecodeResult {
         var manifestJson: ByteArray? = null
-        val files = linkedMapOf<String, ByteArray>()
+        var manifest: CustomLyricsManifest? = null
+        var expectedByFileId: Map<String, CustomLyricsEntry>? = null
+        val seenFileIds = mutableSetOf<String>()
         var entryCount = 0
-        var totalBytes = 0L
+        var totalTtmlBytes = 0L
         return try {
             ZipInputStream(BufferedInputStream(input)).use { zip ->
                 while (true) {
@@ -101,44 +156,48 @@ internal object CustomLyricsBackupCodec {
                         if (manifestJson != null) {
                             return CustomLyricsBackupDecodeResult.Rejected("备份包含重复的 manifest.json")
                         }
-                        manifestJson = CustomLyricsFilePolicy.readBounded(zip)
-                        if (manifestJson.size > MAX_MANIFEST_JSON_BYTES) {
-                            return CustomLyricsBackupDecodeResult.Rejected("manifest.json 超出大小上限")
+                        manifestJson = CustomLyricsFilePolicy.readBounded(zip, MAX_MANIFEST_JSON_BYTES)
+                        val parsed = parseManifestStrict(manifestJson.toString(Charsets.UTF_8))
+                            ?: return CustomLyricsBackupDecodeResult.Rejected("manifest.json 无效或不支持的版本")
+                        if (parsed.entries.map(CustomLyricsEntry::fileId).distinct().size != parsed.entries.size) {
+                            return CustomLyricsBackupDecodeResult.Rejected("备份文件与映射不一致")
                         }
+                        manifest = parsed
+                        expectedByFileId = parsed.entries.associateBy(CustomLyricsEntry::fileId)
                     } else {
                         if (!CustomLyricsManifestPolicy.isValidFileId(name)) {
                             return CustomLyricsBackupDecodeResult.Rejected("备份包含非法文件名：$name")
                         }
-                        if (files.containsKey(name)) {
+                        if (!seenFileIds.add(name)) {
                             return CustomLyricsBackupDecodeResult.Rejected("备份包含重复文件：$name")
                         }
                         val bytes = CustomLyricsFilePolicy.readBounded(zip)
-                        files[name] = bytes
-                        totalBytes += bytes.size
-                        if (totalBytes > MAX_TOTAL_TTML_BYTES) {
+                        totalTtmlBytes += bytes.size
+                        if (totalTtmlBytes > MAX_TOTAL_TTML_BYTES) {
                             return CustomLyricsBackupDecodeResult.Rejected("备份解压总量超过上限")
                         }
+                        val expected = expectedByFileId?.get(name)
+                            ?: return CustomLyricsBackupDecodeResult.Rejected(
+                                if (manifestJson == null) "备份缺少 manifest.json" else "备份文件与映射不一致",
+                            )
+                        if (
+                            bytes.size.toLong() != expected.sizeBytes ||
+                            !CustomLyricsFilePolicy.sha256(bytes).equals(expected.sha256, ignoreCase = true) ||
+                            CustomLyricsFilePolicy.inspect(bytes.toString(Charsets.UTF_8))
+                                !is CustomLyricsInspection.Accepted
+                        ) {
+                            return CustomLyricsBackupDecodeResult.Rejected("歌词文件校验失败：${expected.displayName}")
+                        }
+                        onFile(name, bytes)
                     }
                     zip.closeEntry()
                 }
-                val raw = manifestJson
+                val parsed = manifest
                     ?: return CustomLyricsBackupDecodeResult.Rejected("备份缺少 manifest.json")
-                val manifest = CustomLyricsManifestCodec.decodeStrict(raw.toString(Charsets.UTF_8))
-                    ?: return CustomLyricsBackupDecodeResult.Rejected("manifest.json 无效或不支持的版本")
-                val expectedFileIds = manifest.entries.map(CustomLyricsEntry::fileId)
-                if (
-                    expectedFileIds.size != expectedFileIds.toSet().size ||
-                    expectedFileIds.toSet() != files.keys
-                ) {
+                if (parsed.entries.any { it.fileId !in seenFileIds }) {
                     return CustomLyricsBackupDecodeResult.Rejected("备份文件与映射不一致")
                 }
-                val reader = CustomLyricsFileReader { fileId -> files[fileId] }
-                manifest.entries.forEach { entry ->
-                    if (reader.read(entry) == null) {
-                        return CustomLyricsBackupDecodeResult.Rejected("歌词文件校验失败：${entry.displayName}")
-                    }
-                }
-                CustomLyricsBackupDecodeResult.Decoded(CustomLyricsBackup(manifest, files))
+                CustomLyricsBackupDecodeResult.Decoded(CustomLyricsBackup(parsed))
             }
         } catch (e: CustomLyricsFilePolicy.SizeLimitExceeded) {
             CustomLyricsBackupDecodeResult.Rejected("备份解压超过大小上限")
@@ -146,4 +205,39 @@ internal object CustomLyricsBackupCodec {
             CustomLyricsBackupDecodeResult.Rejected("读取备份失败")
         }
     }
+
+    /**
+     * Strict manifest decode for backups: mirrors the config codec's strict
+     * decode minus the fixed entry cap, so backups beyond 32 entries restore.
+     * Rejects foreign versions, malformed payloads, and any entry that policy
+     * would alter or deduplicate.
+     */
+    private fun parseManifestStrict(raw: String): CustomLyricsManifest? {
+        val root = try {
+            JSONObject(raw)
+        } catch (e: JSONException) {
+            return null
+        }
+        val version = root.optInt(KEY_VERSION, 0)
+        if (version != VERSION && version != LEGACY_VERSION) return null
+        val entries = root.optJSONArray(KEY_ENTRIES) ?: return null
+        if (entries.length() > MAX_ZIP_ENTRIES) return null
+        val parsed = mutableListOf<CustomLyricsEntry>()
+        for (index in 0 until entries.length()) {
+            val entry = entries.optJSONObject(index) ?: return null
+            parsed += parseEntry(entry)
+        }
+        val sanitized = CustomLyricsManifestPolicy.sanitize(CustomLyricsManifest(parsed))
+        return sanitized.takeIf { it.entries.size == parsed.size }
+    }
+
+    private fun parseEntry(entry: JSONObject): CustomLyricsEntry = CustomLyricsEntry(
+        appleMusicId = entry.optLong(KEY_APPLE_MUSIC_ID, 0L),
+        displayName = entry.optString(KEY_DISPLAY_NAME),
+        fileId = entry.optString(KEY_FILE_ID),
+        sizeBytes = entry.optLong(KEY_SIZE_BYTES, 0L),
+        sha256 = entry.optString(KEY_SHA256),
+        source = entry.optString(KEY_SOURCE),
+        enabled = entry.optBoolean(KEY_ENABLED, false),
+    )
 }

--- a/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsFilePolicy.kt
+++ b/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsFilePolicy.kt
@@ -28,13 +28,16 @@ internal object CustomLyricsFilePolicy {
         )
     }
 
-    fun readBounded(input: InputStream): ByteArray {
+    fun readBounded(input: InputStream): ByteArray =
+        readBounded(input, TtmlInputPolicy.MAX_TTML_BYTES)
+
+    fun readBounded(input: InputStream, maxBytes: Int): ByteArray {
         val output = ByteArrayOutputStream()
         val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
         while (true) {
             val count = input.read(buffer)
             if (count < 0) break
-            if (output.size() + count > TtmlInputPolicy.MAX_TTML_BYTES) {
+            if (output.size() + count > maxBytes) {
                 throw SizeLimitExceeded()
             }
             output.write(buffer, 0, count)

--- a/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsImportTransaction.kt
+++ b/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsImportTransaction.kt
@@ -41,6 +41,9 @@ internal class CustomLyricsImportTransaction(
         val replacedEntry = oldManifest.entries.firstOrNull {
             it.appleMusicId == replacedAppleMusicId
         }
+        if (replacingAppleMusicId == null && replacedEntry != null) {
+            return CustomLyricsSaveResult.Failed("目标 Apple Music ID 已存在")
+        }
         if (replacingAppleMusicId != null && replacedEntry == null) {
             return CustomLyricsSaveResult.Failed("原歌词映射不存在")
         }

--- a/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsManager.kt
+++ b/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsManager.kt
@@ -4,6 +4,9 @@ import android.os.ParcelFileDescriptor
 import dev.amenhancer.module.ModuleApplication
 import dev.amenhancer.module.XposedServiceSnapshot
 import dev.amenhancer.module.config.ConfigStore
+import dev.amenhancer.module.config.CustomLyricsIndexCommitResult
+import dev.amenhancer.module.config.CustomLyricsIndexRepository
+import dev.amenhancer.module.config.CustomLyricsIndexState
 import dev.amenhancer.module.config.CustomLyricsManifestPolicy
 import dev.amenhancer.module.model.CustomLyricsManifest
 import java.io.InputStream
@@ -20,27 +23,39 @@ internal sealed interface CustomLyricsBackupResult {
     data class Failed(val message: String) : CustomLyricsBackupResult
 }
 
-/** Settings-process facade for atomic custom-lyrics file and manifest changes. */
+/** Settings-process facade for atomic custom-lyrics file and index changes. */
 internal class CustomLyricsManager(
     private val snapshot: XposedServiceSnapshot,
     private val configStore: ConfigStore,
 ) {
+    private val indexRepository = CustomLyricsIndexRepository(
+        newIndexFileId = ::newIndexFileId,
+        openFile = { fileId ->
+            snapshot.openRemoteFile(fileId)?.let { ParcelFileDescriptor.AutoCloseInputStream(it) }
+        },
+        writeRemoteFile = ::writeRemoteFile,
+        publishPointer = { pointer ->
+            isWritable() && configStore.publishIndexPointer(pointer, snapshot)
+        },
+        deleteRemoteFile = { fileId ->
+            if (ModuleApplication.isCurrentSnapshot(snapshot)) snapshot.deleteRemoteFile(fileId)
+        },
+    )
+
     fun save(
         draft: CustomLyricsDraft,
         replacingAppleMusicId: Long? = null,
     ): CustomLyricsSaveResult = synchronized(mutationLock) {
         if (!isWritable()) return CustomLyricsSaveResult.Failed("libxposed remote file 服务不可用")
-        val oldManifest = configStore.settings(snapshot).customLyricsManifest
+        val state = configStore.indexState(snapshot)
         return CustomLyricsImportTransaction(
             fileIdFactory = ::newFileId,
             writeRemoteFile = ::writeRemoteFile,
-            publishManifest = { manifest ->
-                isWritable() && configStore.saveCustomLyricsManifest(manifest, snapshot)
-            },
+            publishManifest = { manifest -> commitIndex(state, manifest) },
             deleteRemoteFile = { fileId ->
                 if (ModuleApplication.isCurrentSnapshot(snapshot)) snapshot.deleteRemoteFile(fileId)
             },
-        ).upsert(oldManifest, draft, replacingAppleMusicId)
+        ).upsert(state.manifest, draft, replacingAppleMusicId)
     }
 
     fun setEnabled(appleMusicId: Long, enabled: Boolean): CustomLyricsMutationResult = synchronized(mutationLock) {
@@ -60,29 +75,29 @@ internal class CustomLyricsManager(
 
     fun delete(appleMusicId: Long): CustomLyricsMutationResult = synchronized(mutationLock) {
         if (!isWritable()) return CustomLyricsMutationResult.Failed("libxposed remote file 服务不可用")
-        val oldManifest = configStore.settings(snapshot).customLyricsManifest
-        val removed = oldManifest.entries.singleOrNull { it.appleMusicId == appleMusicId }
+        val state = configStore.indexState(snapshot)
+        val removed = state.manifest.entries.singleOrNull { it.appleMusicId == appleMusicId }
             ?: return CustomLyricsMutationResult.Failed("歌词映射不存在")
         val next = CustomLyricsManifestPolicy.sanitize(
-            CustomLyricsManifest(oldManifest.entries.filterNot { it.appleMusicId == appleMusicId }),
+            CustomLyricsManifest(state.manifest.entries.filterNot { it.appleMusicId == appleMusicId }),
         )
-        if (!configStore.saveCustomLyricsManifest(next, snapshot)) {
-            return CustomLyricsMutationResult.Failed("无法发布歌词映射")
+        if (commitIndex(state, next)) {
+            if (ModuleApplication.isCurrentSnapshot(snapshot)) {
+                runCatching { snapshot.deleteRemoteFile(removed.fileId) }
+            }
+            return CustomLyricsMutationResult.Updated(next)
         }
-        if (ModuleApplication.isCurrentSnapshot(snapshot)) {
-            runCatching { snapshot.deleteRemoteFile(removed.fileId) }
-        }
-        return CustomLyricsMutationResult.Updated(next)
+        return CustomLyricsMutationResult.Failed("无法发布歌词索引")
     }
 
     /**
-     * Writes a bounded ZIP backup (manifest.json plus one file per entry) into
-     * [out]; every TTML body is validated by [CustomLyricsFileReader] first.
-     * Consumes and closes [out].
+     * Streams a bounded ZIP backup (manifest.json plus one file per entry)
+     * into [out]; each TTML body is read, validated, and written one at a
+     * time. Consumes and closes [out].
      */
     fun backup(out: OutputStream): CustomLyricsBackupResult = synchronized(mutationLock) {
         if (!isWritable()) return CustomLyricsBackupResult.Failed("libxposed remote file 服务不可用")
-        val manifest = configStore.settings(snapshot).customLyricsManifest
+        val manifest = configStore.indexState(snapshot).manifest
         return when (val result = CustomLyricsBackupCodec.encode(manifest, ::readRemoteFile, out)) {
             is CustomLyricsBackupEncodeResult.Encoded ->
                 CustomLyricsBackupResult.Done(result.entryCount)
@@ -92,29 +107,23 @@ internal class CustomLyricsManager(
     }
 
     /**
-     * Decodes a bounded ZIP backup from [input] and merge-restores it: backup
+     * Streams a bounded ZIP backup from [input] into a merge-restore: backup
      * entries overwrite same-ID current entries, current-only IDs are kept,
-     * every restored entry gets a fresh remote fileId. Consumes and closes
-     * [input].
+     * every restored entry gets a fresh remote fileId. TTML bodies are
+     * validated and written one at a time, never all at once. Consumes and
+     * closes [input].
      */
     fun restore(input: InputStream): CustomLyricsRestoreResult = synchronized(mutationLock) {
         if (!isWritable()) return CustomLyricsRestoreResult.Failed("libxposed remote file 服务不可用")
-        val oldManifest = configStore.settings(snapshot).customLyricsManifest
-        val decoded = when (val result = CustomLyricsBackupCodec.decode(input)) {
-            is CustomLyricsBackupDecodeResult.Rejected ->
-                return CustomLyricsRestoreResult.Failed(result.message)
-            is CustomLyricsBackupDecodeResult.Decoded -> result.backup
-        }
+        val state = configStore.indexState(snapshot)
         return CustomLyricsRestoreTransaction(
             fileIdFactory = ::newFileId,
             writeRemoteFile = ::writeRemoteFile,
-            publishManifest = { manifest ->
-                isWritable() && configStore.saveCustomLyricsManifest(manifest, snapshot)
-            },
+            publishManifest = { manifest -> commitIndex(state, manifest, allowRecovery = true) },
             deleteRemoteFile = { fileId ->
                 if (ModuleApplication.isCurrentSnapshot(snapshot)) snapshot.deleteRemoteFile(fileId)
             },
-        ).merge(oldManifest, decoded)
+        ).merge(state.manifest) { onFile -> CustomLyricsBackupCodec.decode(input, onFile) }
     }
 
     private fun readRemoteFile(fileId: String): ByteArray? {
@@ -131,14 +140,22 @@ internal class CustomLyricsManager(
         transform: (CustomLyricsManifest) -> CustomLyricsManifest?,
     ): CustomLyricsMutationResult {
         if (!isWritable()) return CustomLyricsMutationResult.Failed("libxposed remote file 服务不可用")
-        val oldManifest = configStore.settings(snapshot).customLyricsManifest
-        val candidate = transform(oldManifest) ?: return CustomLyricsMutationResult.Failed("歌词映射不存在")
+        val state = configStore.indexState(snapshot)
+        val candidate = transform(state.manifest) ?: return CustomLyricsMutationResult.Failed("歌词映射不存在")
         val next = CustomLyricsManifestPolicy.sanitize(candidate)
-        if (!configStore.saveCustomLyricsManifest(next, snapshot)) {
-            return CustomLyricsMutationResult.Failed("无法发布歌词映射")
-        }
-        return CustomLyricsMutationResult.Updated(next)
+        if (commitIndex(state, next)) return CustomLyricsMutationResult.Updated(next)
+        return CustomLyricsMutationResult.Failed("无法发布歌词索引")
     }
+
+    private fun commitIndex(
+        state: CustomLyricsIndexState,
+        manifest: CustomLyricsManifest,
+        allowRecovery: Boolean = false,
+    ): Boolean = indexRepository.commit(
+        state,
+        manifest,
+        allowRecovery,
+    ) is CustomLyricsIndexCommitResult.Committed
 
     private fun isWritable(): Boolean =
         snapshot.isRemoteFileAvailable && ModuleApplication.isCurrentSnapshot(snapshot)
@@ -156,6 +173,8 @@ internal class CustomLyricsManager(
     }
 
     private fun newFileId(): String = "lyrics_" + UUID.randomUUID().toString().replace("-", "")
+
+    private fun newIndexFileId(): String = "index_" + UUID.randomUUID().toString().replace("-", "")
 
     private companion object {
         val mutationLock = Any()

--- a/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsRestoreTransaction.kt
+++ b/app/src/main/java/dev/amenhancer/module/lyrics/CustomLyricsRestoreTransaction.kt
@@ -11,11 +11,12 @@ internal sealed interface CustomLyricsRestoreResult {
 
 /**
  * Merge-restore semantics: backup entries overwrite current entries with the
- * same Apple Music ID, current-only IDs are kept. Every backup entry is
- * rebuilt with a fresh remote fileId; the merged manifest is published once
- * after all new files are written, then old files of overwritten IDs are
- * deleted. Any write or publish failure rolls back only the new files and
- * leaves the old manifest and old files untouched. An empty backup is a
+ * same Apple Music ID, current-only IDs are kept. The backup's files arrive
+ * one at a time through the caller-supplied stream; every one is written to a
+ * fresh remote fileId as it arrives, the merged manifest is published once
+ * after the whole backup scans, then old files of overwritten IDs are
+ * deleted. Any scan, write, or publish failure rolls back only the new files
+ * and leaves the old manifest and old files untouched. An empty backup is a
  * successful no-op.
  */
 internal class CustomLyricsRestoreTransaction(
@@ -26,58 +27,85 @@ internal class CustomLyricsRestoreTransaction(
 ) {
     fun merge(
         oldManifest: CustomLyricsManifest,
-        backup: CustomLyricsBackup,
+        streamBackup: (onFile: (fileId: String, bytes: ByteArray) -> Unit) -> CustomLyricsBackupDecodeResult,
     ): CustomLyricsRestoreResult {
-        if (backup.manifest.entries.isEmpty()) {
-            return CustomLyricsRestoreResult.Restored(oldManifest)
-        }
-        val rebuilt = mutableListOf<Pair<CustomLyricsEntry, ByteArray>>()
         val allocatedFileIds = oldManifest.entries.mapTo(mutableSetOf(), CustomLyricsEntry::fileId)
-        for (incoming in backup.manifest.entries) {
-            val bytes = backup.files[incoming.fileId]
-                ?: return CustomLyricsRestoreResult.Failed("备份内容缺失")
-            val fileId = runCatching(fileIdFactory).getOrNull()
-                ?.takeIf(CustomLyricsManifestPolicy::isValidFileId)
-                ?: return CustomLyricsRestoreResult.Failed("无法生成歌词文件 ID")
-            if (!allocatedFileIds.add(fileId)) {
-                return CustomLyricsRestoreResult.Failed("无法生成唯一歌词文件 ID")
-            }
-            rebuilt += incoming.copy(fileId = fileId) to bytes
-        }
-        val incomingById = rebuilt.associate { it.first.appleMusicId to it }
-        val currentIds = oldManifest.entries.map { it.appleMusicId }.toSet()
-        val mergedEntries = mutableListOf<CustomLyricsEntry>()
-        val retiredFileIds = mutableListOf<String>()
-        oldManifest.entries.forEach { current ->
-            val replacement = incomingById[current.appleMusicId]
-            if (replacement != null) {
-                mergedEntries += replacement.first
-                retiredFileIds += current.fileId
-            } else {
-                mergedEntries += current
-            }
-        }
-        rebuilt.forEach { (entry, _) ->
-            if (entry.appleMusicId !in currentIds) mergedEntries += entry
-        }
-        if (mergedEntries.size > CustomLyricsManifestPolicy.MAX_ENTRIES) {
-            return CustomLyricsRestoreResult.Failed("合并后歌词映射数量超过上限")
-        }
-        val merged = CustomLyricsManifestPolicy.sanitize(CustomLyricsManifest(mergedEntries))
+        val newFileIds = linkedMapOf<String, String>()
         val written = mutableListOf<String>()
-        rebuilt.forEach { (entry, bytes) ->
-            if (!runCatching { writeRemoteFile(entry.fileId, bytes) }.getOrDefault(false)) {
-                runCatching { deleteRemoteFile(entry.fileId) }
-                written.forEach { runCatching { deleteRemoteFile(it) } }
-                return CustomLyricsRestoreResult.Failed("无法写入共享歌词文件")
+        var writeError: String? = null
+        val scan = streamBackup { backupFileId, bytes ->
+            if (writeError != null) return@streamBackup
+            val newFileId = newFileIds[backupFileId]
+            if (newFileId == null) {
+                val generated = runCatching(fileIdFactory).getOrNull()
+                    ?.takeIf(CustomLyricsManifestPolicy::isValidFileId)
+                if (generated == null) {
+                    writeError = "无法生成歌词文件 ID"
+                    return@streamBackup
+                }
+                if (generated in allocatedFileIds) {
+                    writeError = "无法生成唯一歌词文件 ID"
+                    return@streamBackup
+                }
+                allocatedFileIds += generated
+                newFileIds[backupFileId] = generated
             }
-            written += entry.fileId
+            val target = newFileIds.getValue(backupFileId)
+            if (!runCatching { writeRemoteFile(target, bytes) }.getOrDefault(false)) {
+                runCatching { deleteRemoteFile(target) }
+                writeError = "无法写入共享歌词文件"
+                return@streamBackup
+            }
+            written += target
         }
-        if (!runCatching { publishManifest(merged) }.getOrDefault(false)) {
-            written.forEach { runCatching { deleteRemoteFile(it) } }
-            return CustomLyricsRestoreResult.Failed("无法发布歌词映射")
+        return when (scan) {
+            is CustomLyricsBackupDecodeResult.Rejected -> {
+                written.forEach { runCatching { deleteRemoteFile(it) } }
+                CustomLyricsRestoreResult.Failed(scan.message)
+            }
+            is CustomLyricsBackupDecodeResult.Decoded -> {
+                val backup = scan.backup
+                if (backup.manifest.entries.isEmpty()) {
+                    return CustomLyricsRestoreResult.Restored(oldManifest)
+                }
+                val error = writeError
+                if (error != null) {
+                    written.forEach { runCatching { deleteRemoteFile(it) } }
+                    return CustomLyricsRestoreResult.Failed(error)
+                }
+                val rebuilt = mutableListOf<CustomLyricsEntry>()
+                for (incoming in backup.manifest.entries) {
+                    val fileId = newFileIds[incoming.fileId]
+                    if (fileId == null) {
+                        written.forEach { runCatching { deleteRemoteFile(it) } }
+                        return CustomLyricsRestoreResult.Failed("备份内容缺失")
+                    }
+                    rebuilt += incoming.copy(fileId = fileId)
+                }
+                val incomingById = rebuilt.associateBy(CustomLyricsEntry::appleMusicId)
+                val currentIds = oldManifest.entries.mapTo(mutableSetOf(), CustomLyricsEntry::appleMusicId)
+                val mergedEntries = mutableListOf<CustomLyricsEntry>()
+                val retiredFileIds = mutableListOf<String>()
+                oldManifest.entries.forEach { current ->
+                    val replacement = incomingById[current.appleMusicId]
+                    if (replacement != null) {
+                        mergedEntries += replacement
+                        retiredFileIds += current.fileId
+                    } else {
+                        mergedEntries += current
+                    }
+                }
+                rebuilt.forEach { entry ->
+                    if (entry.appleMusicId !in currentIds) mergedEntries += entry
+                }
+                val merged = CustomLyricsManifestPolicy.sanitize(CustomLyricsManifest(mergedEntries))
+                if (!runCatching { publishManifest(merged) }.getOrDefault(false)) {
+                    written.forEach { runCatching { deleteRemoteFile(it) } }
+                    return CustomLyricsRestoreResult.Failed("无法发布歌词映射")
+                }
+                retiredFileIds.forEach { runCatching { deleteRemoteFile(it) } }
+                CustomLyricsRestoreResult.Restored(merged)
+            }
         }
-        retiredFileIds.forEach { runCatching { deleteRemoteFile(it) } }
-        return CustomLyricsRestoreResult.Restored(merged)
     }
 }

--- a/app/src/main/java/dev/amenhancer/module/ui/CustomLyricsListState.kt
+++ b/app/src/main/java/dev/amenhancer/module/ui/CustomLyricsListState.kt
@@ -1,0 +1,68 @@
+package dev.amenhancer.module.ui
+
+import dev.amenhancer.module.model.CustomLyricsEntry
+
+/**
+ * Android-free pagination and search seam behind the custom lyrics page.
+ *
+ * The page renders only [visibleEntries] (at most [pageSize] at first) and
+ * reveals more through [loadMore]; a case-insensitive query narrows by
+ * display name or Apple Music ID before pagination applies.
+ *
+ * Contract:
+ * - [update] replaces the dataset wholesale, so a refresh after
+ *   save/toggle/delete/restore can never mix old and new rows.
+ * - The revealed window survives [update] and [setQuery] but converges:
+ *   it is clamped to the filtered total, and it re-seeds to the first page
+ *   whenever the filtered total used to be empty.
+ */
+class CustomLyricsListState(
+    private val pageSize: Int = DEFAULT_PAGE_SIZE,
+) {
+    private var entries: List<CustomLyricsEntry> = emptyList()
+    private var query: String = ""
+    private var revealed: Int = 0
+
+    val totalCount: Int get() = filtered().size
+
+    val visibleCount: Int get() = visibleEntries.size
+
+    val visibleEntries: List<CustomLyricsEntry> get() = filtered().take(revealed)
+
+    val hasMore: Boolean get() = revealed < totalCount
+
+    fun update(newEntries: List<CustomLyricsEntry>, newQuery: String = query) {
+        entries = newEntries
+        query = newQuery
+        converge()
+    }
+
+    fun setQuery(newQuery: String) {
+        query = newQuery
+        converge()
+    }
+
+    fun loadMore(amount: Int = pageSize) {
+        if (amount <= 0) return
+        revealed = minOf(revealed + amount, totalCount)
+        converge()
+    }
+
+    private fun converge() {
+        revealed = minOf(revealed, totalCount)
+        if (revealed == 0 && totalCount > 0) revealed = minOf(pageSize, totalCount)
+    }
+
+    private fun filtered(): List<CustomLyricsEntry> {
+        val needle = query.trim().lowercase()
+        if (needle.isEmpty()) return entries
+        return entries.filter { entry ->
+            entry.displayName.lowercase().contains(needle) ||
+                entry.appleMusicId.toString().contains(needle)
+        }
+    }
+
+    companion object {
+        const val DEFAULT_PAGE_SIZE = 50
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt
+++ b/app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt
@@ -10,7 +10,9 @@ import android.graphics.Color
 import android.graphics.Typeface
 import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.RippleDrawable
+import android.text.Editable
 import android.text.InputType
+import android.text.TextWatcher
 import android.os.Build
 import android.os.Bundle
 import android.view.Gravity
@@ -78,6 +80,9 @@ class SettingsActivity : Activity() {
     private var pendingCustomTtmlImport: ((String) -> Unit)? = null
     private var awaitingCustomTtmlPickerResult = false
     private var currentPage = SettingsPage.MAIN
+    private val customLyricsListState = CustomLyricsListState()
+    private var customLyricsSearchQuery = ""
+    private var customLyricsListRegion: LinearLayout? = null
 
     private val serviceListener: (XposedServiceSnapshot) -> Unit = { snapshot ->
         runOnUiThread { if (::content.isInitialized) render(snapshot) }
@@ -252,7 +257,11 @@ class SettingsActivity : Activity() {
 
     private fun render(snapshot: XposedServiceSnapshot = ModuleApplication.serviceSnapshot) {
         content.removeAllViews()
-        val settings = store.settings(snapshot)
+        val settings = if (currentPage == SettingsPage.CUSTOM_LYRICS) {
+            store.settingsWithCustomLyrics(snapshot)
+        } else {
+            store.settings(snapshot)
+        }
         updateTopBar()
         when (currentPage) {
             SettingsPage.MAIN -> renderMainPage(settings, snapshot)
@@ -279,6 +288,10 @@ class SettingsActivity : Activity() {
     }
 
     private fun renderCustomLyricsPage(settings: ModuleSettings, snapshot: XposedServiceSnapshot) {
+        customLyricsListState.update(
+            settings.customLyricsManifest.entries,
+            customLyricsSearchQuery,
+        )
         content.addView(customLyricsSettingsCard(settings, snapshot.isRemoteAvailable))
         content.addView(spacer(20))
         content.addView(
@@ -586,9 +599,19 @@ class SettingsActivity : Activity() {
                 setTextColor(palette.onSurfaceVariant)
                 setPadding(dp(16), dp(4), dp(16), dp(12))
             })
-            manifest.entries.forEach { entry ->
-                addView(customLyricsEntryRow(entry, writable))
-                addView(insetDivider())
+            if (manifest.entries.isNotEmpty()) {
+                addView(
+                    customLyricsSearchInput(writable),
+                    LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        dp(44),
+                    ).apply {
+                        marginStart = dp(16)
+                        marginEnd = dp(16)
+                        bottomMargin = dp(6)
+                    },
+                )
+                addView(customLyricsEntriesRegion(writable))
             }
             addView(LinearLayout(this@SettingsActivity).apply {
                 orientation = LinearLayout.HORIZONTAL
@@ -612,6 +635,72 @@ class SettingsActivity : Activity() {
                 )
             })
         }
+
+    private fun customLyricsSearchInput(writable: Boolean): View =
+        EditText(this).apply {
+            hint = "搜索名称或 Apple Music ID"
+            textSize = 14f
+            setTextColor(palette.onSurface)
+            setHintTextColor(palette.onSurfaceVariant)
+            isSingleLine = true
+            setText(customLyricsSearchQuery)
+            setPadding(dp(14), 0, dp(14), 0)
+            background = roundedDrawable(palette.background, radiusDp = 12)
+            addTextChangedListener(object : TextWatcher {
+                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+                override fun afterTextChanged(s: Editable?) {
+                    customLyricsSearchQuery = s?.toString().orEmpty()
+                    customLyricsListState.setQuery(customLyricsSearchQuery)
+                    refreshCustomLyricsEntries(writable)
+                }
+            })
+        }
+
+    private fun customLyricsEntriesRegion(writable: Boolean): View =
+        LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            customLyricsListRegion = this
+            refreshCustomLyricsEntries(writable)
+        }
+
+    private fun refreshCustomLyricsEntries(writable: Boolean) {
+        val region = customLyricsListRegion ?: return
+        region.removeAllViews()
+        val state = customLyricsListState
+        if (state.totalCount == 0) {
+            region.addView(TextView(this).apply {
+                text = "没有匹配的歌词"
+                textSize = 13.5f
+                setTextColor(palette.onSurfaceVariant)
+                setPadding(dp(16), dp(8), dp(16), dp(12))
+            })
+            return
+        }
+        state.visibleEntries.forEach { entry ->
+            region.addView(customLyricsEntryRow(entry, writable))
+            region.addView(insetDivider())
+        }
+        region.addView(TextView(this).apply {
+            text = "已显示 ${state.visibleCount} / 共 ${state.totalCount} 首"
+            textSize = 13f
+            setTextColor(palette.onSurfaceVariant)
+            setPadding(dp(16), dp(8), dp(16), dp(12))
+        })
+        if (state.hasMore) {
+            region.addView(LinearLayout(this@SettingsActivity).apply {
+                orientation = LinearLayout.HORIZONTAL
+                setPadding(dp(12), 0, dp(12), dp(12))
+                addView(
+                    fontActionButton("加载更多", true) {
+                        customLyricsListState.loadMore()
+                        refreshCustomLyricsEntries(writable)
+                    },
+                    LinearLayout.LayoutParams(0, dp(48), 1f),
+                )
+            })
+        }
+    }
 
     private fun chooseCustomLyricsBackupDestination() {
         if (!ModuleApplication.serviceSnapshot.isRemoteFileAvailable) {

--- a/app/src/test/java/dev/amenhancer/module/config/CustomLyricsIndexRepositoryTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/config/CustomLyricsIndexRepositoryTest.kt
@@ -1,0 +1,434 @@
+package dev.amenhancer.module.config
+
+import dev.amenhancer.module.model.CustomLyricsEntry
+import dev.amenhancer.module.model.CustomLyricsManifest
+import dev.amenhancer.module.model.CustomLyricsSources
+import java.io.ByteArrayInputStream
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CustomLyricsIndexRepositoryTest {
+    private val sha256 = "0cba697d61a21fb62408b2411aa2152d1bc24cc2414d2bd162f70e04d20c5e53"
+    private val legacyEntry = entry(42L, "lyrics_legacy")
+    private val legacyJson = v1Json(listOf(legacyEntry))
+
+    @Test
+    fun `legacy v1 preferences resolve without any remote index file`() {
+        val prefs = mutableMapOf<String, Any>(
+            "custom_lyrics_manifest" to legacyJson,
+        )
+
+        val state = CustomLyricsIndexRepository.state(prefs) { null }
+
+        assertNull(state.pointer)
+        assertEquals(listOf(42L), state.manifest.entries.map(CustomLyricsEntry::appleMusicId))
+    }
+
+    @Test
+    fun `a published v2 index file wins over the legacy v1 preference string`() {
+        val files = mutableMapOf<String, ByteArray>()
+        val large = largeManifest(1100)
+        val indexBytes = CustomLyricsManifestCodec.encode(large).toByteArray(Charsets.UTF_8)
+        files["index_42"] = indexBytes
+        val prefs = mutableMapOf<String, Any>(
+            "custom_lyrics_manifest" to legacyJson,
+            "custom_lyrics_index_file_id" to "index_42",
+            "custom_lyrics_index_generation" to 5L,
+            "custom_lyrics_index_sha256" to sha256(indexBytes),
+            "custom_lyrics_index_size_bytes" to indexBytes.size.toLong(),
+        )
+
+        val state = CustomLyricsIndexRepository.state(prefs) { fileId -> files[fileId]?.let(::ByteArrayInputStream) }
+
+        assertEquals(1100, state.manifest.entries.size)
+        assertEquals(listOf(100001L), state.manifest.entries.map(CustomLyricsEntry::appleMusicId).take(1))
+        assertEquals("index_42", state.pointer?.fileId)
+    }
+
+    @Test
+    fun `a corrupt published index fails closed instead of using stale legacy data`() {
+        val files = mutableMapOf<String, ByteArray>()
+        val indexBytes = CustomLyricsManifestCodec.encode(largeManifest(5)).toByteArray(Charsets.UTF_8)
+        files["index_42"] = indexBytes
+        val prefs = mutableMapOf<String, Any>(
+            "custom_lyrics_manifest" to legacyJson,
+            "custom_lyrics_index_file_id" to "index_42",
+            "custom_lyrics_index_generation" to 5L,
+            "custom_lyrics_index_sha256" to sha256Of("tampered"),
+            "custom_lyrics_index_size_bytes" to indexBytes.size.toLong(),
+        )
+
+        val state = CustomLyricsIndexRepository.state(prefs) { fileId -> files[fileId]?.let(::ByteArrayInputStream) }
+
+        assertTrue(state.manifest.entries.isEmpty())
+        assertEquals("index_42", state.pointer?.fileId)
+        assertEquals(false, state.canCommit)
+    }
+
+    @Test
+    fun `a missing published index fails closed instead of using stale legacy data`() {
+        val prefs = mutableMapOf<String, Any>(
+            "custom_lyrics_manifest" to legacyJson,
+            "custom_lyrics_index_file_id" to "index_missing",
+            "custom_lyrics_index_generation" to 5L,
+            "custom_lyrics_index_sha256" to sha256,
+            "custom_lyrics_index_size_bytes" to 42L,
+        )
+
+        val state = CustomLyricsIndexRepository.state(prefs) { null }
+
+        assertTrue(state.manifest.entries.isEmpty())
+        assertEquals(false, state.canCommit)
+    }
+
+    @Test
+    fun `partial pointer values fail closed and cannot overwrite the index`() {
+        val files = mutableMapOf<String, ByteArray>()
+        val prefs = mutableMapOf<String, Any>(
+            "custom_lyrics_manifest" to legacyJson,
+            "custom_lyrics_index_file_id" to "index_partial",
+        )
+        val events = mutableListOf<String>()
+        val repository = repository(files, prefs, events, nextFileIds = listOf("index_new"))
+
+        val state = repository.state(prefs)
+        val result = repository.commit(state, largeManifest(2))
+
+        assertTrue(state.manifest.entries.isEmpty())
+        assertEquals(false, state.canCommit)
+        assertEquals(
+            CustomLyricsIndexCommitResult.Failed("歌词索引文件不可读，无法修改"),
+            result,
+        )
+        assertTrue(events.isEmpty())
+    }
+
+    @Test
+    fun `explicit recovery can replace an unreadable index from a complete backup`() {
+        val files = mutableMapOf<String, ByteArray>()
+        val prefs = mutableMapOf<String, Any>(
+            "custom_lyrics_index_file_id" to "index_missing",
+            "custom_lyrics_index_generation" to 5L,
+            "custom_lyrics_index_sha256" to sha256,
+            "custom_lyrics_index_size_bytes" to 42L,
+        )
+        val events = mutableListOf<String>()
+        val repository = repository(files, prefs, events, nextFileIds = listOf("index_recovered"))
+        val state = repository.state(prefs)
+
+        val result = repository.commit(state, largeManifest(40), allowRecovery = true)
+
+        assertTrue(result is CustomLyricsIndexCommitResult.Committed)
+        assertEquals(6L, (result as CustomLyricsIndexCommitResult.Committed).pointer.generation)
+        assertEquals("index_recovered", prefs["custom_lyrics_index_file_id"])
+        assertEquals(40, repository.state(prefs).manifest.entries.size)
+    }
+
+    @Test
+    fun `an unreadable published index cannot be overwritten from a stale legacy fallback`() {
+        val files = mutableMapOf<String, ByteArray>()
+        val prefs = mutableMapOf<String, Any>(
+            "custom_lyrics_manifest" to legacyJson,
+            "custom_lyrics_index_file_id" to "index_missing",
+            "custom_lyrics_index_generation" to 5L,
+            "custom_lyrics_index_sha256" to sha256,
+            "custom_lyrics_index_size_bytes" to 42L,
+        )
+        val events = mutableListOf<String>()
+        val repository = repository(files, prefs, events, nextFileIds = listOf("index_new"))
+
+        val result = repository.commit(repository.state(prefs), largeManifest(2))
+
+        assertEquals(
+            CustomLyricsIndexCommitResult.Failed("歌词索引文件不可读，无法修改"),
+            result,
+        )
+        assertTrue(events.isEmpty())
+        assertEquals("index_missing", prefs["custom_lyrics_index_file_id"])
+    }
+
+    @Test
+    fun `an oversized index is rejected before writing or publishing`() {
+        val files = mutableMapOf<String, ByteArray>()
+        val prefs = mutableMapOf<String, Any>()
+        val events = mutableListOf<String>()
+        val repository = repository(
+            files,
+            prefs,
+            events,
+            nextFileIds = listOf("index_new"),
+            maxIndexBytes = 100,
+        )
+
+        val result = repository.commit(
+            CustomLyricsIndexState(null, CustomLyricsManifest.empty()),
+            CustomLyricsManifest(listOf(entry(42L, "lyrics_a"))),
+        )
+
+        assertEquals(
+            CustomLyricsIndexCommitResult.Failed("歌词索引超出大小上限"),
+            result,
+        )
+        assertTrue(events.isEmpty())
+        assertTrue(files.isEmpty())
+    }
+
+    @Test
+    fun `neither pointer nor legacy yields an empty manifest`() {
+        val state = CustomLyricsIndexRepository.state(emptyMap<String, Any>()) { null }
+
+        assertNull(state.pointer)
+        assertTrue(state.manifest.entries.isEmpty())
+    }
+
+    @Test
+    fun `an empty published index is authoritative over the legacy string`() {
+        val files = mutableMapOf<String, ByteArray>()
+        val indexBytes = CustomLyricsManifestCodec.encode(CustomLyricsManifest.empty()).toByteArray(Charsets.UTF_8)
+        files["index_42"] = indexBytes
+        val prefs = mutableMapOf<String, Any>(
+            "custom_lyrics_manifest" to legacyJson,
+            "custom_lyrics_index_file_id" to "index_42",
+            "custom_lyrics_index_generation" to 3L,
+            "custom_lyrics_index_sha256" to sha256(indexBytes),
+            "custom_lyrics_index_size_bytes" to indexBytes.size.toLong(),
+        )
+
+        val state = CustomLyricsIndexRepository.state(prefs) { fileId -> files[fileId]?.let(::ByteArrayInputStream) }
+
+        assertTrue(state.manifest.entries.isEmpty())
+    }
+
+    @Test
+    fun `first commit migrates legacy v1 into an index file and publishes generation one`() {
+        val files = mutableMapOf<String, ByteArray>()
+        val prefs = mutableMapOf<String, Any>("custom_lyrics_manifest" to legacyJson)
+        val repository = repository(files, prefs, nextFileIds = listOf("index_new"))
+
+        val state = CustomLyricsIndexRepository.state(prefs) { null }
+        val next = CustomLyricsManifest(listOf(legacyEntry, entry(84L, "lyrics_new")))
+        val result = repository.commit(state, next)
+
+        assertTrue(result is CustomLyricsIndexCommitResult.Committed)
+        val committed = result as CustomLyricsIndexCommitResult.Committed
+        assertEquals("index_new", committed.pointer.fileId)
+        assertEquals(1L, committed.pointer.generation)
+        assertEquals("index_new", prefs["custom_lyrics_index_file_id"])
+        assertEquals(1L, prefs["custom_lyrics_index_generation"])
+        assertTrue(files.containsKey("index_new"))
+        assertTrue(prefs.containsKey("custom_lyrics_manifest"))
+        val resolved = CustomLyricsIndexRepository.resolve(prefs) { fileId -> files[fileId]?.let(::ByteArrayInputStream) }
+        assertEquals(listOf(42L, 84L), resolved.entries.map(CustomLyricsEntry::appleMusicId))
+    }
+
+    @Test
+    fun `commit writes the new index file, publishes the pointer, then retires the old index file`() {
+        val files = mutableMapOf<String, ByteArray>()
+        val prefs = mutableMapOf<String, Any>()
+        val events = mutableListOf<String>()
+        val repository = repository(files, prefs, events, nextFileIds = listOf("index_new"))
+        val oldPointer = CustomLyricsIndexPointer("index_old", 3L, sha256, 10L)
+        val state = CustomLyricsIndexState(
+            pointer = oldPointer,
+            manifest = CustomLyricsManifest(listOf(entry(42L, "lyrics_a"))),
+        )
+
+        val result = repository.commit(state, CustomLyricsManifest(listOf(entry(42L, "lyrics_a"), entry(84L, "lyrics_b"))))
+
+        assertTrue(result is CustomLyricsIndexCommitResult.Committed)
+        val committed = result as CustomLyricsIndexCommitResult.Committed
+        assertEquals("index_new", committed.pointer.fileId)
+        assertEquals(4L, committed.pointer.generation)
+        assertEquals(listOf("write:index_new", "publish", "delete:index_old"), events)
+        assertEquals("index_new", prefs["custom_lyrics_index_file_id"])
+        assertTrue(!files.containsKey("index_old"))
+    }
+
+    @Test
+    fun `a failed pointer publication keeps the old pointer and deletes the new index file`() {
+        val files = mutableMapOf<String, ByteArray>()
+        val prefs = mutableMapOf<String, Any>(
+            "custom_lyrics_index_file_id" to "index_old",
+            "custom_lyrics_index_generation" to 3L,
+            "custom_lyrics_index_sha256" to sha256,
+            "custom_lyrics_index_size_bytes" to 10L,
+        )
+        files["index_old"] = byteArrayOf(1, 2, 3)
+        val events = mutableListOf<String>()
+        val repository = repository(files, prefs, events, nextFileIds = listOf("index_new")) {
+            events += "publish"
+            false
+        }
+        val state = CustomLyricsIndexState(
+            pointer = CustomLyricsIndexPointer("index_old", 3L, sha256, 10L),
+            manifest = CustomLyricsManifest(listOf(entry(42L, "lyrics_a"))),
+        )
+
+        val result = repository.commit(state, CustomLyricsManifest(listOf(entry(42L, "lyrics_a"), entry(84L, "lyrics_b"))))
+
+        assertTrue(result is CustomLyricsIndexCommitResult.Failed)
+        assertEquals(listOf("write:index_new", "publish", "delete:index_new"), events)
+        assertEquals("index_old", prefs["custom_lyrics_index_file_id"])
+        assertEquals(3L, prefs["custom_lyrics_index_generation"])
+        assertTrue(!files.containsKey("index_new"))
+        assertTrue(files.containsKey("index_old"))
+    }
+
+    @Test
+    fun `a failed index file write publishes nothing and deletes the new file`() {
+        val files = mutableMapOf<String, ByteArray>()
+        val prefs = mutableMapOf<String, Any>()
+        val repository = repository(
+            files,
+            prefs,
+            nextFileIds = listOf("index_new"),
+            write = { _, _ -> false },
+        )
+
+        val result = repository.commit(
+            CustomLyricsIndexState(null, CustomLyricsManifest.empty()),
+            CustomLyricsManifest(listOf(entry(42L, "lyrics_a"))),
+        )
+
+        assertTrue(result is CustomLyricsIndexCommitResult.Failed)
+        assertTrue(prefs.isEmpty())
+        assertTrue(files.isEmpty())
+    }
+
+    @Test
+    fun `a commit with no prior pointer never deletes a file`() {
+        val files = mutableMapOf<String, ByteArray>()
+        val prefs = mutableMapOf<String, Any>()
+        val events = mutableListOf<String>()
+        val repository = repository(files, prefs, events, nextFileIds = listOf("index_new"))
+
+        repository.commit(
+            CustomLyricsIndexState(null, CustomLyricsManifest.empty()),
+            CustomLyricsManifest(listOf(entry(42L, "lyrics_a"))),
+        )
+
+        assertEquals(listOf("write:index_new", "publish"), events)
+    }
+
+    @Test
+    fun `generation increments across commits`() {
+        val files = mutableMapOf<String, ByteArray>()
+        val prefs = mutableMapOf<String, Any>()
+        val repository = repository(files, prefs, nextFileIds = listOf("index_1", "index_2"))
+        val manifest = CustomLyricsManifest(listOf(entry(42L, "lyrics_a")))
+
+        val first = repository.commit(
+            CustomLyricsIndexState(null, CustomLyricsManifest.empty()),
+            manifest,
+        ) as CustomLyricsIndexCommitResult.Committed
+        val second = repository.commit(
+            CustomLyricsIndexState(first.pointer, first.manifest),
+            manifest,
+        ) as CustomLyricsIndexCommitResult.Committed
+
+        assertEquals(1L, first.pointer.generation)
+        assertEquals(2L, second.pointer.generation)
+        assertEquals(2L, prefs["custom_lyrics_index_generation"])
+    }
+
+    @Test
+    fun `over a thousand entries survive a commit and resolve round trip`() {
+        val files = mutableMapOf<String, ByteArray>()
+        val prefs = mutableMapOf<String, Any>()
+        val repository = repository(files, prefs, nextFileIds = listOf("index_big"))
+        val large = largeManifest(1100)
+
+        val committed = repository.commit(
+            CustomLyricsIndexState(null, CustomLyricsManifest.empty()),
+            large,
+        ) as CustomLyricsIndexCommitResult.Committed
+
+        assertEquals(1100, committed.manifest.entries.size)
+        val resolved = CustomLyricsIndexRepository.resolve(prefs) { fileId -> files[fileId]?.let(::ByteArrayInputStream) }
+        assertEquals(1100, resolved.entries.size)
+        assertEquals(large, resolved)
+    }
+
+    private fun repository(
+        files: MutableMap<String, ByteArray>,
+        prefs: MutableMap<String, Any>,
+        events: MutableList<String> = mutableListOf(),
+        nextFileIds: List<String>,
+        write: (String, ByteArray) -> Boolean = { fileId, bytes ->
+            events += "write:$fileId"
+            files[fileId] = bytes
+            true
+        },
+        maxIndexBytes: Int = CustomLyricsManifestPolicy.MAX_INDEX_BYTES,
+        publish: (CustomLyricsIndexPointer) -> Boolean = { pointer ->
+            events += "publish"
+            prefs.putAll(ModuleSettingsSchema.encodeIndexPointer(pointer))
+            true
+        },
+    ): CustomLyricsIndexRepository {
+        val ids = ArrayDeque(nextFileIds)
+        return CustomLyricsIndexRepository(
+            newIndexFileId = { ids.removeFirst() },
+            openFile = { fileId -> files[fileId]?.let(::ByteArrayInputStream) },
+            writeRemoteFile = write,
+            publishPointer = publish,
+            deleteRemoteFile = { fileId ->
+                events += "delete:$fileId"
+                files.remove(fileId)
+            },
+            maxIndexBytes = maxIndexBytes,
+        )
+    }
+
+    private fun entry(appleMusicId: Long, fileId: String) = CustomLyricsEntry(
+        appleMusicId = appleMusicId,
+        displayName = "Song $appleMusicId",
+        fileId = fileId,
+        sizeBytes = 42L,
+        sha256 = sha256,
+        source = CustomLyricsSources.MANUAL,
+        enabled = true,
+    )
+
+    private fun largeManifest(count: Int): CustomLyricsManifest = CustomLyricsManifest(
+        (1..count).map { index ->
+            CustomLyricsEntry(
+                appleMusicId = 100000L + index,
+                displayName = "Song $index",
+                fileId = "lyrics_%06d".format(index),
+                sizeBytes = 42L,
+                sha256 = sha256,
+                source = CustomLyricsSources.MANUAL,
+                enabled = true,
+            )
+        },
+    )
+
+    private fun v1Json(entries: List<CustomLyricsEntry>): String = JSONObject().apply {
+        put("version", 1)
+        put("entries", JSONArray().apply {
+            entries.forEach { entry ->
+                put(JSONObject().apply {
+                    put("appleMusicId", entry.appleMusicId)
+                    put("displayName", entry.displayName)
+                    put("fileId", entry.fileId)
+                    put("sizeBytes", entry.sizeBytes)
+                    put("sha256", entry.sha256)
+                    put("source", entry.source)
+                    put("enabled", entry.enabled)
+                })
+            }
+        })
+    }.toString()
+
+    private fun sha256(bytes: ByteArray): String =
+        java.security.MessageDigest.getInstance("SHA-256")
+            .digest(bytes)
+            .joinToString(separator = "") { byte -> "%02x".format(byte) }
+
+    private fun sha256Of(text: String): String = sha256(text.toByteArray(Charsets.UTF_8))
+}

--- a/app/src/test/java/dev/amenhancer/module/config/CustomLyricsManifestCodecTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/config/CustomLyricsManifestCodecTest.kt
@@ -4,6 +4,8 @@ import dev.amenhancer.module.model.CustomLyricsEntry
 import dev.amenhancer.module.model.CustomLyricsManifest
 import dev.amenhancer.module.model.CustomLyricsSources
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class CustomLyricsManifestCodecTest {
@@ -40,4 +42,57 @@ class CustomLyricsManifestCodecTest {
 
         assertEquals(listOf(entry), CustomLyricsManifestPolicy.sanitize(manifest).entries)
     }
+
+    @Test
+    fun `legacy v1 payloads still decode`() {
+        val v1 = """{"version":1,"entries":[{"appleMusicId":42,"displayName":"Old","fileId":"lyrics_old","sizeBytes":42,"sha256":"0cba697d61a21fb62408b2411aa2152d1bc24cc2414d2bd162f70e04d20c5e53","source":"manual","enabled":true}]}"""
+
+        val decoded = CustomLyricsManifestCodec.decode(v1)
+
+        assertEquals(listOf(42L), decoded.entries.map(CustomLyricsEntry::appleMusicId))
+        assertEquals("lyrics_old", decoded.entries.single().fileId)
+    }
+
+    @Test
+    fun `v2 payloads round trip with over a thousand entries`() {
+        val manifest = CustomLyricsManifest(
+            (1..1100).map { index ->
+                entry.copy(appleMusicId = 100000L + index, fileId = "lyrics_%06d".format(index))
+            },
+        )
+
+        val roundTripped = CustomLyricsManifestCodec.decode(CustomLyricsManifestCodec.encode(manifest))
+
+        assertEquals(1100, roundTripped.entries.size)
+        assertEquals(manifest, roundTripped)
+    }
+
+    @Test
+    fun `decodeStrict accepts legacy v1 and current v2 payloads but nothing else`() {
+        val v1 = """{"version":1,"entries":[{"appleMusicId":42,"displayName":"Old","fileId":"lyrics_old","sizeBytes":42,"sha256":"0cba697d61a21fb62408b2411aa2152d1bc24cc2414d2bd162f70e04d20c5e53","source":"manual","enabled":true}]}"""
+
+        assertNotNull(CustomLyricsManifestCodec.decodeStrict(v1))
+        assertNotNull(CustomLyricsManifestCodec.decodeStrict(CustomLyricsManifestCodec.encode(entryManifest())))
+        assertNull(CustomLyricsManifestCodec.decodeStrict("""{"version":3,"entries":[]}"""))
+        assertNull(CustomLyricsManifestCodec.decodeStrict("not json"))
+    }
+
+    @Test
+    fun `decodeIndexFile accepts only current v2 index documents`() {
+        val manifest = entryManifest()
+
+        assertEquals(
+            manifest,
+            CustomLyricsManifestCodec.decodeIndexFile(CustomLyricsManifestCodec.encode(manifest)),
+        )
+        assertEquals(
+            CustomLyricsManifest.empty(),
+            CustomLyricsManifestCodec.decodeIndexFile("""{"version":2,"entries":[]}"""),
+        )
+        assertNull(CustomLyricsManifestCodec.decodeIndexFile("""{"version":1,"entries":[]}"""))
+        assertNull(CustomLyricsManifestCodec.decodeIndexFile("not json"))
+        assertNull(CustomLyricsManifestCodec.decodeIndexFile("""{"version":2}"""))
+    }
+
+    private fun entryManifest(): CustomLyricsManifest = CustomLyricsManifest(listOf(entry))
 }

--- a/app/src/test/java/dev/amenhancer/module/config/CustomLyricsManifestPolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/config/CustomLyricsManifestPolicyTest.kt
@@ -1,0 +1,60 @@
+package dev.amenhancer.module.config
+
+import dev.amenhancer.module.model.CustomLyricsEntry
+import dev.amenhancer.module.model.CustomLyricsManifest
+import dev.amenhancer.module.model.CustomLyricsSources
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CustomLyricsManifestPolicyTest {
+    private val sha256 = "0cba697d61a21fb62408b2411aa2152d1bc24cc2414d2bd162f70e04d20c5e53"
+
+    @Test
+    fun `sanitize keeps over a thousand entries without truncation`() {
+        val manifest = CustomLyricsManifest(
+            (1..1100).map { index ->
+                CustomLyricsEntry(
+                    appleMusicId = 100000L + index,
+                    displayName = "Song $index",
+                    fileId = "lyrics_%06d".format(index),
+                    sizeBytes = 42L,
+                    sha256 = sha256,
+                    source = CustomLyricsSources.MANUAL,
+                    enabled = true,
+                )
+            },
+        )
+
+        assertEquals(1100, CustomLyricsManifestPolicy.sanitize(manifest).entries.size)
+    }
+
+    @Test
+    fun `sanitize still deduplicates ids and drops invalid entries`() {
+        val manifest = CustomLyricsManifest(
+            listOf(
+                entry(42L, "lyrics_one"),
+                entry(42L, "lyrics_two"),
+                entry(84L, "bad..id"),
+            ),
+        )
+
+        val sanitized = CustomLyricsManifestPolicy.sanitize(manifest)
+        assertEquals(listOf(42L), sanitized.entries.map(CustomLyricsEntry::appleMusicId))
+    }
+
+    @Test
+    fun `sha256 validation accepts only hex digests`() {
+        assertEquals(true, CustomLyricsManifestPolicy.isValidSha256(sha256))
+        assertEquals(false, CustomLyricsManifestPolicy.isValidSha256("not-a-hash"))
+        assertEquals(false, CustomLyricsManifestPolicy.isValidSha256(""))
+    }
+
+    private fun entry(appleMusicId: Long, fileId: String) = CustomLyricsEntry(
+        appleMusicId = appleMusicId,
+        displayName = "Song $appleMusicId",
+        fileId = fileId,
+        sizeBytes = 42L,
+        sha256 = sha256,
+        source = CustomLyricsSources.MANUAL,
+    )
+}

--- a/app/src/test/java/dev/amenhancer/module/config/ModuleSettingsSchemaTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/config/ModuleSettingsSchemaTest.kt
@@ -4,6 +4,7 @@ import dev.amenhancer.module.ModuleConstants
 import dev.amenhancer.module.model.CustomLyricsManifest
 import dev.amenhancer.module.model.ModuleSettings
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ModuleSettingsSchemaTest {
@@ -199,5 +200,66 @@ class ModuleSettingsSchemaTest {
 
         assertEquals(true, upgraded?.get("custom_lyrics_enabled"))
         assertEquals(ModuleConstants.CONFIG_SCHEMA_VERSION, upgraded?.get("schema_version"))
+    }
+
+    @Test
+    fun `index pointer round trips through its preference keys`() {
+        val pointer = CustomLyricsIndexPointer(
+            fileId = "index_abc123",
+            generation = 7L,
+            sha256 = "0cba697d61a21fb62408b2411aa2152d1bc24cc2414d2bd162f70e04d20c5e53",
+            sizeBytes = 4096L,
+        )
+
+        assertEquals(
+            pointer,
+            ModuleSettingsSchema.decodeIndexPointer(ModuleSettingsSchema.encodeIndexPointer(pointer)),
+        )
+    }
+
+    @Test
+    fun `malformed index pointers fail closed`() {
+        val base = mapOf(
+            "custom_lyrics_index_file_id" to "index_abc123",
+            "custom_lyrics_index_generation" to 1L,
+            "custom_lyrics_index_sha256" to "0cba697d61a21fb62408b2411aa2152d1bc24cc2414d2bd162f70e04d20c5e53",
+            "custom_lyrics_index_size_bytes" to 4096L,
+        )
+
+        assertNull(ModuleSettingsSchema.decodeIndexPointer(emptyMap<String, Any>()))
+        assertNull(ModuleSettingsSchema.decodeIndexPointer(base - "custom_lyrics_index_file_id"))
+        assertNull(
+            ModuleSettingsSchema.decodeIndexPointer(
+                base + ("custom_lyrics_index_file_id" to "../bad"),
+            ),
+        )
+        assertNull(
+            ModuleSettingsSchema.decodeIndexPointer(
+                base + ("custom_lyrics_index_generation" to 0L),
+            ),
+        )
+        assertNull(
+            ModuleSettingsSchema.decodeIndexPointer(
+                base + ("custom_lyrics_index_sha256" to "not-a-hash"),
+            ),
+        )
+        assertNull(
+            ModuleSettingsSchema.decodeIndexPointer(
+                base + ("custom_lyrics_index_size_bytes" to 0L),
+            ),
+        )
+    }
+
+    @Test
+    fun `legacy manifest decode reads the v1 preference string`() {
+        val values = mapOf(
+            "custom_lyrics_manifest" to
+                """{"version":1,"entries":[{"appleMusicId":42,"displayName":"Old","fileId":"lyrics_old","sizeBytes":42,"sha256":"0cba697d61a21fb62408b2411aa2152d1bc24cc2414d2bd162f70e04d20c5e53","source":"manual","enabled":true}]}""",
+        )
+
+        assertEquals(
+            listOf(42L),
+            ModuleSettingsSchema.decodeLegacyCustomLyricsManifest(values).entries.map { it.appleMusicId },
+        )
     }
 }

--- a/app/src/test/java/dev/amenhancer/module/config/OrdinarySettingsWritePolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/config/OrdinarySettingsWritePolicyTest.kt
@@ -39,6 +39,18 @@ class OrdinarySettingsWritePolicyTest {
         "lyrics_font_size_bytes",
         "lyrics_font_sha256",
     )
+    private val pointerKeys = listOf(
+        "custom_lyrics_index_file_id",
+        "custom_lyrics_index_generation",
+        "custom_lyrics_index_sha256",
+        "custom_lyrics_index_size_bytes",
+    )
+    private val indexPointer = CustomLyricsIndexPointer(
+        fileId = "index_abc123",
+        generation = 3L,
+        sha256 = "0cba697d61a21fb62408b2411aa2152d1bc24cc2414d2bd162f70e04d20c5e53",
+        sizeBytes = 4096L,
+    )
     private val customLyricsManifest = CustomLyricsManifest(
         entries = listOf(
             CustomLyricsEntry(
@@ -115,5 +127,33 @@ class OrdinarySettingsWritePolicyTest {
             CustomLyricsManifest.empty(),
             ModuleSettingsSchema.decode(encoded).customLyricsManifest,
         )
+    }
+
+    @Test
+    fun `stale ordinary settings write after a published index pointer leaves the pointer unchanged`() {
+        val currentPreferences = mutableMapOf<String, Any>().apply {
+            putAll(ModuleSettingsSchema.encodeOrdinarySettings(ModuleSettings()))
+            putAll(ModuleSettingsSchema.encodeIndexPointer(indexPointer))
+        }
+
+        val ordinaryWrite = ModuleSettingsSchema.encodeOrdinarySettings(staleSettings)
+        val merged = currentPreferences + ordinaryWrite
+
+        assertFalse(
+            "ordinary write must not touch any index pointer key",
+            ordinaryWrite.keys.any(pointerKeys::contains),
+        )
+        assertFalse("ordinary write must not carry the legacy manifest key", ordinaryWrite.containsKey("custom_lyrics_manifest"))
+        assertEquals(indexPointer, ModuleSettingsSchema.decodeIndexPointer(merged))
+    }
+
+    @Test
+    fun `full schema encode never emits the index pointer keys`() {
+        val encoded = ModuleSettingsSchema.encode(
+            ModuleSettings(customLyricsManifest = customLyricsManifest),
+        )
+
+        assertFalse(encoded.keys.any(pointerKeys::contains))
+        assertTrue(encoded.containsKey("custom_lyrics_manifest"))
     }
 }

--- a/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsReplacementSessionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsReplacementSessionTest.kt
@@ -5,6 +5,8 @@ import dev.amenhancer.module.model.CustomLyricsManifest
 import dev.amenhancer.module.model.CustomLyricsSources
 import java.util.concurrent.Executor
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Test
@@ -63,7 +65,10 @@ class CustomLyricsReplacementSessionTest {
         var parses = 0
         val pointer = Pointer(42L)
         val session = CustomLyricsReplacementSession(
-            manifestProvider = { manifestReads += 1; manifest(entry(42L)) },
+            index = CustomLyricsIndexProvider {
+                manifestReads += 1
+                manifest(entry(42L)).entries.associateBy(CustomLyricsEntry::appleMusicId)
+            },
             readTtml = { fileReads += 1; TTML },
             parseTtml = { parses += 1; pointer },
             isAlive = { it is Pointer },
@@ -90,15 +95,80 @@ class CustomLyricsReplacementSessionTest {
     }
 
     @Test
-    fun `a failed initial manifest read retries from a later i2 without blocking it`() {
+    fun `start loads only the lightweight index and never lyric bodies`() {
+        val queued = QueuedExecutor()
+        var manifestReads = 0
+        var fileReads = 0
+        var parses = 0
+        val session = CustomLyricsReplacementSession(
+            index = CustomLyricsIndexProvider {
+                manifestReads += 1
+                manyEntries(1000).entries.associateBy(CustomLyricsEntry::appleMusicId)
+            },
+            readTtml = { fileReads += 1; TTML },
+            parseTtml = { parses += 1; Pointer(0L) },
+            isAlive = { it is Pointer },
+            verifyPtr = { it is Pointer },
+            readAdamId = { (it as Pointer).adamId },
+            bindAdamId = { value, id -> (value as Pointer).adamId = id; true },
+            executor = queued,
+            logger = {},
+        )
+
+        session.start()
+        queued.runAll()
+
+        assertEquals(1, manifestReads)
+        assertEquals(0, fileReads)
+        assertEquals(0, parses)
+    }
+
+    @Test
+    fun `first request among a thousand parses only the requested entry`() {
+        val queued = QueuedExecutor()
+        var fileReads = 0
+        var parses = 0
+        val session = CustomLyricsReplacementSession(
+            index = CustomLyricsIndexProvider {
+                manyEntries(1000).entries.associateBy(CustomLyricsEntry::appleMusicId)
+            },
+            readTtml = { fileReads += 1; TTML },
+            parseTtml = { parses += 1; Pointer(0L) },
+            isAlive = { it is Pointer },
+            verifyPtr = { it is Pointer },
+            readAdamId = { (it as Pointer).adamId },
+            bindAdamId = { value, id -> (value as Pointer).adamId = id; true },
+            executor = queued,
+            logger = {},
+        )
+
+        session.start()
+        queued.runAll()
+        assertEquals(0, fileReads)
+
+        assertNull(session.replacementFor(777L))
+        queued.runAll()
+        assertNotNull(session.replacementFor(777L))
+        assertEquals(1, fileReads)
+        assertEquals(1, parses)
+
+        assertNull(session.replacementFor(42L))
+        queued.runAll()
+        assertNotNull(session.replacementFor(42L))
+        assertEquals(2, fileReads)
+        assertEquals(2, parses)
+    }
+
+    @Test
+    fun `a failed initial index read retries from a later i2 without blocking it`() {
         val queued = QueuedExecutor()
         var manifestReads = 0
         val pointer = Pointer(42L)
         val session = CustomLyricsReplacementSession(
-            manifestProvider = {
+            index = CustomLyricsIndexProvider {
                 manifestReads += 1
                 if (manifestReads == 1) error("remote preferences unavailable")
-                manifest(entry(42L))
+                manifest(entry(42L)).entries.associateBy(CustomLyricsEntry::appleMusicId)
             },
             readTtml = { TTML },
             parseTtml = { pointer },
@@ -125,7 +195,9 @@ class CustomLyricsReplacementSessionTest {
         var manifest = CustomLyricsManifest()
         val pointer = Pointer(42L)
         val session = CustomLyricsReplacementSession(
-            manifestProvider = { manifest },
+            index = CustomLyricsIndexProvider {
+                manifest.entries.associateBy(CustomLyricsEntry::appleMusicId)
+            },
             readTtml = { TTML },
             parseTtml = { pointer },
             isAlive = { it is Pointer },
@@ -146,13 +218,81 @@ class CustomLyricsReplacementSessionTest {
     }
 
     @Test
-    fun `availability lookup returns only a ready pointer without queueing preload`() {
+    fun `concurrent duplicate known-id misses prepare a single entry`() {
         val queued = QueuedExecutor()
-        var manifestReads = 0
+        var parses = 0
         val pointer = Pointer(42L)
         val session = CustomLyricsReplacementSession(
-            manifestProvider = { manifestReads += 1; manifest(entry(42L)) },
+            index = CustomLyricsIndexProvider {
+                manifest(entry(42L)).entries.associateBy(CustomLyricsEntry::appleMusicId)
+            },
             readTtml = { TTML },
+            parseTtml = { parses += 1; pointer },
+            isAlive = { it is Pointer },
+            verifyPtr = { it is Pointer },
+            readAdamId = { (it as Pointer).adamId },
+            bindAdamId = { value, id -> (value as Pointer).adamId = id; true },
+            executor = queued,
+            logger = {},
+        )
+
+        session.start()
+        queued.runAll()
+
+        assertNull(session.replacementFor(42L))
+        assertNull(session.replacementFor(42L))
+        queued.runAll()
+        assertEquals(1, parses)
+        assertSame(pointer, session.replacementFor(42L))
+        queued.runAll()
+        assertEquals(1, parses)
+    }
+
+    @Test
+    fun `concurrent unknown-id misses refresh the index only once`() {
+        val queued = QueuedExecutor()
+        var manifestReads = 0
+        var parses = 0
+        var manifest = CustomLyricsManifest()
+        val pointer = Pointer(42L)
+        val session = CustomLyricsReplacementSession(
+            index = CustomLyricsIndexProvider {
+                manifestReads += 1
+                manifest.entries.associateBy(CustomLyricsEntry::appleMusicId)
+            },
+            readTtml = { TTML },
+            parseTtml = { parses += 1; pointer },
+            isAlive = { it is Pointer },
+            verifyPtr = { it is Pointer },
+            readAdamId = { (it as Pointer).adamId },
+            bindAdamId = { value, id -> (value as Pointer).adamId = id; true },
+            executor = queued,
+            logger = {},
+        )
+
+        assertNull(session.replacementFor(42L))
+        assertNull(session.replacementFor(42L))
+        assertNull(session.replacementFor(42L))
+        manifest = manifest(entry(42L))
+        queued.runAll()
+
+        assertEquals(1, manifestReads)
+        assertEquals(1, parses)
+        assertSame(pointer, session.replacementFor(42L))
+    }
+
+    @Test
+    fun `availability lookup returns only a ready pointer without queueing work`() {
+        val queued = QueuedExecutor()
+        var manifestReads = 0
+        var fileReads = 0
+        val pointer = Pointer(42L)
+        val session = CustomLyricsReplacementSession(
+            index = CustomLyricsIndexProvider {
+                manifestReads += 1
+                manifest(entry(42L)).entries.associateBy(CustomLyricsEntry::appleMusicId)
+            },
+            readTtml = { fileReads += 1; TTML },
             parseTtml = { pointer },
             isAlive = { it is Pointer },
             verifyPtr = { it is Pointer },
@@ -168,23 +308,34 @@ class CustomLyricsReplacementSessionTest {
 
         session.start()
         queued.runAll()
+        assertEquals(1, manifestReads)
+        assertEquals(0, fileReads)
+        assertNull(session.readyReplacementFor(42L))
+
+        assertNull(session.replacementFor(42L))
+        queued.runAll()
         assertSame(pointer, session.readyReplacementFor(42L))
         assertNull(session.readyReplacementFor(41L))
         queued.runAll()
         assertEquals(1, manifestReads)
+        assertEquals(1, fileReads)
     }
 
     @Test
-    fun `availability queues background reprepare only for a mapped dead pointer`() {
+    fun `availability queues a single-file reprepare for a mapped dead pointer`() {
         val queued = QueuedExecutor()
         var manifestReads = 0
+        var fileReads = 0
         var parses = 0
         val first = Pointer(42L)
         val second = Pointer(42L)
         val session = CustomLyricsReplacementSession(
-            manifestProvider = { manifestReads += 1; manifest(entry(42L)) },
-            readTtml = { TTML },
-            parseTtml = { if (parses++ == 0) first else second },
+            index = CustomLyricsIndexProvider {
+                manifestReads += 1
+                manifest(entry(42L)).entries.associateBy(CustomLyricsEntry::appleMusicId)
+            },
+            readTtml = { fileReads += 1; TTML },
+            parseTtml = { parses += 1; if (parses == 1) first else second },
             isAlive = { it is Pointer && it.live },
             verifyPtr = { it is Pointer && it.live },
             readAdamId = { (it as Pointer).adamId },
@@ -195,16 +346,105 @@ class CustomLyricsReplacementSessionTest {
 
         session.start()
         queued.runAll()
+        assertNull(session.replacementOrPrepareFor(42L))
+        queued.runAll()
+        assertSame(first, session.replacementOrPrepareFor(42L))
         first.live = false
 
         assertNull(session.replacementOrPrepareFor(42L))
         assertEquals(1, manifestReads)
         queued.runAll()
         assertSame(second, session.replacementOrPrepareFor(42L))
+        assertEquals(2, fileReads)
+        assertEquals(2, parses)
 
         assertNull(session.replacementOrPrepareFor(41L))
         queued.runAll()
-        assertEquals(2, manifestReads)
+        assertEquals(1, manifestReads)
+    }
+
+    @Test
+    fun `lru eviction re-prepares a single evicted entry on the next request`() {
+        val queued = QueuedExecutor()
+        var parses = 0
+        val session = CustomLyricsReplacementSession(
+            index = CustomLyricsIndexProvider {
+                manyEntries(1000).entries.associateBy(CustomLyricsEntry::appleMusicId)
+            },
+            readTtml = { TTML },
+            parseTtml = { parses += 1; Pointer(0L) },
+            isAlive = { it is Pointer },
+            verifyPtr = { it is Pointer },
+            readAdamId = { (it as Pointer).adamId },
+            bindAdamId = { value, id -> (value as Pointer).adamId = id; true },
+            executor = queued,
+            logger = {},
+        )
+
+        session.start()
+        queued.runAll()
+
+        (1L..33L).forEach { id ->
+            assertNull(session.replacementFor(id))
+            queued.runAll()
+        }
+        assertEquals(33, parses)
+
+        assertNull(session.replacementFor(1L))
+        queued.runAll()
+        assertNotNull(session.replacementFor(1L))
+        assertEquals(34, parses)
+    }
+
+    @Test
+    fun `a changed manifest hash invalidates the cached pointer after refresh`() {
+        val queued = QueuedExecutor()
+        var fileReads = 0
+        var parses = 0
+        val readFiles = mutableListOf<String>()
+        var manifest = CustomLyricsManifest(
+            listOf(entry(42L, fileId = "lyrics_v1", sha256 = SHA256_A)),
+        )
+        val session = CustomLyricsReplacementSession(
+            index = CustomLyricsIndexProvider {
+                manifest.entries.associateBy(CustomLyricsEntry::appleMusicId)
+            },
+            readTtml = { entry ->
+                fileReads += 1
+                readFiles += entry.fileId
+                TTML
+            },
+            parseTtml = { parses += 1; Pointer(0L) },
+            isAlive = { it is Pointer },
+            verifyPtr = { it is Pointer },
+            readAdamId = { (it as Pointer).adamId },
+            bindAdamId = { value, id -> (value as Pointer).adamId = id; true },
+            executor = queued,
+            logger = {},
+        )
+
+        session.start()
+        queued.runAll()
+        assertNull(session.replacementFor(42L))
+        queued.runAll()
+        val first = session.replacementFor(42L)
+        assertNotNull(first)
+        assertEquals(listOf("lyrics_v1"), readFiles)
+
+        manifest = CustomLyricsManifest(
+            listOf(entry(42L, fileId = "lyrics_v2", sha256 = SHA256_B)),
+        )
+        assertNull(session.replacementFor(999L))
+        queued.runAll()
+
+        assertNull(session.readyReplacementFor(42L))
+        assertNull(session.replacementFor(42L))
+        queued.runAll()
+        val second = session.replacementFor(42L)
+        assertNotNull(second)
+        assertNotSame(first, second)
+        assertEquals(listOf("lyrics_v1", "lyrics_v2"), readFiles)
+        assertEquals(2, parses)
     }
 
     private fun session(
@@ -213,7 +453,9 @@ class CustomLyricsReplacementSessionTest {
         parse: (String) -> Any?,
         bind: (Pointer, Long) -> Boolean = { pointer, id -> pointer.adamId = id; true },
     ): CustomLyricsReplacementSession = CustomLyricsReplacementSession(
-        manifestProvider = { manifest },
+        index = CustomLyricsIndexProvider {
+            manifest.entries.associateBy(CustomLyricsEntry::appleMusicId)
+        },
         readTtml = read,
         parseTtml = parse,
         isAlive = { it is Pointer },
@@ -226,12 +468,21 @@ class CustomLyricsReplacementSessionTest {
 
     private fun manifest(entry: CustomLyricsEntry) = CustomLyricsManifest(listOf(entry))
 
-    private fun entry(id: Long, enabled: Boolean = true) = CustomLyricsEntry(
+    private fun manyEntries(count: Int): CustomLyricsManifest = CustomLyricsManifest(
+        (1L..count.toLong()).map(::entry),
+    )
+
+    private fun entry(
+        id: Long,
+        enabled: Boolean = true,
+        fileId: String = "lyrics_$id",
+        sha256: String = SHA256_A,
+    ) = CustomLyricsEntry(
         appleMusicId = id,
         displayName = "Song",
-        fileId = "lyrics_$id",
+        fileId = fileId,
         sizeBytes = TTML.toByteArray().size.toLong(),
-        sha256 = "0cba697d61a21fb62408b2411aa2152d1bc24cc2414d2bd162f70e04d20c5e53",
+        sha256 = sha256,
         source = CustomLyricsSources.MANUAL,
         enabled = enabled,
     )
@@ -252,5 +503,7 @@ class CustomLyricsReplacementSessionTest {
 
     private companion object {
         const val TTML = "<tt><body><p><span>word</span></p></body></tt>"
+        const val SHA256_A = "0cba697d61a21fb62408b2411aa2152d1bc24cc2414d2bd162f70e04d20c5e53"
+        const val SHA256_B = "1111111111111111111111111111111111111111111111111111111111111111"
     }
 }

--- a/app/src/test/java/dev/amenhancer/module/hook/TargetConfigClientIndexResolveTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/TargetConfigClientIndexResolveTest.kt
@@ -1,0 +1,54 @@
+package dev.amenhancer.module.hook
+
+import android.content.SharedPreferences
+import dev.amenhancer.module.config.TargetConfigClient
+import dev.amenhancer.module.model.CustomLyricsEntry
+import java.lang.reflect.Proxy
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TargetConfigClientIndexResolveTest {
+
+    @Test
+    fun `settings without a pointer falls back to the legacy v1 manifest`() {
+        val v1 = """{"version":1,"entries":[{"appleMusicId":42,"displayName":"Old","fileId":"lyrics_old","sizeBytes":42,"sha256":"0cba697d61a21fb62408b2411aa2152d1bc24cc2414d2bd162f70e04d20c5e53","source":"manual","enabled":true}]}"""
+        val client = TargetConfigClient(
+            preferences(
+                mapOf(
+                    "custom_lyrics_enabled" to true,
+                    "custom_lyrics_manifest" to v1,
+                ),
+            ),
+        )
+
+        val manifest = client.settings().customLyricsManifest
+
+        assertEquals(listOf(42L), manifest.entries.map(CustomLyricsEntry::appleMusicId))
+    }
+
+    @Test
+    fun `settings with neither pointer nor legacy yields an empty manifest`() {
+        val client = TargetConfigClient(
+            preferences(
+                mapOf("custom_lyrics_enabled" to true),
+            ),
+        )
+
+        assertTrue(client.settings().customLyricsManifest.entries.isEmpty())
+    }
+
+    private fun preferences(values: Map<String, Any>): SharedPreferences =
+        Proxy.newProxyInstance(
+            SharedPreferences::class.java.classLoader,
+            arrayOf(SharedPreferences::class.java),
+        ) { _, method, _ ->
+            when (method.name) {
+                "getAll" -> values
+                "toString" -> "target-config-index-resolve-test-preferences"
+                "hashCode" -> 1
+                "equals" -> false
+                else -> null
+            }
+        } as SharedPreferences
+}

--- a/app/src/test/java/dev/amenhancer/module/lyrics/CustomLyricsBackupCodecTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/lyrics/CustomLyricsBackupCodecTest.kt
@@ -4,7 +4,6 @@ import dev.amenhancer.module.config.CustomLyricsManifestCodec
 import dev.amenhancer.module.model.CustomLyricsEntry
 import dev.amenhancer.module.model.CustomLyricsManifest
 import dev.amenhancer.module.model.CustomLyricsSources
-import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -38,16 +37,19 @@ class CustomLyricsBackupCodecTest {
         assertTrue(encoded is CustomLyricsBackupEncodeResult.Encoded)
         assertEquals(2, (encoded as CustomLyricsBackupEncodeResult.Encoded).entryCount)
 
-        val decoded = CustomLyricsBackupCodec.decode(ByteArrayInputStream(out.toByteArray()))
+        val delivered = linkedMapOf<String, ByteArray>()
+        val decoded = CustomLyricsBackupCodec.decode(ByteArrayInputStream(out.toByteArray())) { fileId, bytes ->
+            delivered[fileId] = bytes
+        }
         assertTrue(decoded is CustomLyricsBackupDecodeResult.Decoded)
         val backup = (decoded as CustomLyricsBackupDecodeResult.Decoded).backup
         assertEquals(manifest, backup.manifest)
-        assertEquals(ttml1, backup.files.getValue("lyrics_a").toString(Charsets.UTF_8))
-        assertEquals(ttml2, backup.files.getValue("lyrics_b").toString(Charsets.UTF_8))
+        assertEquals(files.keys, delivered.keys)
+        files.forEach { (fileId, bytes) -> assertTrue(bytes.contentEquals(delivered[fileId])) }
     }
 
     @Test
-    fun `backup fails entirely when any remote file cannot be read`() {
+    fun `a failed backup never decodes as valid`() {
         val manifest = CustomLyricsManifest(
             listOf(
                 entry(appleMusicId = 1L, fileId = "lyrics_a", ttml = ttml1),
@@ -59,12 +61,20 @@ class CustomLyricsBackupCodecTest {
         val result = CustomLyricsBackupCodec.encode(manifest, { null }, out)
 
         assertTrue(result is CustomLyricsBackupEncodeResult.Failed)
-        assertEquals(0, out.size())
+        assertTrue(
+            "a partial backup must never decode as valid",
+            decode(out.toByteArray()) is CustomLyricsBackupDecodeResult.Rejected,
+        )
     }
 
     @Test
     fun `encode rejects a manifest that policy would alter`() {
-        val manifest = CustomLyricsManifest((1L..33L).map { entry(it, "lyrics_$it", ttml1) })
+        val manifest = CustomLyricsManifest(
+            listOf(
+                entry(1L, "lyrics_a", ttml1),
+                entry(1L, "lyrics_b", ttml1),
+            ),
+        )
 
         val result = CustomLyricsBackupCodec.encode(manifest, { ttml1.toByteArray() }, ByteArrayOutputStream())
 
@@ -96,48 +106,75 @@ class CustomLyricsBackupCodecTest {
     }
 
     @Test
-    fun `decode rejects a manifest with more than 32 entries`() {
-        val entries = JSONArray()
-        repeat(33) { index ->
-            entries.put(
-                JSONObject().apply {
-                    put("appleMusicId", index + 1L)
-                    put("displayName", "s")
-                    put("fileId", "lyrics_$index")
-                    put("sizeBytes", 5L)
-                    put("sha256", "0".repeat(64))
-                    put("source", CustomLyricsSources.MANUAL)
-                    put("enabled", true)
-                },
-            )
-        }
-        val json = JSONObject().apply { put("version", 1); put("entries", entries) }.toString()
-        val result = decode(zipBytes(listOf("manifest.json" to json.toByteArray())))
+    fun `decode accepts a manifest with more than 32 entries when every file is present`() {
+        val entries = (1L..40L).map { index -> entry(index, "lyrics_$index", ttml1) }
+        val manifest = CustomLyricsManifest(entries)
+        val files = entries.associate { it.fileId to ttml1.toByteArray(Charsets.UTF_8) }
+        val out = ByteArrayOutputStream()
+        val encoded = CustomLyricsBackupCodec.encode(manifest, { files[it] }, out)
+        assertTrue(encoded is CustomLyricsBackupEncodeResult.Encoded)
+        assertEquals(40, (encoded as CustomLyricsBackupEncodeResult.Encoded).entryCount)
 
-        assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
+        val delivered = linkedMapOf<String, ByteArray>()
+        val decoded = CustomLyricsBackupCodec.decode(ByteArrayInputStream(out.toByteArray())) { fileId, bytes ->
+            delivered[fileId] = bytes
+        }
+        assertTrue(decoded is CustomLyricsBackupDecodeResult.Decoded)
+        assertEquals(40, (decoded as CustomLyricsBackupDecodeResult.Decoded).backup.manifest.entries.size)
+        assertEquals(40, delivered.size)
+    }
+
+    @Test
+    fun `a backup of over a thousand small entries roundtrips`() {
+        val entries = (1L..1000L).map { index ->
+            entry(index, "lyrics_$index", smallTtml(index))
+        }
+        val manifest = CustomLyricsManifest(entries)
+        val files = entries.associate { it.fileId to smallTtml(it.appleMusicId).toByteArray(Charsets.UTF_8) }
+        val out = ByteArrayOutputStream()
+        val encoded = CustomLyricsBackupCodec.encode(manifest, { files[it] }, out)
+        assertTrue(encoded is CustomLyricsBackupEncodeResult.Encoded)
+        assertEquals(1000, (encoded as CustomLyricsBackupEncodeResult.Encoded).entryCount)
+
+        val delivered = linkedMapOf<String, ByteArray>()
+        val decoded = CustomLyricsBackupCodec.decode(ByteArrayInputStream(out.toByteArray())) { fileId, bytes ->
+            delivered[fileId] = bytes
+        }
+        assertTrue(decoded is CustomLyricsBackupDecodeResult.Decoded)
+        val backup = (decoded as CustomLyricsBackupDecodeResult.Decoded).backup
+        assertEquals(1000, backup.manifest.entries.size)
+        assertEquals(manifest, backup.manifest)
+        assertEquals(1000, delivered.size)
+        files.forEach { (fileId, bytes) -> assertTrue(bytes.contentEquals(delivered[fileId])) }
     }
 
     @Test
     fun `decode rejects duplicate apple music ids in the manifest`() {
-        val entries = JSONArray()
-        listOf(
-            entry(appleMusicId = 1L, fileId = "lyrics_a", ttml = ttml1),
-            entry(appleMusicId = 1L, fileId = "lyrics_b", ttml = ttml2),
-        ).forEach { e ->
-            entries.put(
-                JSONObject().apply {
-                    put("appleMusicId", e.appleMusicId)
-                    put("displayName", e.displayName)
-                    put("fileId", e.fileId)
-                    put("sizeBytes", e.sizeBytes)
-                    put("sha256", e.sha256)
-                    put("source", e.source)
-                    put("enabled", e.enabled)
+        val entries = JSONObject().apply {
+            put("version", 1)
+            put(
+                "entries",
+                org.json.JSONArray().apply {
+                    listOf(
+                        entry(appleMusicId = 1L, fileId = "lyrics_a", ttml = ttml1),
+                        entry(appleMusicId = 1L, fileId = "lyrics_b", ttml = ttml2),
+                    ).forEach { e ->
+                        put(
+                            JSONObject().apply {
+                                put("appleMusicId", e.appleMusicId)
+                                put("displayName", e.displayName)
+                                put("fileId", e.fileId)
+                                put("sizeBytes", e.sizeBytes)
+                                put("sha256", e.sha256)
+                                put("source", e.source)
+                                put("enabled", e.enabled)
+                            },
+                        )
+                    }
                 },
             )
         }
-        val json = JSONObject().apply { put("version", 1); put("entries", entries) }.toString()
-        val result = decode(zipBytes(listOf("manifest.json" to json.toByteArray())))
+        val result = decode(zipBytes(listOf("manifest.json" to entries.toString().toByteArray())))
 
         assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
     }
@@ -170,8 +207,17 @@ class CustomLyricsBackupCodecTest {
     @Test
     fun `decode rejects duplicate file names`() {
         val bytes = ttml1.toByteArray(Charsets.UTF_8)
+        val manifest = CustomLyricsManifest(listOf(entry(appleMusicId = 1L, fileId = "lyrics_a", ttml = ttml1)))
 
-        val result = decode(zipWithDuplicateName("lyrics_a", bytes, bytes))
+        val result = decode(
+            zipRaw(
+                listOf(
+                    "manifest.json" to manifestJson(manifest),
+                    "lyrics_a" to bytes,
+                    "lyrics_a" to bytes,
+                ),
+            ),
+        )
 
         assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
     }
@@ -181,6 +227,22 @@ class CustomLyricsBackupCodecTest {
         val json = CustomLyricsManifestCodec.encode(CustomLyricsManifest.empty()).toByteArray()
 
         val result = decode(zipWithDuplicateName("manifest.json", json, json))
+
+        assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
+    }
+
+    @Test
+    fun `decode rejects files that precede the manifest`() {
+        val manifest = CustomLyricsManifest(listOf(entry(appleMusicId = 1L, fileId = "lyrics_a", ttml = ttml1)))
+
+        val result = decode(
+            zipRaw(
+                listOf(
+                    "lyrics_a" to ttml1.toByteArray(Charsets.UTF_8),
+                    "manifest.json" to manifestJson(manifest),
+                ),
+            ),
+        )
 
         assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
     }
@@ -299,21 +361,47 @@ class CustomLyricsBackupCodecTest {
 
     @Test
     fun `decode rejects an oversize entry (zip bomb per entry bound)`() {
-        val result = decode(zipBytes(listOf("lyrics_big" to ByteArray(512 * 1024 + 1))))
+        val bytes = ByteArray(512 * 1024 + 1)
+        val oversized = CustomLyricsEntry(
+            appleMusicId = 1L,
+            displayName = "Song",
+            fileId = "lyrics_big",
+            sizeBytes = 512 * 1024L,
+            sha256 = CustomLyricsFilePolicy.sha256(bytes),
+            source = CustomLyricsSources.MANUAL,
+        )
+        val result = decode(
+            zipBytes(
+                listOf(
+                    "manifest.json" to manifestJson(CustomLyricsManifest(listOf(oversized))),
+                    "lyrics_big" to bytes,
+                ),
+            ),
+        )
 
         assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
     }
 
     @Test
-    fun `decode rejects too many zip entries`() {
-        val bytes = ttml1.toByteArray(Charsets.UTF_8)
-        val result = decode(zipBytes((1..34).map { "lyrics_$it" to bytes }))
-
-        assertTrue(result is CustomLyricsBackupDecodeResult.Rejected)
+    fun `encode rejects a backup whose total ttml exceeds the restore limit`() {
+        val bigTtml = "<tt><body><p><span>" + " ".repeat(TtmlInputPolicy.MAX_TTML_BYTES - 42) + "</span></p></body></tt>"
+        val bigBytes = bigTtml.toByteArray(Charsets.UTF_8)
+        assertEquals(TtmlInputPolicy.MAX_TTML_BYTES, bigBytes.size)
+        val base = entry(appleMusicId = 1L, fileId = "lyrics_1", ttml = bigTtml)
+        val entries = (1..513).map { index -> base.copy(appleMusicId = index.toLong(), fileId = "lyrics_$index") }
+        val manifest = CustomLyricsManifest(entries)
+        val files = entries.associate { it.fileId to bigBytes }
+        val out = ByteArrayOutputStream()
+        val encoded = CustomLyricsBackupCodec.encode(manifest, { files[it] }, out)
+        assertEquals(
+            CustomLyricsBackupEncodeResult.Failed("歌词备份总量超过上限"),
+            encoded,
+        )
+        assertEquals(0, out.size())
     }
 
     private fun decode(zip: ByteArray): CustomLyricsBackupDecodeResult =
-        CustomLyricsBackupCodec.decode(ByteArrayInputStream(zip))
+        CustomLyricsBackupCodec.decode(ByteArrayInputStream(zip)) { _, _ -> }
 
     private fun zipBytes(entries: List<Pair<String, ByteArray>>): ByteArray {
         val out = ByteArrayOutputStream()
@@ -328,16 +416,16 @@ class CustomLyricsBackupCodecTest {
     }
 
     /**
-     * Builds a zip with several entries sharing [name]. ZipOutputStream
-     * refuses duplicate names, so the ZIP is assembled by hand (little-endian
-     * layout, STORED method, real CRC32s).
+     * Builds a zip with arbitrary entries including duplicate names.
+     * ZipOutputStream refuses duplicates, so the ZIP is assembled by hand
+     * (little-endian layout, STORED method, real CRC32s).
      */
-    private fun zipWithDuplicateName(name: String, vararg datas: ByteArray): ByteArray {
-        val nameBytes = name.toByteArray(Charsets.UTF_8)
+    private fun zipRaw(entries: List<Pair<String, ByteArray>>): ByteArray {
         val out = ByteArrayOutputStream()
         var offset = 0
         val centralHeaders = ArrayList<ByteArray>()
-        datas.forEach { data ->
+        entries.forEach { (name, data) ->
+            val nameBytes = name.toByteArray(Charsets.UTF_8)
             val crc = CRC32().apply { update(data) }.value.toInt()
             val local = ByteBuffer.allocate(30 + nameBytes.size).order(ByteOrder.LITTLE_ENDIAN)
             local.putInt(0x04034b50)
@@ -363,7 +451,7 @@ class CustomLyricsBackupCodecTest {
         centralHeaders.forEach { out.write(it) }
         val eocd = ByteBuffer.allocate(22).order(ByteOrder.LITTLE_ENDIAN)
         eocd.putInt(0x06054b50)
-        eocd.putShort(0); eocd.putShort(0); eocd.putShort(datas.size.toShort()); eocd.putShort(datas.size.toShort())
+        eocd.putShort(0); eocd.putShort(0); eocd.putShort(entries.size.toShort()); eocd.putShort(entries.size.toShort())
         eocd.putInt(centralHeaders.sumOf { it.size })
         eocd.putInt(centralStart)
         eocd.putShort(0)
@@ -371,8 +459,13 @@ class CustomLyricsBackupCodecTest {
         return out.toByteArray()
     }
 
+    private fun zipWithDuplicateName(name: String, vararg datas: ByteArray): ByteArray =
+        zipRaw(datas.map { name to it })
+
     private fun manifestJson(manifest: CustomLyricsManifest): ByteArray =
         CustomLyricsManifestCodec.encode(manifest).toByteArray(Charsets.UTF_8)
+
+    private fun smallTtml(index: Long): String = "<tt><body><p><span>$index</span></p></body></tt>"
 
     private fun entry(appleMusicId: Long, fileId: String, ttml: String): CustomLyricsEntry {
         val bytes = ttml.toByteArray(Charsets.UTF_8)

--- a/app/src/test/java/dev/amenhancer/module/lyrics/CustomLyricsImportTransactionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/lyrics/CustomLyricsImportTransactionTest.kt
@@ -16,7 +16,7 @@ class CustomLyricsImportTransactionTest {
         val old = CustomLyricsManifest(listOf(existingEntry()))
         val transaction = transaction(events) { events += "publish"; true }
 
-        val result = transaction.upsert(old, draft())
+        val result = transaction.upsert(old, draft(), replacingAppleMusicId = 42L)
 
         assertTrue(result is CustomLyricsSaveResult.Saved)
         assertEquals(listOf("write", "publish", "delete:lyrics_old"), events)
@@ -83,6 +83,20 @@ class CustomLyricsImportTransactionTest {
             oldManifest = old,
             draft = draft(appleMusicId = 84L),
             replacingAppleMusicId = 42L,
+        )
+
+        assertEquals(CustomLyricsSaveResult.Failed("目标 Apple Music ID 已存在"), result)
+        assertTrue(events.isEmpty())
+    }
+
+    @Test
+    fun `adding an id that already exists fails without overwriting its file`() {
+        val events = mutableListOf<String>()
+        val transaction = transaction(events) { events += "publish"; true }
+
+        val result = transaction.upsert(
+            oldManifest = CustomLyricsManifest(listOf(existingEntry())),
+            draft = draft(),
         )
 
         assertEquals(CustomLyricsSaveResult.Failed("目标 Apple Music ID 已存在"), result)

--- a/app/src/test/java/dev/amenhancer/module/lyrics/CustomLyricsRestoreTransactionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/lyrics/CustomLyricsRestoreTransactionTest.kt
@@ -1,12 +1,13 @@
 package dev.amenhancer.module.lyrics
 
-import dev.amenhancer.module.config.CustomLyricsManifestPolicy
 import dev.amenhancer.module.model.CustomLyricsEntry
 import dev.amenhancer.module.model.CustomLyricsManifest
 import dev.amenhancer.module.model.CustomLyricsSources
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 
 class CustomLyricsRestoreTransactionTest {
     private val ttml = "<tt><body><p><span>word</span></p></body></tt>"
@@ -21,7 +22,7 @@ class CustomLyricsRestoreTransactionTest {
                 existingEntry(appleMusicId = 2L, fileId = "lyrics_b"),
             ),
         )
-        val backup = backup(
+        val (backup, files) = backup(
             backupEntry(appleMusicId = 2L, fileId = "lyrics_bb", displayName = "B new") to ttmlBytes(),
             backupEntry(appleMusicId = 3L, fileId = "lyrics_cc") to ttmlBytes(),
         )
@@ -30,7 +31,7 @@ class CustomLyricsRestoreTransactionTest {
             events += "publish"
             published = manifest
             true
-        }.merge(current, backup)
+        }.merge(current, streamBackup(backup, files))
 
         assertTrue(result is CustomLyricsRestoreResult.Restored)
         assertEquals(
@@ -54,7 +55,7 @@ class CustomLyricsRestoreTransactionTest {
                 existingEntry(appleMusicId = 2L, fileId = "lyrics_b"),
             ),
         )
-        val backup = backup(
+        val (backup, files) = backup(
             backupEntry(appleMusicId = 2L, fileId = "lyrics_bb") to ttmlBytes(),
             backupEntry(appleMusicId = 3L, fileId = "lyrics_cc") to ttmlBytes(),
         )
@@ -65,7 +66,7 @@ class CustomLyricsRestoreTransactionTest {
                 events += "write:$fileId"
                 fileId != "lyrics_new2"
             },
-        ) { events += "publish"; true }.merge(current, backup)
+        ) { events += "publish"; true }.merge(current, streamBackup(backup, files))
 
         assertEquals(CustomLyricsRestoreResult.Failed("无法写入共享歌词文件"), result)
         assertEquals(
@@ -88,12 +89,12 @@ class CustomLyricsRestoreTransactionTest {
                 existingEntry(appleMusicId = 2L, fileId = "lyrics_b"),
             ),
         )
-        val backup = backup(
+        val (backup, files) = backup(
             backupEntry(appleMusicId = 2L, fileId = "lyrics_bb") to ttmlBytes(),
             backupEntry(appleMusicId = 3L, fileId = "lyrics_cc") to ttmlBytes(),
         )
 
-        val result = transaction(events) { events += "publish"; false }.merge(current, backup)
+        val result = transaction(events) { events += "publish"; false }.merge(current, streamBackup(backup, files))
 
         assertEquals(CustomLyricsRestoreResult.Failed("无法发布歌词映射"), result)
         assertEquals(
@@ -108,7 +109,7 @@ class CustomLyricsRestoreTransactionTest {
         val current = CustomLyricsManifest(listOf(existingEntry(appleMusicId = 1L, fileId = "lyrics_a")))
 
         val result = transaction(events) { events += "publish"; true }
-            .merge(current, backup())
+            .merge(current, streamBackup(CustomLyricsBackup(CustomLyricsManifest.empty()), emptyMap()))
 
         assertTrue(result is CustomLyricsRestoreResult.Restored)
         assertEquals(current, (result as CustomLyricsRestoreResult.Restored).manifest)
@@ -116,26 +117,86 @@ class CustomLyricsRestoreTransactionTest {
     }
 
     @Test
-    fun `a merge exceeding the entry limit fails before any write`() {
+    fun `merging a backup with more than 32 entries publishes every entry`() {
         val events = mutableListOf<String>()
+        var published = CustomLyricsManifest.empty()
         val current = CustomLyricsManifest(
-            (1L..CustomLyricsManifestPolicy.MAX_ENTRIES.toLong()).map { existingEntry(it, "lyrics_$it") },
+            (1L..5L).map { existingEntry(it, "lyrics_old$it") },
         )
-        val backup = backup(backupEntry(appleMusicId = 100L, fileId = "lyrics_new") to ttmlBytes())
+        val backupEntries = (2L..41L).map { backupEntry(it, "lyrics_bb$it") }
+        val (backup, files) = backup(*backupEntries.map { it to ttmlBytes() }.toTypedArray())
 
-        val result = transaction(events) { events += "publish"; true }.merge(current, backup)
+        val result = transaction(events) { manifest ->
+            events += "publish"
+            published = manifest
+            true
+        }.merge(current, streamBackup(backup, files))
 
-        assertEquals(CustomLyricsRestoreResult.Failed("合并后歌词映射数量超过上限"), result)
-        assertTrue(events.isEmpty())
+        assertTrue(result is CustomLyricsRestoreResult.Restored)
+        assertEquals(41, (result as CustomLyricsRestoreResult.Restored).manifest.entries.size)
+        assertEquals(41, published.entries.size)
+        assertEquals((1L..41L).toList(), published.entries.map(CustomLyricsEntry::appleMusicId))
+        assertEquals((1..40).map { "write:lyrics_new$it" }, events.take(40))
+        assertEquals("publish", events[40])
+        assertEquals(
+            listOf("delete:lyrics_old2", "delete:lyrics_old3", "delete:lyrics_old4", "delete:lyrics_old5"),
+            events.drop(41),
+        )
+    }
+
+    @Test
+    fun `restoring a 40 entry backup through the real codec rebuilds every file with a fresh id`() {
+        val events = mutableListOf<String>()
+        var published = CustomLyricsManifest.empty()
+        val current = CustomLyricsManifest(
+            listOf(
+                existingEntry(4L, "lyrics_old4"),
+                existingEntry(5L, "lyrics_old5"),
+                existingEntry(6L, "lyrics_old6"),
+            ),
+        )
+        val backupEntries = (1L..40L).map { backupEntry(it, "lyrics_$it") }
+        val files = backupEntries.associate { it.fileId to ttmlBytes() }
+        val out = ByteArrayOutputStream()
+        val encoded = CustomLyricsBackupCodec.encode(
+            CustomLyricsManifest(backupEntries),
+            { fileId -> files[fileId] },
+            out,
+        )
+        assertTrue(encoded is CustomLyricsBackupEncodeResult.Encoded)
+
+        val result = transaction(events) { manifest ->
+            events += "publish"
+            published = manifest
+            true
+        }.merge(current) { onFile ->
+            CustomLyricsBackupCodec.decode(ByteArrayInputStream(out.toByteArray()), onFile)
+        }
+
+        assertTrue(result is CustomLyricsRestoreResult.Restored)
+        assertEquals(40, (result as CustomLyricsRestoreResult.Restored).manifest.entries.size)
+        assertEquals(40, published.entries.size)
+        assertEquals(
+            listOf(4L, 5L, 6L) + (1L..3L) + (7L..40L),
+            published.entries.map(CustomLyricsEntry::appleMusicId),
+        )
+        assertTrue(published.entries.all { it.fileId.startsWith("lyrics_new") })
+        assertEquals(40, published.entries.map(CustomLyricsEntry::fileId).toSet().size)
+        assertEquals(40, events.count { it.startsWith("write:") })
+        assertEquals(listOf("publish"), events.filter { it.startsWith("publish") })
+        assertEquals(
+            listOf("delete:lyrics_old4", "delete:lyrics_old5", "delete:lyrics_old6"),
+            events.filter { it.startsWith("delete:") },
+        )
     }
 
     @Test
     fun `an invalid generated file id fails before any write`() {
         val events = mutableListOf<String>()
-        val backup = backup(backupEntry(appleMusicId = 3L, fileId = "lyrics_cc") to ttmlBytes())
+        val (backup, files) = backup(backupEntry(appleMusicId = 3L, fileId = "lyrics_cc") to ttmlBytes())
 
         val result = transaction(events, fileIdFactory = { "bad file id!" }) { events += "publish"; true }
-            .merge(CustomLyricsManifest.empty(), backup)
+            .merge(CustomLyricsManifest.empty(), streamBackup(backup, files))
 
         assertEquals(CustomLyricsRestoreResult.Failed("无法生成歌词文件 ID"), result)
         assertTrue(events.isEmpty())
@@ -144,14 +205,47 @@ class CustomLyricsRestoreTransactionTest {
     @Test
     fun `a generated file id collision fails before any write`() {
         val events = mutableListOf<String>()
-        val current = CustomLyricsManifest(listOf(existingEntry(1L, "lyrics_taken")))
-        val backup = backup(backupEntry(appleMusicId = 3L, fileId = "lyrics_cc") to ttmlBytes())
+        val (backup, files) = backup(backupEntry(appleMusicId = 3L, fileId = "lyrics_cc") to ttmlBytes())
 
         val result = transaction(events, fileIdFactory = { "lyrics_taken" }) { events += "publish"; true }
-            .merge(current, backup)
+            .merge(CustomLyricsManifest(listOf(existingEntry(1L, "lyrics_taken"))), streamBackup(backup, files))
 
         assertEquals(CustomLyricsRestoreResult.Failed("无法生成唯一歌词文件 ID"), result)
         assertTrue(events.isEmpty())
+    }
+
+    @Test
+    fun `a rejected backup rolls back files written before the rejection`() {
+        val events = mutableListOf<String>()
+
+        val result = transaction(events) { events += "publish"; true }.merge(CustomLyricsManifest.empty()) { onFile ->
+            onFile("lyrics_bb", ttmlBytes())
+            CustomLyricsBackupDecodeResult.Rejected("备份条目过多")
+        }
+
+        assertEquals(CustomLyricsRestoreResult.Failed("备份条目过多"), result)
+        assertEquals(listOf("write:lyrics_new1", "delete:lyrics_new1"), events)
+    }
+
+    @Test
+    fun `a backup missing a declared file fails and rolls back`() {
+        val events = mutableListOf<String>()
+        val declared = CustomLyricsBackup(
+            CustomLyricsManifest(
+                listOf(
+                    backupEntry(1L, "lyrics_bb"),
+                    backupEntry(2L, "lyrics_cc"),
+                ),
+            ),
+        )
+
+        val result = transaction(events) { events += "publish"; true }.merge(CustomLyricsManifest.empty()) { onFile ->
+            onFile("lyrics_bb", ttmlBytes())
+            CustomLyricsBackupDecodeResult.Decoded(declared)
+        }
+
+        assertEquals(CustomLyricsRestoreResult.Failed("备份内容缺失"), result)
+        assertEquals(listOf("write:lyrics_new1", "delete:lyrics_new1"), events)
     }
 
     private fun transaction(
@@ -174,11 +268,17 @@ class CustomLyricsRestoreTransactionTest {
         return { next += 1; "lyrics_new$next" }
     }
 
-    private fun backup(vararg entries: Pair<CustomLyricsEntry, ByteArray>): CustomLyricsBackup =
-        CustomLyricsBackup(
-            manifest = CustomLyricsManifest(entries.map { it.first }),
-            files = entries.associate { it.first.fileId to it.second },
-        )
+    private fun streamBackup(
+        backup: CustomLyricsBackup,
+        files: Map<String, ByteArray>,
+    ): (onFile: (String, ByteArray) -> Unit) -> CustomLyricsBackupDecodeResult = { onFile ->
+        files.forEach { (fileId, bytes) -> onFile(fileId, bytes) }
+        CustomLyricsBackupDecodeResult.Decoded(backup)
+    }
+
+    private fun backup(vararg entries: Pair<CustomLyricsEntry, ByteArray>): Pair<CustomLyricsBackup, Map<String, ByteArray>> =
+        CustomLyricsBackup(CustomLyricsManifest(entries.map { it.first })) to
+            entries.associate { it.first.fileId to it.second }
 
     private fun backupEntry(
         appleMusicId: Long,

--- a/app/src/test/java/dev/amenhancer/module/ui/CustomLyricsListPageStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/ui/CustomLyricsListPageStructuralRegressionTest.kt
@@ -1,0 +1,65 @@
+package dev.amenhancer.module.ui
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CustomLyricsListPageStructuralRegressionTest {
+    private fun projectFile(relativePath: String): String = sequenceOf(
+        File(relativePath),
+        File("../$relativePath"),
+    ).firstOrNull(File::isFile)?.readText()
+        ?: error("$relativePath was not found from the unit-test working directory")
+
+    @Test
+    fun `renders only the revealed window from the shared list state`() {
+        val activity = projectFile("app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt")
+        val state = projectFile("app/src/main/java/dev/amenhancer/module/ui/CustomLyricsListState.kt")
+
+        assertTrue(activity.contains("CustomLyricsListState"))
+        assertTrue(
+            activity.contains(
+                "customLyricsListState.update(\n" +
+                    "            settings.customLyricsManifest.entries,\n" +
+                    "            customLyricsSearchQuery,\n" +
+                    "        )",
+            ),
+        )
+        assertTrue(activity.contains("state.visibleEntries.forEach"))
+        assertTrue(activity.contains("customLyricsEntryRow(entry, writable)"))
+        assertFalse(activity.contains("manifest.entries.forEach"))
+        assertTrue(state.contains("DEFAULT_PAGE_SIZE = 50"))
+        assertTrue(state.contains("visibleEntries"))
+        assertTrue(state.contains("hasMore"))
+        assertFalse(state.contains("import android"))
+    }
+
+    @Test
+    fun `paginates with search, load more and a shown total counter`() {
+        val activity = projectFile("app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt")
+
+        assertTrue(activity.contains("搜索名称或 Apple Music ID"))
+        assertTrue(activity.contains("addTextChangedListener"))
+        assertTrue(activity.contains("afterTextChanged"))
+        assertTrue(activity.contains("customLyricsSearchQuery"))
+        assertTrue(activity.contains("加载更多"))
+        assertTrue(activity.contains("customLyricsListState.loadMore()"))
+        assertTrue(
+            activity.contains(
+                "已显示 \${state.visibleCount} / 共 \${state.totalCount} 首",
+            ),
+        )
+        assertFalse(activity.contains("RecyclerView"))
+    }
+
+    @Test
+    fun `keeps empty and remote unavailable semantics with a no match state`() {
+        val activity = projectFile("app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt")
+
+        assertTrue(activity.contains("需要 libxposed API 102 remote file 服务"))
+        assertTrue(activity.contains("按 Apple Music ID 手动添加 TTML；不会在播放时联网识歌"))
+        assertTrue(activity.contains("没有匹配的歌词"))
+        assertTrue(activity.contains("已配置 \${manifest.entries.size} 首；更改后重开 Apple Music 生效"))
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/ui/CustomLyricsListStateTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/ui/CustomLyricsListStateTest.kt
@@ -1,0 +1,155 @@
+package dev.amenhancer.module.ui
+
+import dev.amenhancer.module.model.CustomLyricsEntry
+import dev.amenhancer.module.model.CustomLyricsSources
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CustomLyricsListStateTest {
+
+    private fun entry(appleMusicId: Long, displayName: String): CustomLyricsEntry =
+        CustomLyricsEntry(
+            appleMusicId = appleMusicId,
+            displayName = displayName,
+            fileId = "file-$appleMusicId",
+            sizeBytes = 1L,
+            sha256 = "sha-$appleMusicId",
+            source = CustomLyricsSources.MANUAL,
+        )
+
+    private fun numbered(count: Int, offset: Long = 1L): List<CustomLyricsEntry> =
+        (0 until count).map { index -> entry(offset + index, "Song ${offset + index}") }
+
+    @Test
+    fun `first update reveals only the default page size of a large dataset`() {
+        val state = CustomLyricsListState()
+        state.update(numbered(1000))
+        assertEquals(1000, state.totalCount)
+        assertEquals(50, state.visibleCount)
+        assertEquals(50, state.visibleEntries.size)
+        assertTrue(state.hasMore)
+    }
+
+    @Test
+    fun `reveals everything when the dataset fits one page`() {
+        val state = CustomLyricsListState()
+        state.update(numbered(3))
+        assertEquals(3, state.visibleCount)
+        assertFalse(state.hasMore)
+    }
+
+    @Test
+    fun `loads more in page sized increments up to the total`() {
+        val state = CustomLyricsListState()
+        state.update(numbered(120))
+        assertEquals(50, state.visibleCount)
+        state.loadMore()
+        assertEquals(100, state.visibleCount)
+        state.loadMore()
+        assertEquals(120, state.visibleCount)
+        assertFalse(state.hasMore)
+        state.loadMore()
+        assertEquals(120, state.visibleCount)
+    }
+
+    @Test
+    fun `filters by display name case insensitively before pagination`() {
+        val state = CustomLyricsListState()
+        state.update(
+            listOf(
+                entry(1, "Alice in Wonderland"),
+                entry(2, "alice cooper"),
+                entry(3, "Bob Marley"),
+            ),
+        )
+        state.setQuery("aLiCe")
+        assertEquals(2, state.totalCount)
+        assertEquals(listOf(1L, 2L), state.visibleEntries.map { it.appleMusicId })
+        assertFalse(state.hasMore)
+    }
+
+    @Test
+    fun `filters by apple music id substring`() {
+        val state = CustomLyricsListState()
+        state.update(listOf(entry(123456789, "First"), entry(987654321, "Second")))
+        state.setQuery("2345")
+        assertEquals(listOf(123456789L), state.visibleEntries.map { it.appleMusicId })
+    }
+
+    @Test
+    fun `search empties and then recovers the window when cleared`() {
+        val state = CustomLyricsListState()
+        state.update(numbered(1000))
+        state.loadMore()
+        assertEquals(100, state.visibleCount)
+        state.setQuery("no such song")
+        assertEquals(0, state.totalCount)
+        assertEquals(0, state.visibleCount)
+        assertFalse(state.hasMore)
+        state.setQuery("")
+        assertEquals(1000, state.totalCount)
+        assertEquals(50, state.visibleCount)
+        assertTrue(state.hasMore)
+    }
+
+    @Test
+    fun `refresh after deletion never shows removed entries`() {
+        val state = CustomLyricsListState()
+        val before = numbered(1000)
+        state.update(before)
+        state.loadMore()
+        state.loadMore()
+        assertEquals(150, state.visibleCount)
+
+        val after = before.filter { it.appleMusicId % 10L != 0L }
+        state.update(after)
+
+        assertEquals(900, state.totalCount)
+        assertEquals(150, state.visibleCount)
+        assertEquals(after.take(150), state.visibleEntries)
+        assertTrue(state.visibleEntries.none { it.appleMusicId % 10L == 0L })
+    }
+
+    @Test
+    fun `refresh converges the window when the dataset shrinks`() {
+        val state = CustomLyricsListState()
+        state.update(numbered(60))
+        state.loadMore()
+        assertEquals(60, state.visibleCount)
+
+        val restored = listOf(entry(1, "Restored One"), entry(2, "Restored Two"))
+        state.update(restored)
+
+        assertEquals(2, state.totalCount)
+        assertEquals(restored, state.visibleEntries)
+        assertFalse(state.hasMore)
+    }
+
+    @Test
+    fun `keeps the active query across dataset refresh`() {
+        val state = CustomLyricsListState()
+        val all = listOf(entry(1, "Alice"), entry(2, "Bob"), entry(3, "Alice in Chains"))
+        state.update(all, "aliCe")
+        assertEquals(listOf(1L, 3L), state.visibleEntries.map { it.appleMusicId })
+
+        state.update(all + entry(4, "Alice Keys"), "aliCe")
+        assertEquals(3, state.totalCount)
+        assertEquals(listOf(1L, 3L), state.visibleEntries.map { it.appleMusicId })
+        assertTrue(state.hasMore)
+        state.loadMore()
+        assertEquals(listOf(1L, 3L, 4L), state.visibleEntries.map { it.appleMusicId })
+    }
+
+    @Test
+    fun `empty dataset stays empty without more pages`() {
+        val state = CustomLyricsListState()
+        state.update(emptyList())
+        assertEquals(0, state.totalCount)
+        assertEquals(0, state.visibleCount)
+        assertFalse(state.hasMore)
+        state.loadMore()
+        assertEquals(0, state.visibleCount)
+    }
+}


### PR DESCRIPTION
## Summary\n- move the custom lyrics index to a verified remote file with an atomic pointer\n- remove the fixed 32-entry mapping limit and preserve v1 migration\n- prepare TTML and native pointers on demand with a bounded LRU\n- stream large backups/restores and paginate custom lyrics management\n\n## Verification\n- :app:testDebugUnitTest\n- :app:assembleDebug\n- :app:assembleRelease\n- :app:lintVitalRelease\n\nAll run offline with JDK 17.