### PR TITLE
fix: restore current lyrics item binding

### DIFF
--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicCurrentSongIdentityTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicCurrentSongIdentityTarget.kt
@@ -10,6 +10,8 @@ import android.os.Bundle
 import android.os.ResultReceiver
 import dev.amenhancer.module.CurrentSongDetails
 import dev.amenhancer.module.CurrentSongIdentityProtocol
+import java.util.ArrayDeque
+import java.util.concurrent.CopyOnWriteArraySet
 import java.util.concurrent.atomic.AtomicReference
 
 internal data class TargetCurrentSong(
@@ -20,18 +22,50 @@ internal data class TargetCurrentSong(
 /** Shared target-process state from Apple's player-level metadata funnel. */
 internal class CurrentSongIdentityCache {
     private val current = AtomicReference<TargetCurrentSong?>(null)
+    private val listeners = CopyOnWriteArraySet<(TargetCurrentSong?) -> Unit>()
+    private val recentIds = ArrayDeque<Long>()
+    private val recentIdsLock = Any()
 
     fun publish(item: Any?, details: CurrentSongDetails?) {
-        current.set(
-            if (item != null && details != null && details.appleMusicId > 0L) {
-                TargetCurrentSong(item, details)
+        val published = if (item != null && details != null && details.appleMusicId > 0L) {
+            TargetCurrentSong(item, details)
+        } else {
+            null
+        }
+        current.set(published)
+        synchronized(recentIdsLock) {
+            if (published == null) {
+                recentIds.clear()
             } else {
-                null
-            },
-        )
+                recentIds.remove(published.details.appleMusicId)
+                recentIds.addLast(published.details.appleMusicId)
+                while (recentIds.size > MAX_RECENT_IDS) recentIds.removeFirst()
+            }
+        }
+        listeners.forEach { listener ->
+            runCatching { listener(published) }
+        }
+    }
+
+    fun addListener(listener: (TargetCurrentSong?) -> Unit) {
+        listeners += listener
+        current.get()?.let { published ->
+            runCatching { listener(published) }
+        }
     }
 
     fun current(): TargetCurrentSong? = current.get()
+
+    /** Allows a stale fragment ID only when it was recently observed as current. */
+    fun canRebind(fragmentAdamId: Long?, publishedAdamId: Long?): Boolean {
+        if (publishedAdamId == null || publishedAdamId <= 0L) return false
+        if (fragmentAdamId == null) return true
+        return synchronized(recentIdsLock) { fragmentAdamId in recentIds }
+    }
+
+    private companion object {
+        const val MAX_RECENT_IDS = 8
+    }
 }
 
 /** Responds only to the module's signature-protected, user-initiated requests. */

--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicCustomLyricsTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicCustomLyricsTarget.kt
@@ -15,6 +15,7 @@ import java.util.concurrent.TimeUnit
 internal class AppleMusicCustomLyricsTarget(
     private val config: TargetConfigClient,
     private val symbols: TargetSymbolResolver,
+    private val currentSong: CurrentSongIdentityCache,
 ) : CustomLyricsTarget {
     override fun install(): TargetCapabilityInstall {
         val installMethodResolution = symbols.resolve(AppleMusicSymbols.LyricsInstallMethod)
@@ -110,11 +111,33 @@ internal class AppleMusicCustomLyricsTarget(
                     runCatching {
                         if (!acceptsLyricsInstallArguments(param.args, ptrClass)) return@runCatching
                         val original = param.args[0]
-                        val adamId = seam.currentItemAdamIdOf(param.thisObject)
+                        val fragmentAdamId = seam.currentItemAdamIdOf(param.thisObject)
+                        val publishedCurrent = currentSong.current()
+                        val publishedAdamId = publishedCurrent?.details?.appleMusicId
+                        val adamId = selectLyricsInjectionAdamId(
+                            original = original,
+                            fragmentAdamId = fragmentAdamId,
+                            publishedAdamId = publishedAdamId,
+                        )
                         adamId ?: return@runCatching
                         val replacement = session.replacementFor(adamId)
+                        val tracking = session.isTracking(adamId)
+                        val needsRebind = original == null &&
+                            publishedCurrent != null &&
+                            publishedAdamId != null &&
+                            publishedAdamId != fragmentAdamId
+                        val canRebind = currentSong.canRebind(fragmentAdamId, publishedAdamId)
+                        if (
+                            needsRebind && tracking && canRebind &&
+                            (fragmentAdamId == null || session.isMapped(adamId))
+                        ) {
+                            val rebound = param.thisObject?.let { fragment ->
+                                seam.bindCurrentItemOf(fragment, publishedCurrent.item)
+                            } == true
+                            if (!rebound) return@runCatching
+                        }
                         if (replacement == null) {
-                            if (shouldRecordReadyLateMiss(original, replacement)) {
+                            if (shouldRecordReadyLateMiss(original, replacement) && tracking) {
                                 param.thisObject?.let { readyReapply.recordMiss(it, adamId) }
                             }
                         } else {
@@ -144,6 +167,7 @@ internal class AppleMusicCustomLyricsTarget(
                         val nativeLyricsAvailable = param.result as? Boolean ?: return@runCatching
                         if (nativeLyricsAvailable) return@runCatching
                         val appleMusicId = seam.detailsOfItem(param.args.getOrNull(0))?.appleMusicId
+                        appleMusicId?.let(session::ensureRequested)
                         val replacementReady = appleMusicId != null &&
                             session.replacementOrPrepareFor(appleMusicId) != null
                         if (
@@ -162,6 +186,9 @@ internal class AppleMusicCustomLyricsTarget(
             })
         }.isSuccess
         session.start()
+        currentSong.addListener { current ->
+            current?.details?.appleMusicId?.let(session::ensureRequested)
+        }
         if (!availabilityHooked) {
             return TargetCapabilityInstall.Degraded(
                 "Custom lyric I2 replacement installed, but unavailable-lyrics entry could not be enabled; " +
@@ -184,11 +211,26 @@ internal class AppleMusicCustomLyricsTarget(
 
 }
 
+internal fun selectLyricsInjectionAdamId(
+    original: Any?,
+    fragmentAdamId: Long?,
+    publishedAdamId: Long?,
+): Long? = if (
+    original == null &&
+    publishedAdamId != null &&
+    publishedAdamId > 0L &&
+    publishedAdamId != fragmentAdamId
+) {
+    publishedAdamId
+} else {
+    fragmentAdamId
+}
+
 /**
  * Apple emits a null SongInfoPtr when a playback item has no native lyrics,
- * and a live SongInfoPtr otherwise. Only a live original pointer whose custom
- * replacement is not ready yet is recorded by the ready-late reapply ledger;
- * a null original is never retried.
+ * and a live SongInfoPtr otherwise. Both forms can be recorded by the
+ * ready-late reapply ledger while their custom replacement is preparing; the
+ * ledger applies the same current-item and lifecycle gates to both.
  */
 internal fun acceptsLyricsInstallArguments(args: Array<Any?>, ptrClass: Class<*>): Boolean =
     args.isNotEmpty() && (args[0] == null || ptrClass.isInstance(args[0]))

--- a/app/src/main/java/dev/amenhancer/module/hook/CurrentItemIdentitySeam.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/CurrentItemIdentitySeam.kt
@@ -69,6 +69,16 @@ internal class CurrentItemIdentitySeam(
         }.getOrNull()
     }
 
+    /** Rebinds the verified lyrics fragment field to an exact player item. */
+    fun bindCurrentItemOf(fragment: Any?, item: Any?): Boolean {
+        if (fragment == null || item == null) return false
+        return runCatching {
+            if (!currentItemField.type.isInstance(item)) return@runCatching false
+            currentItemField.set(fragment, item)
+            currentItemField.get(fragment) === item
+        }.getOrDefault(false)
+    }
+
     /** Reads identity directly from a verified player item argument. */
     fun detailsOfItem(item: Any?): CurrentSongDetails? {
         if (item == null) return null

--- a/app/src/main/java/dev/amenhancer/module/hook/CustomLyricsReadyReapply.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/CustomLyricsReadyReapply.kt
@@ -37,10 +37,9 @@ internal class CustomLyricsReadyReapply(
     private val pending = mutableListOf<PendingMiss>()
 
     /**
-     * I2 hot path: remembers a fragment that just installed a valid native
-     * pointer while its replacement was still preparing. Pure in-memory map
-     * write — no IO, no native parse. A newer I2 entry for the same fragment
-     * supersedes the older one.
+     * I2 hot path: remembers a fragment whose replacement was still preparing.
+     * Pure in-memory map write — no IO, no native parse. A newer I2 entry for
+     * the same fragment supersedes the older one.
      */
     fun recordMiss(fragment: Any, appleMusicId: Long) {
         synchronized(pending) {
@@ -127,12 +126,13 @@ internal class CustomLyricsReadyReapply(
 }
 
 /**
- * A ready-late candidate is recorded only for a valid original/native lyrics
- * pointer whose custom replacement is not ready yet; a null original (no
- * native lyrics) is never retried.
+ * A ready-late candidate is recorded whenever the custom replacement is not
+ * ready yet. The original pointer may be null for a song without native
+ * lyrics; the ledger applies the same identity and lifecycle gates to both
+ * paths.
  */
 internal fun shouldRecordReadyLateMiss(original: Any?, replacement: Any?): Boolean =
-    original != null && replacement == null
+    replacement == null
 
 /**
  * Fragment usability predicate for ready-late re-entry, backed by the

--- a/app/src/main/java/dev/amenhancer/module/hook/CustomLyricsReplacementSession.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/CustomLyricsReplacementSession.kt
@@ -79,6 +79,22 @@ internal class CustomLyricsReplacementSession(
         return readyReplacementFor(appleMusicId)
     }
 
+    /** Queues the current-song prewarm without touching the ready-only result. */
+    fun ensureRequested(appleMusicId: Long) {
+        if (appleMusicId <= 0L) return
+        request(appleMusicId, refreshOnUnknown = true)
+    }
+
+    /** True while an ID is known or has an in-flight index/prepare request. */
+    fun isTracking(appleMusicId: Long): Boolean = synchronized(lock) {
+        appleMusicId > 0L && (appleMusicId in entriesById || appleMusicId in pendingPrepares)
+    }
+
+    /** True only after the current index has confirmed an enabled mapping. */
+    fun isMapped(appleMusicId: Long): Boolean = synchronized(lock) {
+        appleMusicId > 0L && appleMusicId in entriesById
+    }
+
     /** Ready cache only; safe for availability predicates and other hot paths. */
     fun readyReplacementFor(appleMusicId: Long): Any? {
         if (appleMusicId <= 0L) return null

--- a/app/src/main/java/dev/amenhancer/module/hook/TargetAdaptation.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/TargetAdaptation.kt
@@ -46,7 +46,7 @@ internal data class TargetAdaptation(
                     symbols = resolver,
                     session = lyricsTypefaceSession ?: LyricsTypefaceSession(),
                 ),
-                customLyrics = AppleMusicCustomLyricsTarget(config, resolver),
+                customLyrics = AppleMusicCustomLyricsTarget(config, resolver, currentSong),
                 currentSongIdentity = AppleMusicCurrentSongIdentityTarget(
                     application,
                     resolver,

--- a/app/src/test/java/dev/amenhancer/module/hook/CurrentSongIdentityStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CurrentSongIdentityStructuralRegressionTest.kt
@@ -43,6 +43,10 @@ class CurrentSongIdentityStructuralRegressionTest {
 
         assertTrue(target.contains("val seam = CurrentItemIdentitySeam(symbols)"))
         assertTrue(target.contains("seam.currentItemAdamIdOf(param.thisObject)"))
+        assertTrue(target.contains("selectLyricsInjectionAdamId("))
+        assertTrue(target.contains("seam.bindCurrentItemOf(fragment, publishedCurrent.item)"))
+        assertTrue(target.contains("currentSong.canRebind(fragmentAdamId, publishedAdamId)"))
+        assertTrue(target.contains("session.isMapped(adamId)"))
         assertFalse(target.contains("private fun currentItemAdamIdOf"))
         assertFalse(target.contains("private fun resolveGetIdMethod"))
     }
@@ -56,6 +60,7 @@ class CurrentSongIdentityStructuralRegressionTest {
         assertTrue(target.contains("AppleMusicSymbols.LyricsAvailabilityPredicate"))
         assertTrue(target.contains("override fun afterHookedMethod(param: MethodHookParam)"))
         assertTrue(target.contains("seam.detailsOfItem(param.args.getOrNull(0))"))
+        assertTrue(target.contains("appleMusicId?.let(session::ensureRequested)"))
         assertTrue(target.contains("session.replacementOrPrepareFor(appleMusicId)"))
         assertTrue(target.contains("shouldExposeCustomLyrics("))
         assertFalse(target.contains("LyricsResultField"))
@@ -76,7 +81,11 @@ class CurrentSongIdentityStructuralRegressionTest {
 
         assertTrue(adaptation.contains("val currentSong = CurrentSongIdentityCache()"))
         assertTrue(adaptation.contains("currentSongIdentity = AppleMusicCurrentSongIdentityTarget("))
-        assertTrue(adaptation.contains("customLyrics = AppleMusicCustomLyricsTarget(config, resolver)"))
+        assertTrue(
+            adaptation.contains(
+                "customLyrics = AppleMusicCustomLyricsTarget(config, resolver, currentSong)",
+            ),
+        )
         assertTrue(adaptation.contains("internal fun interface CurrentSongIdentityTarget"))
         assertTrue(installation.contains("FeatureInstallationPlan(feature = CurrentSongIdentityFeature())"))
         assertTrue(

--- a/app/src/test/java/dev/amenhancer/module/hook/CurrentSongIdentityTargetTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CurrentSongIdentityTargetTest.kt
@@ -36,6 +36,17 @@ class CurrentSongIdentityTargetTest {
     }
 
     @Test
+    fun `seam can rebind a stale lyrics fragment to the verified current item`() {
+        val seam = CurrentItemIdentitySeam(resolver(SongFragment::class.java))
+        assertNull(seam.resolve(SongFragment.installMethod()))
+        val fragment = SongFragment(SongItem("182861090"))
+
+        assertTrue(seam.bindCurrentItemOf(fragment, SongItem("7335408332109193189")))
+        assertEquals(7335408332109193189L, seam.currentItemAdamIdOf(fragment))
+        assertTrue(!seam.bindCurrentItemOf(fragment, Any()))
+    }
+
+    @Test
     fun `seam reads fail closed when the current item is unavailable`() {
         val seam = CurrentItemIdentitySeam(resolver(SongFragment::class.java))
         seam.resolve(SongFragment.installMethod())
@@ -101,6 +112,36 @@ class CurrentSongIdentityTargetTest {
         assertNull(cache.current())
         cache.publish(Any(), CurrentSongDetails(-7L))
         assertNull(cache.current())
+    }
+
+    @Test
+    fun `cache replays and publishes identity changes to listeners`() {
+        val cache = CurrentSongIdentityCache()
+        val first = Any()
+        val second = Any()
+        val events = mutableListOf<TargetCurrentSong?>()
+
+        cache.publish(first, CurrentSongDetails(12345L))
+        cache.addListener { events += it }
+        cache.publish(second, CurrentSongDetails(67890L))
+        cache.publish(null, null)
+
+        assertEquals(3, events.size)
+        assertTrue(events[0]?.item === first)
+        assertTrue(events[1]?.item === second)
+        assertNull(events[2])
+    }
+
+    @Test
+    fun `cache only permits rebinding from a recently published identity`() {
+        val cache = CurrentSongIdentityCache()
+
+        cache.publish(Any(), CurrentSongDetails(182861090L))
+        cache.publish(Any(), CurrentSongDetails(7335408332109193189L))
+
+        assertTrue(cache.canRebind(182861090L, 7335408332109193189L))
+        assertTrue(cache.canRebind(null, 7335408332109193189L))
+        assertTrue(!cache.canRebind(999L, 7335408332109193189L))
     }
 
     @Test

--- a/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsInjectionIdentityTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsInjectionIdentityTest.kt
@@ -1,0 +1,30 @@
+package dev.amenhancer.module.hook
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CustomLyricsInjectionIdentityTest {
+    @Test
+    fun `null native pointer uses the published player item when fragment identity is stale`() {
+        assertEquals(
+            7335408332109193189L,
+            selectLyricsInjectionAdamId(
+                original = null,
+                fragmentAdamId = 182861090L,
+                publishedAdamId = 7335408332109193189L,
+            ),
+        )
+    }
+
+    @Test
+    fun `non-null native pointer keeps the fragment identity`() {
+        assertEquals(
+            182861090L,
+            selectLyricsInjectionAdamId(
+                original = Any(),
+                fragmentAdamId = 182861090L,
+                publishedAdamId = 7335408332109193189L,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsReadyLateStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsReadyLateStructuralRegressionTest.kt
@@ -22,6 +22,7 @@ class CustomLyricsReadyLateStructuralRegressionTest {
         ).substringBefore("override fun afterHookedMethod(param: MethodHookParam)")
 
         assertTrue(hookBody.contains("shouldRecordReadyLateMiss(original, replacement)"))
+        assertTrue(hookBody.contains("session.isTracking(adamId)"))
         assertTrue(hookBody.contains("readyReapply.recordMiss(it, adamId)"))
         assertTrue(hookBody.contains("readyReapply.dismiss(it)"))
         assertFalse(hookBody.contains("openRemoteFile"))
@@ -38,6 +39,9 @@ class CustomLyricsReadyLateStructuralRegressionTest {
         assertTrue(target.contains("Handler(Looper.getMainLooper())"))
         assertTrue(target.contains("readyReapply.onReplacementPublished(appleMusicId)"))
         assertTrue(target.contains("CustomLyricsReadyReapply("))
+        assertTrue(target.contains("currentSong.addListener"))
+        assertTrue(target.contains("current?.details?.appleMusicId"))
+        assertTrue(target.contains("session::ensureRequested"))
     }
 
     @Test

--- a/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsReadyReapplyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsReadyReapplyTest.kt
@@ -158,12 +158,12 @@ class CustomLyricsReadyReapplyTest {
     }
 
     @Test
-    fun `a ready late miss is recorded only for a valid original without a replacement`() {
+    fun `a ready late miss is recorded for a null or valid original without a replacement`() {
         val original = Any()
         val replacement = Any()
 
         assertTrue(shouldRecordReadyLateMiss(original, null))
-        assertFalse(shouldRecordReadyLateMiss(null, null))
+        assertTrue(shouldRecordReadyLateMiss(null, null))
         assertFalse(shouldRecordReadyLateMiss(original, replacement))
         assertFalse(shouldRecordReadyLateMiss(null, replacement))
     }

--- a/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsReplacementSessionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsReplacementSessionTest.kt
@@ -6,6 +6,7 @@ import dev.amenhancer.module.model.CustomLyricsSources
 import java.util.concurrent.Executor
 import java.util.concurrent.RejectedExecutionException
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -217,6 +218,39 @@ class CustomLyricsReplacementSessionTest {
         assertNull(session.replacementFor(42L))
         queued.runAll()
         assertSame(pointer, session.replacementFor(42L))
+    }
+
+    @Test
+    fun `ensure requested prewarms an unknown mapping before availability check`() {
+        val queued = QueuedExecutor()
+        var manifest = CustomLyricsManifest()
+        val pointer = Pointer(42L)
+        val session = CustomLyricsReplacementSession(
+            index = CustomLyricsIndexProvider {
+                manifest.entries.associateBy(CustomLyricsEntry::appleMusicId)
+            },
+            readTtml = { TTML },
+            parseTtml = { pointer },
+            isAlive = { it is Pointer },
+            verifyPtr = { it is Pointer },
+            readAdamId = { (it as Pointer).adamId },
+            bindAdamId = { value, id -> (value as Pointer).adamId = id; true },
+            executor = queued,
+            logger = {},
+        )
+
+        session.start()
+        queued.runAll()
+        assertFalse(session.isTracking(42L))
+
+        manifest = manifest(entry(42L))
+        session.ensureRequested(42L)
+        assertTrue(session.isTracking(42L))
+
+        queued.runAll()
+
+        assertSame(pointer, session.readyReplacementFor(42L))
+        assertTrue(session.isTracking(42L))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Restore ready-late handling for null native lyric pointers without reintroducing the old LiveData/lifecycle hook chain.
- Prewarm the current mapping from the existing player metadata identity stream and refresh unknown mappings before availability checks.
- Rebind a stale Lyrics Fragment item only for null I2 pointers, recently observed metadata identities, and confirmed mappings; preserve the existing identity/lifecycle/ready gates.
- Add regression coverage for null ready-late misses, metadata listener replay, unknown mapping prewarm, and stale current-item rebinding.

## Root Cause
For Apple Music ID 7335408332109193189, metadata reported the current item while the Lyrics Fragment still held the previous ID 182861090. The TTML parser and replacement pointer were ready, but I2 looked up the stale Fragment ID and skipped the replacement.

## Verification
- :app:testDebugUnitTest (418 tests)
- :app:assembleDebug
- :app:assembleRelease
- :app:lintVitalRelease
- git diff --check
- Device verification succeeded for 7335408332109193189
