### PR TITLE
fix: stabilize custom lyrics and tablet bottom bar

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,8 +35,8 @@ android {
         applicationId = "dev.amenhancer.module"
         minSdk = 26
         targetSdk = 37
-        versionCode = 91
-        versionName = "1.3.4"
+        versionCode = 92
+        versionName = "1.3.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicCustomLyricsTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicCustomLyricsTarget.kt
@@ -1,5 +1,7 @@
 package dev.amenhancer.module.hook
 
+import android.os.Handler
+import android.os.Looper
 import android.os.ParcelFileDescriptor
 import dev.amenhancer.module.config.TargetConfigClient
 import dev.amenhancer.module.lyrics.CustomLyricsFilePolicy
@@ -67,6 +69,8 @@ internal class AppleMusicCustomLyricsTarget(
                 }.getOrNull()
             }
         }
+        val mainHandler = Handler(Looper.getMainLooper())
+        lateinit var readyReapply: CustomLyricsReadyReapply
         val session = CustomLyricsReplacementSession(
             index = CustomLyricsIndexProvider {
                 config.customLyricsManifest().entries.associateBy(
@@ -79,6 +83,9 @@ internal class AppleMusicCustomLyricsTarget(
             verifyPtr = parser::isValid,
             readAdamId = parser::adamIdOf,
             bindAdamId = parser::bindAdamId,
+            onReplacementPublished = { appleMusicId ->
+                mainHandler.post { readyReapply.onReplacementPublished(appleMusicId) }
+            },
             executor = ThreadPoolExecutor(
                 1,
                 1,
@@ -90,6 +97,13 @@ internal class AppleMusicCustomLyricsTarget(
             ),
             logger = ModernXposedRuntime::log,
         )
+        readyReapply = CustomLyricsReadyReapply(
+            installMethod = installMethod,
+            seam = seam,
+            readyReplacementFor = session::readyReplacementFor,
+            isFragmentUsable = fragmentIsAddedPredicate(installMethod.declaringClass),
+            logger = ModernXposedRuntime::log,
+        )
         val hooked = runCatching {
             ModernXposedRuntime.hookMethod(installMethod, object : ModernMethodHook() {
                 override fun beforeHookedMethod(param: MethodHookParam) {
@@ -98,7 +112,13 @@ internal class AppleMusicCustomLyricsTarget(
                         val original = param.args[0]
                         val adamId = seam.currentItemAdamIdOf(param.thisObject)
                         adamId ?: return@runCatching
-                        session.replacementFor(adamId)?.let { replacement ->
+                        val replacement = session.replacementFor(adamId)
+                        if (replacement == null) {
+                            if (shouldRecordReadyLateMiss(original, replacement)) {
+                                param.thisObject?.let { readyReapply.recordMiss(it, adamId) }
+                            }
+                        } else {
+                            param.thisObject?.let { readyReapply.dismiss(it) }
                             if (replacement !== original) {
                                 param.args[0] = replacement
                             }
@@ -165,9 +185,10 @@ internal class AppleMusicCustomLyricsTarget(
 }
 
 /**
- * Apple emits a null SongInfoPtr when a playback item has no native lyrics.
- * That null still travels through PlayerLyricsViewFragment.I2 and is the
- * capture point needed to refresh the fragment once a manual pointer is ready.
+ * Apple emits a null SongInfoPtr when a playback item has no native lyrics,
+ * and a live SongInfoPtr otherwise. Only a live original pointer whose custom
+ * replacement is not ready yet is recorded by the ready-late reapply ledger;
+ * a null original is never retried.
  */
 internal fun acceptsLyricsInstallArguments(args: Array<Any?>, ptrClass: Class<*>): Boolean =
     args.isNotEmpty() && (args[0] == null || ptrClass.isInstance(args[0]))

--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
@@ -4,11 +4,14 @@ import android.app.Activity
 import android.content.Context
 import android.content.res.Configuration
 import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
+import android.util.DisplayMetrics
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver
+import android.view.WindowManager
 import android.widget.FrameLayout
 import dev.amenhancer.module.hook.ModernMethodHook as XC_MethodHook
 import dev.amenhancer.module.ModuleConstants
@@ -829,6 +832,9 @@ internal object TabletModeQualifier {
 }
 
 internal object FlatLandscapeWindowPolicy {
+    private const val MIN_ULTRAWIDE_RATIO_NUMERATOR = 17L
+    private const val MIN_ULTRAWIDE_RATIO_DENOMINATOR = 10L
+
     fun shouldReserveNavigationSpace(context: Context): Boolean {
         val configuration = context.resources.configuration
         val width = configuration.screenWidthDp
@@ -837,6 +843,53 @@ internal object FlatLandscapeWindowPolicy {
             configuration.orientation == Configuration.ORIENTATION_LANDSCAPE &&
             height > 0 &&
             width.toFloat() / height.toFloat() >= 1.7f
+    }
+
+    /**
+     * Boundary sync is needed for genuinely wide displays even when a system
+     * rail makes the activity's effective window look narrower than 1.7.
+     * Keep this separate from [shouldReserveNavigationSpace]: the latter is
+     * the eager initial-margin policy and must retain its window semantics.
+     */
+    fun shouldInstallBoundarySync(context: Context): Boolean {
+        if (!TabletModeQualifier.isOfficialTabletLandscape(context)) return false
+        val configuration = context.resources.configuration
+        val metrics = realDisplayMetrics(context)
+        return shouldInstallBoundarySync(
+            windowWidthDp = configuration.screenWidthDp,
+            windowHeightDp = configuration.screenHeightDp,
+            physicalWidthPx = metrics?.widthPixels ?: 0,
+            physicalHeightPx = metrics?.heightPixels ?: 0,
+        )
+    }
+
+    internal fun shouldInstallBoundarySync(
+        windowWidthDp: Int,
+        windowHeightDp: Int,
+        physicalWidthPx: Int,
+        physicalHeightPx: Int,
+    ): Boolean = isUltraWideRatio(windowWidthDp, windowHeightDp) ||
+        isUltraWideRatio(physicalWidthPx, physicalHeightPx)
+
+    private fun isUltraWideRatio(width: Int, height: Int): Boolean {
+        if (width <= 0 || height <= 0) return false
+        val longSide = maxOf(width, height).toLong()
+        val shortSide = minOf(width, height).toLong()
+        return longSide * MIN_ULTRAWIDE_RATIO_DENOMINATOR >=
+            shortSide * MIN_ULTRAWIDE_RATIO_NUMERATOR
+    }
+
+    @Suppress("DEPRECATION")
+    private fun realDisplayMetrics(context: Context): DisplayMetrics? {
+        val display = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            context.display
+        } else {
+            @Suppress("DEPRECATION")
+            (context.getSystemService(Context.WINDOW_SERVICE) as? WindowManager)?.defaultDisplay
+        } ?: return null
+        return runCatching {
+            DisplayMetrics().also { metrics -> display.getRealMetrics(metrics) }
+        }.getOrNull()
     }
 }
 
@@ -1175,6 +1228,7 @@ private object ConstraintLayoutPane {
         tabsFrame: View,
         tabsHeight: Int,
     ) {
+        if (!FlatLandscapeWindowPolicy.shouldInstallBoundarySync(root.context)) return
         val sheetId = targetId(root.resources, PLAYER_SHEET_CONTAINER)
         val sheet = sheetId.takeIf { it != 0 }?.let { root.findViewById<View>(it) } ?: return
         var reserveNavigationSpace =

--- a/app/src/main/java/dev/amenhancer/module/hook/CustomLyricsReadyReapply.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/CustomLyricsReadyReapply.kt
@@ -1,0 +1,158 @@
+package dev.amenhancer.module.hook
+
+import java.lang.ref.WeakReference
+import java.lang.reflect.Method
+
+/**
+ * Ready-late I2 re-entry ledger. When PlayerLyricsViewFragment.I2 installs a
+ * valid native pointer whose custom replacement is still preparing, the I2
+ * hook records the exact fragment instance and Apple Music ID here. Once the
+ * background session publishes the replacement pointer and this ledger is
+ * invoked, every still-live waiting entry for that ID is consumed and I2 is
+ * re-entered with the ready replacement — but only while the same fragment
+ * is still usable, still reports the same Apple Music ID, and the
+ * replacement is still ready.
+ *
+ * The ledger is keyed by fragment identity, never equals, so a replacement
+ * fragment with equal state can never be confused with the recorded one.
+ * Keys hold fragments weakly and cleared entries are swept on every access,
+ * so a dead fragment cannot keep an entry alive forever and the ledger can
+ * never grow without limit. Every entry is consumed exactly once before
+ * re-entry, so duplicate publish callbacks cannot loop. [recordMiss],
+ * [dismiss] and [onReplacementPublished] are safe to call from any thread;
+ * every gate and the re-entry itself fail open, leaving the native pointer
+ * installed.
+ */
+internal class CustomLyricsReadyReapply(
+    private val installMethod: Method,
+    private val seam: CurrentItemIdentitySeam,
+    private val readyReplacementFor: (Long) -> Any?,
+    private val isFragmentUsable: (Any) -> Boolean,
+    private val logger: (String) -> Unit,
+) {
+    /**
+     * Strongly holds only the weak key wrappers, never the fragment referents.
+     * Matching is explicit `===` identity rather than equals/hashCode.
+     */
+    private val pending = mutableListOf<PendingMiss>()
+
+    /**
+     * I2 hot path: remembers a fragment that just installed a valid native
+     * pointer while its replacement was still preparing. Pure in-memory map
+     * write — no IO, no native parse. A newer I2 entry for the same fragment
+     * supersedes the older one.
+     */
+    fun recordMiss(fragment: Any, appleMusicId: Long) {
+        synchronized(pending) {
+            sweepCleared()
+            pending.firstOrNull { it.key.get() === fragment }?.let { existing ->
+                existing.appleMusicId = appleMusicId
+                return@synchronized
+            }
+            if (pending.size >= MAX_PENDING) pending.removeAt(0)
+            pending += PendingMiss(FragmentKey(fragment), appleMusicId)
+        }
+    }
+
+    /**
+     * Drops the pending ready-late entry for a fragment whose I2 call already
+     * received its ready replacement, so a posted publish callback cannot
+     * double-install the same pointer.
+     */
+    fun dismiss(fragment: Any) {
+        synchronized(pending) {
+            sweepCleared()
+            pending.removeAll { it.key.get() === fragment }
+        }
+    }
+
+    /**
+     * Publish callback. Consumes every waiting fragment for the id before any
+     * re-entry, so failures or duplicate publishes cannot loop, then
+     * re-enters I2 for each fragment that still passes every gate; otherwise
+     * the fragment is dropped and the native pointer stays.
+     */
+    fun onReplacementPublished(appleMusicId: Long) {
+        if (appleMusicId <= 0L) return
+        val waiting = synchronized(pending) {
+            sweepCleared()
+            val matches = mutableListOf<Any>()
+            val iterator = pending.iterator()
+            while (iterator.hasNext()) {
+                val entry = iterator.next()
+                if (entry.appleMusicId == appleMusicId) {
+                    entry.key.get()?.let(matches::add)
+                    iterator.remove()
+                }
+            }
+            matches
+        }
+        for (fragment in waiting) {
+            try {
+                if (!isFragmentUsable(fragment)) continue
+                if (seam.currentItemAdamIdOf(fragment) != appleMusicId) continue
+                val replacement = readyReplacementFor(appleMusicId) ?: continue
+                installMethod.invoke(fragment, replacement)
+            } catch (error: Throwable) {
+                logger("custom lyrics ready-late re-entry failed: $error")
+            }
+        }
+    }
+
+    /** Removes entries whose fragment has been collected. Must hold [pending]. */
+    private fun sweepCleared() {
+        val iterator = pending.iterator()
+        while (iterator.hasNext()) {
+            if (iterator.next().key.get() == null) {
+                iterator.remove()
+            }
+        }
+    }
+
+    private data class PendingMiss(
+        val key: FragmentKey,
+        var appleMusicId: Long,
+    )
+
+    /**
+     * The list owns this wrapper, while the wrapper owns only a weak reference
+     * to the Fragment. This avoids the weak-key-of-a-weak-key problem that
+     * would let a WeakHashMap discard the wrapper before the Fragment itself.
+     */
+    private class FragmentKey(referent: Any) : WeakReference<Any>(referent)
+
+    private companion object {
+        const val MAX_PENDING = 64
+    }
+}
+
+/**
+ * A ready-late candidate is recorded only for a valid original/native lyrics
+ * pointer whose custom replacement is not ready yet; a null original (no
+ * native lyrics) is never retried.
+ */
+internal fun shouldRecordReadyLateMiss(original: Any?, replacement: Any?): Boolean =
+    original != null && replacement == null
+
+/**
+ * Fragment usability predicate for ready-late re-entry, backed by the
+ * platform's public `isAdded()` when the I2 fragment hierarchy exposes it.
+ * The fragment is treated as usable when the platform method is unavailable,
+ * so a missing lifecycle surface fails open instead of blocking re-entry.
+ */
+internal fun fragmentIsAddedPredicate(fragmentClass: Class<*>): (Any) -> Boolean {
+    val isAdded = runCatching {
+        fragmentClass.getMethod("isAdded")
+            .takeIf { method ->
+                method.parameterCount == 0 && method.returnType == java.lang.Boolean.TYPE
+            }
+            ?.apply { isAccessible = true }
+    }.getOrNull()
+    return { fragment ->
+        if (isAdded == null) {
+            true
+        } else {
+            runCatching { isAdded.invoke(fragment) as? Boolean }.getOrNull() ?: true
+        }
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/hook/CustomLyricsReplacementSession.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/CustomLyricsReplacementSession.kt
@@ -26,6 +26,10 @@ internal fun interface CustomLyricsIndexProvider {
  * native parsing are prepared per requested Apple Music ID on a single
  * background thread, deduplicated by ID. A miss for an unknown ID triggers
  * one background index refresh to discover mappings published after startup.
+ *
+ * Every successful prepare publishes its Apple Music ID through
+ * [onReplacementPublished] on the preparing thread; callers hop to the main
+ * thread when a UI re-entry is needed.
  */
 internal class CustomLyricsReplacementSession(
     private val index: CustomLyricsIndexProvider,
@@ -35,6 +39,7 @@ internal class CustomLyricsReplacementSession(
     private val verifyPtr: (Any?) -> Boolean,
     private val readAdamId: (Any) -> Long?,
     private val bindAdamId: (Any, Long) -> Boolean,
+    private val onReplacementPublished: ((Long) -> Unit)? = null,
     private val executor: Executor,
     private val logger: (String) -> Unit,
 ) {
@@ -102,7 +107,8 @@ internal class CustomLyricsReplacementSession(
      * prepare, an unknown ID queues a single index refresh so mappings
      * published after startup can be discovered. An unknown ID arriving
      * while a refresh is already queued is still registered so the in-flight
-     * refresh can resolve it.
+     * refresh can resolve it; a rejected refresh drops the unknown pending
+     * IDs so the same IDs can retry from a later request.
      */
     private fun request(appleMusicId: Long, refreshOnUnknown: Boolean) {
         synchronized(lock) {
@@ -137,7 +143,10 @@ internal class CustomLyricsReplacementSession(
         try {
             executor.execute { refreshIndex() }
         } catch (_: RejectedExecutionException) {
-            synchronized(lock) { refreshQueued = false }
+            synchronized(lock) {
+                refreshQueued = false
+                pendingPrepares.retainAll { it in entriesById }
+            }
             logger("custom lyrics index refresh was rejected")
         }
     }
@@ -192,6 +201,7 @@ internal class CustomLyricsReplacementSession(
             synchronized(cache) {
                 cache[key] = replacement
             }
+            onReplacementPublished?.invoke(appleMusicId)
         } finally {
             synchronized(lock) {
                 pendingPrepares.remove(appleMusicId)

--- a/app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt
+++ b/app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt
@@ -257,11 +257,7 @@ class SettingsActivity : Activity() {
 
     private fun render(snapshot: XposedServiceSnapshot = ModuleApplication.serviceSnapshot) {
         content.removeAllViews()
-        val settings = if (currentPage == SettingsPage.CUSTOM_LYRICS) {
-            store.settingsWithCustomLyrics(snapshot)
-        } else {
-            store.settings(snapshot)
-        }
+        val settings = store.settingsWithCustomLyrics(snapshot)
         updateTopBar()
         when (currentPage) {
             SettingsPage.MAIN -> renderMainPage(settings, snapshot)

--- a/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsReadyLateStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsReadyLateStructuralRegressionTest.kt
@@ -1,0 +1,72 @@
+package dev.amenhancer.module.hook
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CustomLyricsReadyLateStructuralRegressionTest {
+    private fun projectFile(relativePath: String): String = sequenceOf(
+        File(relativePath),
+        File("../$relativePath"),
+    ).firstOrNull(File::isFile)?.readText()
+        ?: error("$relativePath was not found from the unit-test working directory")
+
+    @Test
+    fun `i2 records a ready late miss without io or native parse on the hook path`() {
+        val target = projectFile(
+            "app/src/main/java/dev/amenhancer/module/hook/AppleMusicCustomLyricsTarget.kt",
+        )
+        val hookBody = target.substringAfter(
+            "override fun beforeHookedMethod(param: MethodHookParam)",
+        ).substringBefore("override fun afterHookedMethod(param: MethodHookParam)")
+
+        assertTrue(hookBody.contains("shouldRecordReadyLateMiss(original, replacement)"))
+        assertTrue(hookBody.contains("readyReapply.recordMiss(it, adamId)"))
+        assertTrue(hookBody.contains("readyReapply.dismiss(it)"))
+        assertFalse(hookBody.contains("openRemoteFile"))
+        assertFalse(hookBody.contains("readTtml"))
+        assertFalse(hookBody.contains("parseTtml"))
+    }
+
+    @Test
+    fun `ready late callbacks hop to the main thread before re-entering i2`() {
+        val target = projectFile(
+            "app/src/main/java/dev/amenhancer/module/hook/AppleMusicCustomLyricsTarget.kt",
+        )
+
+        assertTrue(target.contains("Handler(Looper.getMainLooper())"))
+        assertTrue(target.contains("readyReapply.onReplacementPublished(appleMusicId)"))
+        assertTrue(target.contains("CustomLyricsReadyReapply("))
+    }
+
+    @Test
+    fun `reapply ledger is weakly identity keyed, consumes before re-entry, and can be dismissed`() {
+        val reapply = projectFile(
+            "app/src/main/java/dev/amenhancer/module/hook/CustomLyricsReadyReapply.kt",
+        )
+
+        assertTrue(reapply.contains("mutableListOf<PendingMiss>()"))
+        assertTrue(reapply.contains("WeakReference<Any>"))
+        assertTrue(reapply.contains("synchronized(pending)"))
+        assertTrue(reapply.contains("iterator.remove()"))
+        assertTrue(reapply.contains("installMethod.invoke(fragment, replacement)"))
+        assertTrue(reapply.contains("seam.currentItemAdamIdOf(fragment) != appleMusicId"))
+        assertTrue(reapply.contains("fun dismiss(fragment: Any)"))
+        assertTrue(reapply.contains("shouldRecordReadyLateMiss"))
+        assertFalse(reapply.contains("IdentityHashMap<Any, Long>"))
+    }
+
+    @Test
+    fun `session publishes the callback only after the cache write`() {
+        val session = projectFile(
+            "app/src/main/java/dev/amenhancer/module/hook/CustomLyricsReplacementSession.kt",
+        )
+
+        assertTrue(session.contains("onReplacementPublished"))
+        assertTrue(
+            session.indexOf("cache[key] = replacement") <
+                session.indexOf("onReplacementPublished?.invoke(appleMusicId)"),
+        )
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsReadyReapplyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsReadyReapplyTest.kt
@@ -1,0 +1,374 @@
+package dev.amenhancer.module.hook
+
+import java.lang.ref.WeakReference
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CustomLyricsReadyReapplyTest {
+
+    @Test
+    fun `first i2 miss then ready late publish re-enters i2 with the replacement`() {
+        val fragment = LyricsFragment(LyricsItem("42"))
+        val pointer = Any()
+        val (reapply, _) = reapply(fragment, ready = { pointer })
+
+        reapply.recordMiss(fragment, 42L)
+        assertNull(fragment.installed)
+
+        reapply.onReplacementPublished(42L)
+
+        assertSame(pointer, fragment.installed)
+        assertEquals(1, fragment.installs)
+    }
+
+    @Test
+    fun `ready late applies only to the exact recorded apple music id`() {
+        val fragment = LyricsFragment(LyricsItem("42"))
+        val pointer = Any()
+        val (reapply, _) = reapply(fragment, ready = { pointer })
+
+        reapply.recordMiss(fragment, 42L)
+        reapply.onReplacementPublished(77L)
+
+        assertNull(fragment.installed)
+        assertEquals(0, fragment.installs)
+
+        reapply.onReplacementPublished(42L)
+        assertSame(pointer, fragment.installed)
+        assertEquals(1, fragment.installs)
+    }
+
+    @Test
+    fun `ledger is identity based and never matches a distinct fragment with equal state`() {
+        val first = LyricsFragment(LyricsItem("42"))
+        val second = LyricsFragment(LyricsItem("42"))
+        val pointer = Any()
+        val (reapply, _) = reapply(first, ready = { pointer })
+
+        reapply.recordMiss(first, 42L)
+        reapply.onReplacementPublished(42L)
+
+        assertSame(pointer, first.installed)
+        assertNull(second.installed)
+    }
+
+    @Test
+    fun `a changed song on the same fragment skips the stale re-entry`() {
+        val fragment = LyricsFragment(LyricsItem("42"))
+        val pointer = Any()
+        val (reapply, _) = reapply(fragment, ready = { pointer })
+
+        reapply.recordMiss(fragment, 42L)
+        fragment.c = LyricsItem("67890")
+        reapply.onReplacementPublished(42L)
+
+        assertNull(fragment.installed)
+        assertEquals(0, fragment.installs)
+    }
+
+    @Test
+    fun `a detached fragment skips re-entry`() {
+        val fragment = LyricsFragment(LyricsItem("42"))
+        val pointer = Any()
+        val (reapply, _) = reapply(fragment, ready = { pointer }, usable = { false })
+
+        reapply.recordMiss(fragment, 42L)
+        reapply.onReplacementPublished(42L)
+
+        assertNull(fragment.installed)
+        assertEquals(0, fragment.installs)
+    }
+
+    @Test
+    fun `a replacement that is no longer ready skips re-entry`() {
+        val fragment = LyricsFragment(LyricsItem("42"))
+        var ready: Any? = null
+        val (reapply, _) = reapply(fragment, ready = { ready })
+
+        reapply.recordMiss(fragment, 42L)
+        reapply.onReplacementPublished(42L)
+
+        assertNull(fragment.installed)
+        assertEquals(0, fragment.installs)
+    }
+
+    @Test
+    fun `duplicate publish callbacks re-enter exactly once`() {
+        val fragment = LyricsFragment(LyricsItem("42"))
+        val pointer = Any()
+        val (reapply, _) = reapply(fragment, ready = { pointer })
+
+        reapply.recordMiss(fragment, 42L)
+        reapply.onReplacementPublished(42L)
+        reapply.onReplacementPublished(42L)
+
+        assertEquals(1, fragment.installs)
+        assertSame(pointer, fragment.installed)
+
+        reapply.recordMiss(fragment, 42L)
+        reapply.onReplacementPublished(42L)
+        assertEquals(2, fragment.installs)
+    }
+
+    @Test
+    fun `a newer miss on the same fragment supersedes the older pending id`() {
+        val fragment = LyricsFragment(LyricsItem("77"))
+        val pointer = Any()
+        val (reapply, _) = reapply(fragment, ready = { pointer })
+
+        reapply.recordMiss(fragment, 42L)
+        reapply.recordMiss(fragment, 77L)
+        reapply.onReplacementPublished(42L)
+
+        assertNull(fragment.installed)
+
+        reapply.onReplacementPublished(77L)
+        assertSame(pointer, fragment.installed)
+        assertEquals(1, fragment.installs)
+    }
+
+    @Test
+    fun `a publish for an id without a waiting fragment is ignored`() {
+        val fragment = LyricsFragment(LyricsItem("42"))
+        val (reapply, _) = reapply(fragment, ready = { Any() })
+
+        reapply.onReplacementPublished(42L)
+
+        assertEquals(0, fragment.installs)
+    }
+
+    @Test
+    fun `re-entry failure fails open and is logged once`() {
+        val fragment = ThrowingLyricsFragment(LyricsItem("42"))
+        val (reapply, logs) = reapply(fragment, ready = { Any() })
+
+        reapply.recordMiss(fragment, 42L)
+        reapply.onReplacementPublished(42L)
+        reapply.onReplacementPublished(42L)
+
+        assertEquals(1, fragment.attempts)
+        assertEquals(1, logs.size)
+        assertTrue(logs.single().contains("ready-late re-entry failed"))
+    }
+
+    @Test
+    fun `a ready late miss is recorded only for a valid original without a replacement`() {
+        val original = Any()
+        val replacement = Any()
+
+        assertTrue(shouldRecordReadyLateMiss(original, null))
+        assertFalse(shouldRecordReadyLateMiss(null, null))
+        assertFalse(shouldRecordReadyLateMiss(original, replacement))
+        assertFalse(shouldRecordReadyLateMiss(null, replacement))
+    }
+
+    @Test
+    fun `is added predicate fails open when the fragment exposes no platform lifecycle method`() {
+        val fragment = LyricsFragment(LyricsItem("42"))
+        assertTrue(fragmentIsAddedPredicate(fragment.javaClass)(fragment))
+    }
+
+    @Test
+    fun `is added predicate reflects a platform isAdded method when present`() {
+        val fragment = AddedLyricsFragment(LyricsItem("42"))
+        val predicate = fragmentIsAddedPredicate(fragment.javaClass)
+
+        assertTrue(predicate(fragment))
+        fragment.added = false
+        assertFalse(predicate(fragment))
+    }
+
+    @Test
+    fun `one publish reapplies every still-live waiting fragment for the same id`() {
+        val first = LyricsFragment(LyricsItem("42"))
+        val second = LyricsFragment(LyricsItem("42"))
+        val other = LyricsFragment(LyricsItem("77"))
+        val pointer = Any()
+        val (reapply, _) = reapply(first, ready = { pointer })
+
+        reapply.recordMiss(first, 42L)
+        reapply.recordMiss(second, 42L)
+        reapply.recordMiss(other, 77L)
+        reapply.onReplacementPublished(42L)
+
+        assertSame(pointer, first.installed)
+        assertEquals(1, first.installs)
+        assertSame(pointer, second.installed)
+        assertEquals(1, second.installs)
+        assertNull(other.installed)
+        assertEquals(0, other.installs)
+
+        reapply.onReplacementPublished(42L)
+        reapply.onReplacementPublished(77L)
+
+        assertEquals(1, first.installs)
+        assertEquals(1, second.installs)
+        assertSame(pointer, other.installed)
+        assertEquals(1, other.installs)
+    }
+
+    @Test
+    fun `a failing re-entry is consumed once without blocking other waiting fragments`() {
+        val failing = LyricsFragment(LyricsItem("42"), failOnInstall = true)
+        val healthy = LyricsFragment(LyricsItem("42"))
+        val pointer = Any()
+        val (reapply, logs) = reapply(healthy, ready = { pointer })
+
+        reapply.recordMiss(failing, 42L)
+        reapply.recordMiss(healthy, 42L)
+        reapply.onReplacementPublished(42L)
+        reapply.onReplacementPublished(42L)
+
+        assertEquals(1, failing.attempts)
+        assertEquals(1, healthy.installs)
+        assertSame(pointer, healthy.installed)
+        assertEquals(1, logs.size)
+        assertTrue(logs.single().contains("ready-late re-entry failed"))
+    }
+
+    @Test
+    fun `dismiss drops a pending entry so a ready late publish cannot double install`() {
+        val fragment = LyricsFragment(LyricsItem("42"))
+        val pointer = Any()
+        val (reapply, _) = reapply(fragment, ready = { pointer })
+
+        reapply.recordMiss(fragment, 42L)
+        reapply.dismiss(fragment)
+        reapply.onReplacementPublished(42L)
+
+        assertEquals(0, fragment.installs)
+        assertNull(fragment.installed)
+    }
+
+    @Test
+    fun `cleared fragment entries are never re-applied and do not accumulate`() {
+        val fragment = LyricsFragment(LyricsItem("42"))
+        val live = LyricsFragment(LyricsItem("42"))
+        val pointer = Any()
+        val (reapply, _) = reapply(live, ready = { pointer })
+        val pending = pendingLedger(reapply)
+
+        reapply.recordMiss(fragment, 42L)
+        reapply.recordMiss(live, 42L)
+        assertEquals(2, pending.size)
+
+        pending.forEach { entry ->
+            val pendingEntry = requireNotNull(entry)
+            val key = pendingEntry.javaClass.getDeclaredField("key")
+                .apply { isAccessible = true }
+                .get(pendingEntry) as WeakReference<*>
+            key.clear()
+        }
+        reapply.onReplacementPublished(42L)
+
+        assertEquals(0, fragment.installs)
+        assertEquals(0, live.installs)
+        assertEquals(0, pending.size)
+
+        reapply.recordMiss(live, 42L)
+        reapply.onReplacementPublished(42L)
+        assertSame(pointer, live.installed)
+        assertEquals(0, pending.size)
+    }
+
+    private fun reapply(
+        fragment: Any,
+        ready: (Long) -> Any? = { null },
+        usable: (Any) -> Boolean = { true },
+    ): Pair<CustomLyricsReadyReapply, MutableList<String>> {
+        val logs = mutableListOf<String>()
+        val fragmentClass = fragment.javaClass
+        val installMethod = fragmentClass.getDeclaredMethod("I2", Any::class.java)
+        val seam = CurrentItemIdentitySeam(
+            ReadyLateResolver(
+                field = fragmentClass.getDeclaredField("c"),
+                installMethod = installMethod,
+            ),
+        )
+        seam.resolve(installMethod)
+        return CustomLyricsReadyReapply(
+            installMethod = installMethod,
+            seam = seam,
+            readyReplacementFor = ready,
+            isFragmentUsable = usable,
+            logger = { logs += it },
+        ) to logs
+    }
+
+    private fun pendingLedger(reapply: CustomLyricsReadyReapply): MutableList<*> {
+        val field = CustomLyricsReadyReapply::class.java.getDeclaredField("pending")
+        field.isAccessible = true
+        return field.get(reapply) as MutableList<*>
+    }
+
+    private class ReadyLateResolver(
+        private val field: Field,
+        private val installMethod: Method,
+    ) : TargetSymbolResolver {
+        override fun <T : Any> resolve(symbol: TargetSymbolKey<T>): TargetResolution<T> {
+            @Suppress("UNCHECKED_CAST")
+            return when (symbol.id) {
+                AppleMusicSymbols.LyricsCurrentItemField.id ->
+                    TargetResolution.Found(symbol.id, field, SymbolMatch.VERSION_PROFILE, "test")
+                AppleMusicSymbols.LyricsInstallMethod.id ->
+                    TargetResolution.Found(
+                        symbol.id,
+                        installMethod,
+                        SymbolMatch.VERSION_PROFILE,
+                        "test",
+                    )
+                else -> TargetResolution.Missing(symbol.id, "test")
+            } as TargetResolution<T>
+        }
+    }
+
+    private class LyricsItem(private val id: String) {
+        fun getId(): String = id
+    }
+
+    private class LyricsFragment(item: LyricsItem?, private val failOnInstall: Boolean = false) {
+        @JvmField
+        var c: LyricsItem? = item
+        var installed: Any? = null
+        var installs: Int = 0
+        var attempts: Int = 0
+
+        @Suppress("UNUSED_PARAMETER")
+        fun I2(ptr: Any) {
+            attempts += 1
+            if (failOnInstall) throw IllegalStateException("I2 exploded")
+            installed = ptr
+            installs += 1
+        }
+    }
+
+    private class AddedLyricsFragment(item: LyricsItem?) {
+        @JvmField
+        var c: LyricsItem? = item
+        var added: Boolean = true
+
+        @Suppress("UNUSED_PARAMETER")
+        fun isAdded(): Boolean = added
+
+        @Suppress("UNUSED_PARAMETER")
+        fun I2(ptr: Any) = Unit
+    }
+
+    private class ThrowingLyricsFragment(item: LyricsItem?) {
+        @JvmField
+        var c: LyricsItem? = item
+        var attempts: Int = 0
+
+        @Suppress("UNUSED_PARAMETER")
+        fun I2(ptr: Any) {
+            attempts += 1
+            throw IllegalStateException("I2 exploded")
+        }
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsReplacementSessionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsReplacementSessionTest.kt
@@ -4,11 +4,13 @@ import dev.amenhancer.module.model.CustomLyricsEntry
 import dev.amenhancer.module.model.CustomLyricsManifest
 import dev.amenhancer.module.model.CustomLyricsSources
 import java.util.concurrent.Executor
+import java.util.concurrent.RejectedExecutionException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class CustomLyricsReplacementSessionTest {
@@ -445,6 +447,116 @@ class CustomLyricsReplacementSessionTest {
         assertNotSame(first, second)
         assertEquals(listOf("lyrics_v1", "lyrics_v2"), readFiles)
         assertEquals(2, parses)
+    }
+
+    @Test
+    fun `publish callback fires only for a successfully prepared replacement`() {
+        val queued = QueuedExecutor()
+        val published = mutableListOf<Long>()
+        var parses = 0
+        val pointer = Pointer(42L)
+        val session = CustomLyricsReplacementSession(
+            index = CustomLyricsIndexProvider {
+                manifest(entry(42L)).entries.associateBy(CustomLyricsEntry::appleMusicId)
+            },
+            readTtml = { TTML },
+            parseTtml = { parses += 1; pointer },
+            isAlive = { it is Pointer },
+            verifyPtr = { it is Pointer },
+            readAdamId = { (it as Pointer).adamId },
+            bindAdamId = { value, id -> (value as Pointer).adamId = id; true },
+            onReplacementPublished = { published += it },
+            executor = queued,
+            logger = {},
+        )
+
+        session.start()
+        queued.runAll()
+        assertTrue(published.isEmpty())
+
+        assertNull(session.replacementFor(42L))
+        queued.runAll()
+        assertEquals(listOf(42L), published)
+
+        assertSame(pointer, session.replacementFor(42L))
+        queued.runAll()
+        assertEquals(listOf(42L), published)
+        assertEquals(1, parses)
+    }
+
+    @Test
+    fun `publish callback is silent for failed prepares and unknown ids`() {
+        val queued = QueuedExecutor()
+        val published = mutableListOf<Long>()
+        val session = CustomLyricsReplacementSession(
+            index = CustomLyricsIndexProvider {
+                manifest(entry(42L)).entries.associateBy(CustomLyricsEntry::appleMusicId)
+            },
+            readTtml = { null },
+            parseTtml = { Pointer(0L) },
+            isAlive = { it is Pointer },
+            verifyPtr = { it is Pointer },
+            readAdamId = { (it as Pointer).adamId },
+            bindAdamId = { value, id -> (value as Pointer).adamId = id; true },
+            onReplacementPublished = { published += it },
+            executor = queued,
+            logger = {},
+        )
+
+        session.start()
+        queued.runAll()
+        assertNull(session.replacementFor(42L))
+        queued.runAll()
+        assertTrue(published.isEmpty())
+
+        assertNull(session.replacementFor(41L))
+        queued.runAll()
+        assertTrue(published.isEmpty())
+    }
+
+    @Test
+    fun `a rejected index refresh drops the unknown pending id so it can retry later`() {
+        val queued = QueuedExecutor()
+        var manifestReads = 0
+        var parses = 0
+        var reject = true
+        val pointer = Pointer(42L)
+        var manifest = CustomLyricsManifest()
+        val session = CustomLyricsReplacementSession(
+            index = CustomLyricsIndexProvider {
+                manifestReads += 1
+                manifest.entries.associateBy(CustomLyricsEntry::appleMusicId)
+            },
+            readTtml = { TTML },
+            parseTtml = { parses += 1; pointer },
+            isAlive = { it is Pointer },
+            verifyPtr = { it is Pointer },
+            readAdamId = { (it as Pointer).adamId },
+            bindAdamId = { value, id -> (value as Pointer).adamId = id; true },
+            executor = Executor { command ->
+                if (reject) {
+                    throw RejectedExecutionException("index refresh rejected")
+                } else {
+                    queued.execute(command)
+                }
+            },
+            logger = {},
+        )
+
+        session.start()
+        assertEquals(0, manifestReads)
+
+        assertNull(session.replacementFor(42L))
+        assertEquals(0, manifestReads)
+
+        reject = false
+        manifest = manifest(entry(42L))
+        assertNull(session.replacementFor(42L))
+        queued.runAll()
+
+        assertSame(pointer, session.replacementFor(42L))
+        assertEquals(1, manifestReads)
+        assertEquals(1, parses)
     }
 
     private fun session(

--- a/app/src/test/java/dev/amenhancer/module/hook/DualPaneStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/DualPaneStructuralRegressionTest.kt
@@ -167,9 +167,11 @@ class DualPaneStructuralRegressionTest {
     }
 
     @Test
-    fun `detects flat player overlap beyond the eager window policy`() {
+    fun `limits flat player boundary sync to a wide effective or physical display`() {
         assertTrue(source.contains("installFlatPlayerBoundarySync(root, playerContainer, tabsFrame, tabsHeight)"))
-        assertFalse(source.contains("if (!FlatLandscapeWindowPolicy.shouldReserveNavigationSpace(root.context)) return"))
+        assertTrue(source.contains("if (!FlatLandscapeWindowPolicy.shouldInstallBoundarySync(root.context)) return"))
+        assertTrue(source.contains("display.getRealMetrics(metrics)"))
+        assertTrue(source.contains("physicalWidthPx = metrics?.widthPixels ?: 0"))
         assertTrue(source.contains("params.bottomMargin = if (FlatLandscapeWindowPolicy.shouldReserveNavigationSpace(context))"))
         assertTrue(source.contains("FlatPlayerBoundaryPolicy.decide"))
         assertTrue(source.contains("sheet.getLocationInWindow(sheetLocation)"))

--- a/app/src/test/java/dev/amenhancer/module/hook/FlatLandscapeWindowPolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/FlatLandscapeWindowPolicyTest.kt
@@ -1,0 +1,79 @@
+package dev.amenhancer.module.hook
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FlatLandscapeWindowPolicyTest {
+    @Test
+    fun `ordinary sixteen to ten tablet stays outside boundary sync`() {
+        assertFalse(
+            FlatLandscapeWindowPolicy.shouldInstallBoundarySync(
+                windowWidthDp = 1600,
+                windowHeightDp = 1000,
+                physicalWidthPx = 1600,
+                physicalHeightPx = 1000,
+            ),
+        )
+    }
+
+    @Test
+    fun `ordinary four to three tablet stays outside boundary sync`() {
+        assertFalse(
+            FlatLandscapeWindowPolicy.shouldInstallBoundarySync(
+                windowWidthDp = 1600,
+                windowHeightDp = 1200,
+                physicalWidthPx = 1600,
+                physicalHeightPx = 1200,
+            ),
+        )
+    }
+
+    @Test
+    fun `physical wide display keeps boundary sync when system rail narrows window`() {
+        assertTrue(
+            FlatLandscapeWindowPolicy.shouldInstallBoundarySync(
+                windowWidthDp = 1630,
+                windowHeightDp = 1000,
+                physicalWidthPx = 1700,
+                physicalHeightPx = 1000,
+            ),
+        )
+    }
+
+    @Test
+    fun `wide effective window keeps boundary sync without physical metrics`() {
+        assertTrue(
+            FlatLandscapeWindowPolicy.shouldInstallBoundarySync(
+                windowWidthDp = 1800,
+                windowHeightDp = 1000,
+                physicalWidthPx = 0,
+                physicalHeightPx = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun `rotated physical dimensions use the same aspect ratio`() {
+        assertTrue(
+            FlatLandscapeWindowPolicy.shouldInstallBoundarySync(
+                windowWidthDp = 1000,
+                windowHeightDp = 600,
+                physicalWidthPx = 1000,
+                physicalHeightPx = 1700,
+            ),
+        )
+    }
+
+    @Test
+    fun `unavailable physical metrics do not enable ordinary tablet sync`() {
+        assertFalse(
+            FlatLandscapeWindowPolicy.shouldInstallBoundarySync(
+                windowWidthDp = 0,
+                windowHeightDp = 0,
+                physicalWidthPx = 0,
+                physicalHeightPx = 0,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/ui/SettingsUiStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/ui/SettingsUiStructuralRegressionTest.kt
@@ -41,7 +41,7 @@ class SettingsUiStructuralRegressionTest {
         val activity = projectFile("app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt")
 
         assertTrue(activity.contains("statusCard(snapshot)"))
-        assertTrue(activity.contains("store.settings(snapshot)"))
+        assertTrue(activity.contains("store.settingsWithCustomLyrics(snapshot)"))
         assertTrue(activity.contains("featureCard(settings, writable)"))
         assertTrue(activity.contains("badge = \"WIP\""))
         assertTrue(activity.contains("LSPosed 配置提示"))
@@ -159,6 +159,17 @@ class SettingsUiStructuralRegressionTest {
             .substringBefore("private fun renderCustomLyricsPage(")
         assertFalse(mainPage.contains("customLyricsCard("))
         assertFalse(mainPage.contains("customLyricsEnabled = enabled"))
+    }
+
+    @Test
+    fun `main page count comes from the resolved v2 index, not the legacy manifest`() {
+        val activity = projectFile("app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt")
+
+        assertTrue(activity.contains("已配置 \${manifest.entries.size} 首歌词"))
+        val render = activity.substringAfter("private fun render(")
+            .substringBefore("private fun renderMainPage(")
+        assertTrue(render.contains("val settings = store.settingsWithCustomLyrics(snapshot)"))
+        assertFalse(render.contains("currentPage == SettingsPage.CUSTOM_LYRICS"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Reapply a custom lyric pointer after background TTML/native preparation completes, while preserving an IO-free I2 hot path.
- Gate re-entry by Fragment identity, current Apple Music ID, attachment, pointer readiness, and one-shot consumption; keep null/no-native and stale paths fail-open.
- Read the v2 resolved index for the settings-home count instead of the legacy 32-entry manifest.
- Retry rejected index refreshes and add regression coverage for ready-late, stale, duplicate, multi-fragment, lifecycle, and failure paths.

## Verification
- :app:testDebugUnitTest
- :app:assembleRelease
- :app:lintVitalRelease
- git diff --check
- Release 1.3.4/versionCode 91 installed on emulator-5554
