### PR TITLE
chore: release 1.3.6

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,8 +35,8 @@ android {
         applicationId = "dev.amenhancer.module"
         minSdk = 26
         targetSdk = 37
-        versionCode = 92
-        versionName = "1.3.5"
+        versionCode = 93
+        versionName = "1.3.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
@@ -282,7 +282,13 @@ internal class AppleMusicDualPaneTarget(
             navigationMenuResolution.valueOrNull(),
         )
         val activityResolution = symbols.resolve(AppleMusicSymbols.PlayerActivityCreateStackedNavigationHolder)
-        val chromeHooks = installNativeStackedNavigationHolderHook(activityResolution.valueOrNull())
+        val activityRootResolution = symbols.resolve(AppleMusicSymbols.PlayerActivityRoot)
+        val behaviorFieldResolution = symbols.resolve(AppleMusicSymbols.PlayerActivityBehaviorField)
+        val chromeHooks = installNativeStackedNavigationHolderHook(
+            activityResolution.valueOrNull(),
+            activityRootResolution.valueOrNull(),
+            behaviorFieldResolution.valueOrNull(),
+        )
         val lyricsFragmentResolution = symbols.resolve(AppleMusicSymbols.LyricsFragment)
         val lyricsFragmentClass = lyricsFragmentResolution.valueOrNull()
         val lyricsChromeResolution = symbols.resolve(AppleMusicSymbols.LyricsChromeAnimate)
@@ -302,6 +308,8 @@ internal class AppleMusicDualPaneTarget(
             controllerSelectPaneResolution,
             navigationMenuResolution,
             activityResolution,
+            activityRootResolution,
+            behaviorFieldResolution,
             lyricsFragmentResolution,
             lyricsChromeResolution,
             lyricsMetricsResolution,
@@ -618,33 +626,45 @@ internal class AppleMusicDualPaneTarget(
      * tablet holder. The native object then owns slide interpolation, peek
      * height, navigation translation, colors and system-bar transitions.
      */
-    private fun installNativeStackedNavigationHolderHook(method: Method?): Int {
+    private fun installNativeStackedNavigationHolderHook(
+        method: Method?,
+        rootMethod: Method?,
+        behaviorField: Field?,
+    ): Int {
         method ?: return 0
+        rootMethod ?: return 0
+        behaviorField ?: return 0
         val activityClass = method.declaringClass
-        val holderClass = activityClass.declaredClasses.firstOrNull { nested ->
-            nested.simpleName == "StackedBottomNavigationHolder" ||
-                nested.declaredConstructors.any { constructor ->
-                    constructor.parameterTypes.map { it.name } == listOf(
-                        activityClass.name,
-                        "android.view.View",
-                        "com.apple.android.music.player.PlayerBottomSheetBehavior",
-                    )
-                }
-        } ?: return 0
-        val constructor = holderClass.declaredConstructors.firstOrNull { constructor ->
-            constructor.parameterTypes.map { it.name } == listOf(
-                activityClass.name,
-                "android.view.View",
-                "com.apple.android.music.player.PlayerBottomSheetBehavior",
-            )
-        }?.apply { isAccessible = true } ?: return 0
-        val behaviorField = findField(activityClass, "c1") ?: return 0
-
+        val behaviorType = behaviorField.type
+        fun isHolderConstructor(parameters: Array<Class<*>>): Boolean {
+            if (parameters.size != 3) return false
+            val activityCompatible = parameters[0].isAssignableFrom(activityClass)
+            val viewCompatible = parameters[1].isAssignableFrom(View::class.java) ||
+                View::class.java.isAssignableFrom(parameters[1])
+            val behaviorCompatible = parameters[2].isAssignableFrom(behaviorType) ||
+                behaviorType.isAssignableFrom(parameters[2])
+            return activityCompatible && viewCompatible && behaviorCompatible
+        }
+        val holderClasses = activityClass.declaredClasses.filter { nested ->
+            nested.declaredConstructors.any { constructor ->
+                isHolderConstructor(constructor.parameterTypes)
+            }
+        }
+        val holderClass = when {
+            holderClasses.size == 1 -> holderClasses.single()
+            else -> holderClasses.singleOrNull { it.simpleName == "StackedBottomNavigationHolder" }
+                ?: return 0
+        }
+        val constructor = holderClass.declaredConstructors
+            .filter { constructor -> isHolderConstructor(constructor.parameterTypes) }
+            .singleOrNull()
+            ?.apply { isAccessible = true }
+            ?: return 0
         return if (hook(method, object : XC_MethodHook() {
                 override fun beforeHookedMethod(param: MethodHookParam) {
                     val activity = param.thisObject as? Activity ?: return
                     if (!TabletModeQualifier.isEligible(activity)) return
-                    val root = DualPaneShell.activityRoot(activity) ?: return
+                    val root = DualPaneShell.activityRoot(activity, rootMethod) ?: return
                     val resources = activity.resources
                     val stackedRootId = resources.getIdentifier(
                         "bottom_navigation_root_stacked",
@@ -659,8 +679,16 @@ internal class AppleMusicDualPaneTarget(
                     val navigationRoot = sequenceOf(stackedRootId, flatRootId)
                         .filter { it != 0 }
                         .mapNotNull(root::findViewById)
-                        .firstOrNull() ?: return
-                    val behavior = runCatching { behaviorField.get(activity) }.getOrNull() ?: return
+                        .firstOrNull()
+                        ?: sequenceOf(stackedRootId, flatRootId)
+                            .filter { it != 0 }
+                            .mapNotNull { id -> activity.findViewById<View>(id) }
+                            .firstOrNull()
+                    if (navigationRoot == null) return
+                    val behavior = runCatching {
+                        behaviorField.apply { isAccessible = true }.get(activity)
+                    }.getOrNull()
+                    if (behavior == null) return
                     if (!constructor.parameterTypes[2].isInstance(behavior)) return
                     val stackedHolder = runCatching {
                         constructor.newInstance(activity, navigationRoot, behavior)
@@ -846,21 +874,21 @@ internal object FlatLandscapeWindowPolicy {
     }
 
     /**
-     * Boundary sync is needed for genuinely wide displays even when a system
-     * rail makes the activity's effective window look narrower than 1.7.
-     * Keep this separate from [shouldReserveNavigationSpace]: the latter is
-     * the eager initial-margin policy and must retain its window semantics.
+     * Observe the real sheet/tabs boundary only for wide displays. Ordinary
+     * tablets keep the v1.2.1 native holder geometry unchanged.
      */
     fun shouldInstallBoundarySync(context: Context): Boolean {
         if (!TabletModeQualifier.isOfficialTabletLandscape(context)) return false
         val configuration = context.resources.configuration
         val metrics = realDisplayMetrics(context)
-        return shouldInstallBoundarySync(
+        val enabled = shouldInstallBoundarySync(
             windowWidthDp = configuration.screenWidthDp,
             windowHeightDp = configuration.screenHeightDp,
             physicalWidthPx = metrics?.widthPixels ?: 0,
             physicalHeightPx = metrics?.heightPixels ?: 0,
         )
+        debug("flat boundary gate enabled=$enabled")
+        return enabled
     }
 
     internal fun shouldInstallBoundarySync(
@@ -916,26 +944,27 @@ internal object FlatPlayerBoundaryPolicy {
     ): FlatPlayerBoundaryDecision {
         require(rootHeight > 0) { "rootHeight must be positive" }
         val expanded = sheetTop <= rootHeight / 2
+        val sheetOverlapsTabs = sheetTop < tabsTop + tabsHeight && sheetBottom > tabsTop
         val collapsedOverlap = !expanded &&
             tabsTop > rootHeight / 2 &&
-            sheetBottom > tabsTop
+            sheetOverlapsTabs
         val reserveNavigationSpace = wasNavigationSpaceReserved || collapsedOverlap
         return FlatPlayerBoundaryDecision(
             reserveNavigationSpace = reserveNavigationSpace,
             bottomMargin = if (!expanded && reserveNavigationSpace) tabsHeight else 0,
-            // Before this root proves it needs compensation, remain visually
-            // inert so ordinary tablet windows keep their native tab behavior.
+            // Let the native holder own an expanded transition until the
+            // collapsed geometry has established a navigation reservation.
             tabsVisible = !reserveNavigationSpace || !expanded,
         )
     }
 }
 
 internal object DualPaneShell {
-    /** Mirrors the modified PlayerActivity's BaseActivity.n0() root lookup. */
-    fun activityRoot(activity: Activity): View? = runCatching {
-        ModernXposedRuntime.callMethod(activity, "n0") as? View
+    /** Invokes the profile-resolved Activity root method without naming its obfuscation. */
+    fun activityRoot(activity: Activity, rootMethod: Method): View? = runCatching {
+        rootMethod.apply { isAccessible = true }.invoke(activity) as? View
     }.onFailure {
-        debug("BaseActivity.n0 root lookup failed: $it")
+        debug("PlayerActivity root lookup failed: $it")
     }.getOrNull()
 
     /**
@@ -1256,7 +1285,10 @@ private object ConstraintLayoutPane {
             val desired = decision.bottomMargin
             val desiredTabsVisibility = if (decision.tabsVisible) View.VISIBLE else View.INVISIBLE
             val tabsVisibilityChanged = tabsFrame.visibility != desiredTabsVisibility
-            if (desired == lastBottomMargin && !tabsVisibilityChanged) return
+            if (
+                desired == lastBottomMargin &&
+                !tabsVisibilityChanged
+            ) return
             lastBottomMargin = desired
             val params = constraintMarginParams(playerContainer, PLAYER_CONTAINER)
             if (params.bottomMargin != desired) {

--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
@@ -940,6 +940,7 @@ internal object FlatPlayerBoundaryPolicy {
         sheetBottom: Int,
         tabsTop: Int,
         tabsHeight: Int,
+        navigationInset: Int,
         wasNavigationSpaceReserved: Boolean,
     ): FlatPlayerBoundaryDecision {
         require(rootHeight > 0) { "rootHeight must be positive" }
@@ -951,7 +952,7 @@ internal object FlatPlayerBoundaryPolicy {
         val reserveNavigationSpace = wasNavigationSpaceReserved || collapsedOverlap
         return FlatPlayerBoundaryDecision(
             reserveNavigationSpace = reserveNavigationSpace,
-            bottomMargin = if (!expanded && reserveNavigationSpace) tabsHeight else 0,
+            bottomMargin = if (!expanded && reserveNavigationSpace) navigationInset else 0,
             // Let the native holder own an expanded transition until the
             // collapsed geometry has established a navigation reservation.
             tabsVisible = !reserveNavigationSpace || !expanded,
@@ -1096,8 +1097,14 @@ private object ConstraintLayoutPane {
                 configureTabsContent(bottomNavigation)
             }
             configureTabsTopShadow(topShadow)
-            configurePlayerContainer(playerContainer, tabsHeight, root.context)
-            installFlatPlayerBoundarySync(root, playerContainer, tabsFrame, tabsHeight)
+            configurePlayerContainer(playerContainer, tabsHeight, menuHeight, root.context)
+            installFlatPlayerBoundarySync(
+                root,
+                playerContainer,
+                tabsFrame,
+                tabsHeight,
+                (tabsHeight - menuHeight).coerceAtLeast(0),
+            )
             installTabsDivider(tabsFrame, resources)
 
             root.setTag(R.id.am_enhancer_dual_pane_state, BottomNavigationLandscapeInstalled)
@@ -1232,12 +1239,17 @@ private object ConstraintLayoutPane {
         topShadow.requestLayout()
     }
 
-    private fun configurePlayerContainer(playerContainer: View, tabsHeight: Int, context: Context) {
+    private fun configurePlayerContainer(
+        playerContainer: View,
+        tabsHeight: Int,
+        menuHeight: Int,
+        context: Context,
+    ) {
         val params = constraintMarginParams(playerContainer, PLAYER_CONTAINER)
         params.width = ViewGroup.LayoutParams.MATCH_PARENT
         params.height = ViewGroup.LayoutParams.MATCH_PARENT
         params.bottomMargin = if (FlatLandscapeWindowPolicy.shouldReserveNavigationSpace(context)) {
-            tabsHeight
+            (tabsHeight - menuHeight).coerceAtLeast(0)
         } else {
             0
         }
@@ -1256,6 +1268,7 @@ private object ConstraintLayoutPane {
         playerContainer: View,
         tabsFrame: View,
         tabsHeight: Int,
+        navigationInset: Int,
     ) {
         if (!FlatLandscapeWindowPolicy.shouldInstallBoundarySync(root.context)) return
         val sheetId = targetId(root.resources, PLAYER_SHEET_CONTAINER)
@@ -1279,6 +1292,7 @@ private object ConstraintLayoutPane {
                 sheetBottom = sheetLocation[1] - rootTop + sheet.height,
                 tabsTop = tabsLocation[1] - rootTop,
                 tabsHeight = tabsHeight,
+                navigationInset = navigationInset,
                 wasNavigationSpaceReserved = reserveNavigationSpace,
             )
             reserveNavigationSpace = decision.reserveNavigationSpace
@@ -1474,6 +1488,7 @@ private object ConstraintLayoutPane {
      */
     fun stackedTabsContainerHeight(context: Context, menuHeight: Int): Int =
         menuHeight + dp(context, STACKED_TABS_VERTICAL_INSET_DP * 2)
+
 
     private fun dp(context: Context, value: Int): Int =
         (value * context.resources.displayMetrics.density + 0.5f).toInt()

--- a/app/src/main/java/dev/amenhancer/module/hook/LayoutInflationRegistry.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/LayoutInflationRegistry.kt
@@ -86,15 +86,19 @@ internal object LayoutInflationRegistry {
             else -> null
         }
         if (exact != null && callbacks.containsKey(exact)) return exact
-        return when {
-            hasResourceName(root, "recycler_view_gradients") &&
-                hasResourceName(root, "current_player_item") -> "fragment_player_lyrics_sheet"
-            hasResourceName(root, "mini_player_content") -> "mini_player"
-            hasResourceName(root, "bottom_navigation") -> "bottom_navigation"
-            hasResourceName(root, "song_lyrics_word") -> "lyrics_word_karaoke"
-            hasResourceName(root, "song_lyrics_line") -> "lyrics_line"
-            else -> null
-        }?.takeIf(callbacks::containsKey)
+        return inferLayoutNameByResourceNames { expected -> hasResourceName(root, expected) }
+            ?.takeIf(callbacks::containsKey)
+    }
+
+    internal fun inferLayoutNameByResourceNames(isPresent: (String) -> Boolean): String? = when {
+        isPresent("lyrics_main_content") &&
+            isPresent("recycler_view_gradients") &&
+            isPresent("current_player_item") -> "fragment_player_lyrics_sheet"
+        isPresent("mini_player_content") -> "mini_player"
+        isPresent("bottom_navigation") -> "bottom_navigation"
+        isPresent("song_lyrics_word") -> "lyrics_word_karaoke"
+        isPresent("song_lyrics_line") -> "lyrics_line"
+        else -> null
     }
 
     private fun hasResourceName(view: View, expected: String): Boolean {

--- a/app/src/main/java/dev/amenhancer/module/hook/TargetSymbols.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/TargetSymbols.kt
@@ -115,6 +115,40 @@ internal class TargetClassIndex(private val source: TargetClassSource) {
             }.getOrDefault(emptyList())
         }
         .distinctBy(::fieldIdentity)
+
+    fun hierarchyMethods(
+        namePredicate: (String) -> Boolean,
+        contract: (Method) -> Boolean,
+    ): List<Method> = classes(namePredicate) { true }
+        .flatMap { type -> methodsFromHierarchy(type, contract) }
+        .distinctBy(::methodIdentity)
+
+    fun hierarchyFields(
+        namePredicate: (String) -> Boolean,
+        contract: (Field) -> Boolean,
+    ): List<Field> = classes(namePredicate) { true }
+        .flatMap { type -> fieldsFromHierarchy(type, contract) }
+        .distinctBy(::fieldIdentity)
+
+    fun methodsFromHierarchy(type: Class<*>, contract: (Method) -> Boolean): List<Method> =
+        generateSequence(type) { it.superclass }
+            .flatMap { current ->
+                current.declaredMethods.asSequence().filter { method ->
+                    runCatching { contract(method) }.getOrDefault(false)
+                }
+            }
+            .distinctBy(::methodIdentity)
+            .toList()
+
+    fun fieldsFromHierarchy(type: Class<*>, contract: (Field) -> Boolean): List<Field> =
+        generateSequence(type) { it.superclass }
+            .flatMap { current ->
+                current.declaredFields.asSequence().filter { field ->
+                    runCatching { contract(field) }.getOrDefault(false)
+                }
+            }
+            .distinctBy(::fieldIdentity)
+            .toList()
 }
 
 internal class TargetSymbolKey<T : Any>(
@@ -198,11 +232,16 @@ internal class IndexedTargetSymbolResolver(
 internal data class AppleMusicProfile(
     val id: String,
     val exactClasses: Map<TargetSymbolId, String>,
+    val exactMethods: Map<TargetSymbolId, String> = emptyMap(),
+    val exactFields: Map<TargetSymbolId, String> = emptyMap(),
 )
 
 internal enum class TargetSymbolId {
     PLAYER_CONTROLLER,
     PLAYER_ACTIVITY,
+    PLAYER_ACTIVITY_CREATE_STACKED_NAVIGATION_HOLDER,
+    PLAYER_ACTIVITY_ROOT,
+    PLAYER_ACTIVITY_BEHAVIOR_FIELD,
     EDITORIAL_VIDEO_OWNER,
     LYRICS_FRAGMENT,
     LYRICS_CHROME,
@@ -250,6 +289,13 @@ private object AppleMusicProfiles {
             TargetSymbolId.METADATA_TO_ITEM_CONVERTER to "com.apple.android.music.player.P",
             TargetSymbolId.LYRICS_AVAILABILITY_OWNER to "com.apple.android.music.player.d1",
         ),
+        exactMethods = mapOf(
+            TargetSymbolId.PLAYER_ACTIVITY_CREATE_STACKED_NAVIGATION_HOLDER to "k1",
+            TargetSymbolId.PLAYER_ACTIVITY_ROOT to "n0",
+        ),
+        exactFields = mapOf(
+            TargetSymbolId.PLAYER_ACTIVITY_BEHAVIOR_FIELD to "c1",
+        ),
     )
 
     private val appleMusic651 = AppleMusicProfile(
@@ -280,6 +326,13 @@ private object AppleMusicProfiles {
             TargetSymbolId.PLAYER_METADATA_HUB to "com.apple.android.music.player.f",
             TargetSymbolId.METADATA_TO_ITEM_CONVERTER to "com.apple.android.music.player.O",
             TargetSymbolId.LYRICS_AVAILABILITY_OWNER to "com.apple.android.music.player.e1",
+        ),
+        exactMethods = mapOf(
+            TargetSymbolId.PLAYER_ACTIVITY_CREATE_STACKED_NAVIGATION_HOLDER to "j1",
+            TargetSymbolId.PLAYER_ACTIVITY_ROOT to "l1",
+        ),
+        exactFields = mapOf(
+            TargetSymbolId.PLAYER_ACTIVITY_BEHAVIOR_FIELD to "c1",
         ),
     )
 
@@ -346,8 +399,29 @@ internal object AppleMusicSymbols {
         id = "player-activity-create-stacked-navigation-holder",
         profileOwner = TargetSymbolId.PLAYER_ACTIVITY,
         profilePolicy = ProfilePolicy.EXACT_PREFERRED,
+        exactMethodId = TargetSymbolId.PLAYER_ACTIVITY_CREATE_STACKED_NAVIGATION_HOLDER,
         fallbackOwner = { it.endsWith(".common.activity.PlayerActivity") },
         contract = ::isPlayerActivityCreateStackedNavigationHolder,
+    )
+
+    val PlayerActivityRoot = methodSymbol(
+        id = "player-activity-root",
+        profileOwner = TargetSymbolId.PLAYER_ACTIVITY,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
+        exactMethodId = TargetSymbolId.PLAYER_ACTIVITY_ROOT,
+        searchHierarchy = true,
+        fallbackOwner = { it.endsWith(".common.activity.PlayerActivity") },
+        contract = ::isPlayerActivityRoot,
+    )
+
+    val PlayerActivityBehaviorField = fieldSymbol(
+        id = "player-activity-bottom-sheet-behavior",
+        profileOwner = TargetSymbolId.PLAYER_ACTIVITY,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
+        exactFieldId = TargetSymbolId.PLAYER_ACTIVITY_BEHAVIOR_FIELD,
+        searchHierarchy = true,
+        fallbackOwner = { it.endsWith(".common.activity.PlayerActivity") },
+        contract = ::isPlayerActivityBehaviorField,
     )
 
     val EditorialVideoUrlSelector = methodSymbol(
@@ -681,6 +755,8 @@ private fun methodSymbol(
     id: String,
     profileOwner: TargetSymbolId,
     profilePolicy: ProfilePolicy = ProfilePolicy.EXACT_REQUIRED,
+    exactMethodId: TargetSymbolId? = null,
+    searchHierarchy: Boolean = false,
     fallbackOwner: (String) -> Boolean,
     contract: (Method) -> Boolean,
     structuralContract: (Method) -> Boolean = contract,
@@ -689,15 +765,70 @@ private fun methodSymbol(
     profilePolicy = profilePolicy,
     profileCandidates = { profile ->
         runCatching {
+            val expectedMethodName = exactMethodId?.let { profile?.exactMethods?.get(it) }
             profile?.exactClasses?.get(profileOwner)
                 ?.let(::load)
-                ?.declaredMethods
-                ?.filter(contract)
+                ?.let { owner ->
+                    val methods = if (searchHierarchy) {
+                        methodsFromHierarchy(owner, contract)
+                    } else {
+                        owner.declaredMethods.filter(contract)
+                    }
+                    methods.filter { method ->
+                        expectedMethodName == null || method.name == expectedMethodName
+                    }
+                }
                 .orEmpty()
         }.getOrDefault(emptyList())
     },
-    structuralCandidates = { methods(fallbackOwner, structuralContract) },
+    structuralCandidates = {
+        if (searchHierarchy) {
+            hierarchyMethods(fallbackOwner, structuralContract)
+        } else {
+            methods(fallbackOwner, structuralContract)
+        }
+    },
     identity = ::methodIdentity,
+)
+
+private fun fieldSymbol(
+    id: String,
+    profileOwner: TargetSymbolId,
+    profilePolicy: ProfilePolicy = ProfilePolicy.EXACT_REQUIRED,
+    exactFieldId: TargetSymbolId? = null,
+    searchHierarchy: Boolean = false,
+    fallbackOwner: (String) -> Boolean,
+    contract: (Field) -> Boolean,
+    structuralContract: (Field) -> Boolean = contract,
+): TargetSymbolKey<Field> = TargetSymbolKey(
+    id = id,
+    profilePolicy = profilePolicy,
+    profileCandidates = { profile ->
+        runCatching {
+            val expectedFieldName = exactFieldId?.let { profile?.exactFields?.get(it) }
+            profile?.exactClasses?.get(profileOwner)
+                ?.let(::load)
+                ?.let { owner ->
+                    val fields = if (searchHierarchy) {
+                        fieldsFromHierarchy(owner, contract)
+                    } else {
+                        owner.declaredFields.filter(contract)
+                    }
+                    fields.filter { field ->
+                        expectedFieldName == null || field.name == expectedFieldName
+                    }
+                }
+                .orEmpty()
+        }.getOrDefault(emptyList())
+    },
+    structuralCandidates = {
+        if (searchHierarchy) {
+            hierarchyFields(fallbackOwner, structuralContract)
+        } else {
+            fields(fallbackOwner, structuralContract)
+        }
+    },
+    identity = ::fieldIdentity,
 )
 
 private fun hasLyricsChromeContract(candidate: Class<*>): Boolean =
@@ -761,9 +892,25 @@ private fun hasPlayerControllerHookContract(candidate: Class<*>): Boolean =
 
 private fun isPlayerActivityCreateStackedNavigationHolder(method: Method): Boolean =
     !Modifier.isStatic(method.modifiers) &&
-        method.name == "k1" &&
         method.parameterTypes.isEmpty() &&
         method.returnType.name == "com.apple.android.music.common.activity.PlayerActivity\$m"
+
+private fun isPlayerActivityRoot(method: Method): Boolean =
+    !Modifier.isStatic(method.modifiers) &&
+        method.parameterTypes.isEmpty() &&
+        View::class.java.isAssignableFrom(method.returnType)
+
+private fun isPlayerActivityBehaviorField(field: Field): Boolean =
+    !Modifier.isStatic(field.modifiers) && isBottomSheetBehaviorType(field.type)
+
+private fun isBottomSheetBehaviorType(type: Class<*>): Boolean {
+    var current: Class<*>? = type
+    while (current != null) {
+        if (current.name == "com.google.android.material.bottomsheet.BottomSheetBehavior") return true
+        current = current.superclass
+    }
+    return type.name.endsWith("PlayerBottomSheetBehavior")
+}
 
 private fun isLyricsFragmentOnResume(method: Method): Boolean =
     !Modifier.isStatic(method.modifiers) &&

--- a/app/src/test/java/com/apple/android/music/player/PlayerBottomSheetBehavior.kt
+++ b/app/src/test/java/com/apple/android/music/player/PlayerBottomSheetBehavior.kt
@@ -1,0 +1,3 @@
+package com.apple.android.music.player
+
+class PlayerBottomSheetBehavior

--- a/app/src/test/java/dev/amenhancer/module/hook/DualPaneStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/DualPaneStructuralRegressionTest.kt
@@ -157,7 +157,7 @@ class DualPaneStructuralRegressionTest {
 
     @Test
     fun `lets the native stacked holder own the collapsed player offset`() {
-        assertTrue(source.contains("configurePlayerContainer(playerContainer, tabsHeight, root.context)"))
+        assertTrue(source.contains("configurePlayerContainer(playerContainer, tabsHeight, menuHeight, root.context)"))
         assertTrue(source.contains("FlatLandscapeWindowPolicy.shouldReserveNavigationSpace(context)"))
         assertFalse(source.contains("restoreStackedNavigationLayout"))
     }
@@ -173,7 +173,8 @@ class DualPaneStructuralRegressionTest {
 
     @Test
     fun `limits flat player boundary sync to wide displays`() {
-        assertTrue(source.contains("installFlatPlayerBoundarySync(root, playerContainer, tabsFrame, tabsHeight)"))
+        assertTrue(source.contains("tabsHeight - menuHeight"))
+        assertTrue(source.contains("navigationInset = navigationInset"))
         assertTrue(source.contains("if (!FlatLandscapeWindowPolicy.shouldInstallBoundarySync(root.context)) return"))
         assertTrue(source.contains("display.getRealMetrics(metrics)"))
         assertTrue(source.contains("physicalWidthPx = metrics?.widthPixels ?: 0"))
@@ -192,7 +193,7 @@ class DualPaneStructuralRegressionTest {
         assertTrue(source.contains("sheet.viewTreeObserver.addOnPreDrawListener"))
         assertTrue(source.contains("removeOnPreDrawListener"))
         assertTrue(source.contains("sheet.addOnAttachStateChangeListener"))
-        assertTrue(source.contains("installFlatPlayerBoundarySync(root, playerContainer, tabsFrame, tabsHeight)"))
+        assertTrue(source.contains("tabsHeight - menuHeight"))
         assertTrue(source.contains("val desiredTabsVisibility = if (decision.tabsVisible) View.VISIBLE else View.INVISIBLE"))
         assertTrue(source.contains("tabsFrame.visibility = desiredTabsVisibility"))
         assertFalse(source.contains("miniPlayerId"))

--- a/app/src/test/java/dev/amenhancer/module/hook/DualPaneStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/DualPaneStructuralRegressionTest.kt
@@ -48,6 +48,8 @@ class DualPaneStructuralRegressionTest {
             "PlayerControllerCreateView",
             "PlayerControllerSelectPane",
             "PlayerActivityCreateStackedNavigationHolder",
+            "PlayerActivityRoot",
+            "PlayerActivityBehaviorField",
             "StackedNavigationMenuOnMeasure",
             "LyricsFragmentOnResume",
             "LyricsChromeAnimate",
@@ -145,9 +147,12 @@ class DualPaneStructuralRegressionTest {
     fun `lets the native stacked holder own mini player content geometry`() {
         assertFalse(source.contains("hookTabletMiniPlayerLayout"))
         assertFalse(source.contains("StackedMiniPlayerLayout"))
-        assertFalse(source.contains("MINI_PLAYER_CONTENT"))
+        assertFalse(source.contains("val miniPlayerId = root.resources.getIdentifier(\"mini_player\", \"id\", ModuleConstants.TARGET_PACKAGE)"))
+        assertFalse(source.contains("decision.miniPlayerVisible"))
+        assertFalse(source.contains("alpha = 1f"))
         assertFalse(source.contains("centerContentInParent"))
         assertFalse(source.contains("AMENH-MINI-PROBE"))
+        assertFalse(source.contains("miniPlayer.visibility = View.GONE"))
     }
 
     @Test
@@ -167,11 +172,12 @@ class DualPaneStructuralRegressionTest {
     }
 
     @Test
-    fun `limits flat player boundary sync to a wide effective or physical display`() {
+    fun `limits flat player boundary sync to wide displays`() {
         assertTrue(source.contains("installFlatPlayerBoundarySync(root, playerContainer, tabsFrame, tabsHeight)"))
         assertTrue(source.contains("if (!FlatLandscapeWindowPolicy.shouldInstallBoundarySync(root.context)) return"))
         assertTrue(source.contains("display.getRealMetrics(metrics)"))
         assertTrue(source.contains("physicalWidthPx = metrics?.widthPixels ?: 0"))
+        assertFalse(source.contains("appleMusicFlatPlayerBoundaryMode(targetBuild(context))"))
         assertTrue(source.contains("params.bottomMargin = if (FlatLandscapeWindowPolicy.shouldReserveNavigationSpace(context))"))
         assertTrue(source.contains("FlatPlayerBoundaryPolicy.decide"))
         assertTrue(source.contains("sheet.getLocationInWindow(sheetLocation)"))
@@ -189,6 +195,10 @@ class DualPaneStructuralRegressionTest {
         assertTrue(source.contains("installFlatPlayerBoundarySync(root, playerContainer, tabsFrame, tabsHeight)"))
         assertTrue(source.contains("val desiredTabsVisibility = if (decision.tabsVisible) View.VISIBLE else View.INVISIBLE"))
         assertTrue(source.contains("tabsFrame.visibility = desiredTabsVisibility"))
+        assertFalse(source.contains("miniPlayerId"))
+        assertFalse(source.contains("decision.miniPlayerVisible"))
+        assertFalse(source.contains("miniPlayerVisibilityChanged"))
+        assertTrue(source.contains("sheetOverlapsTabs"))
     }
 
     @Test
@@ -254,7 +264,7 @@ class DualPaneStructuralRegressionTest {
 
     @Test
     fun `uses the same BaseActivity root as the modified PlayerActivity`() {
-        assertTrue(source.contains("ModernXposedRuntime.callMethod(activity, \"n0\")"))
+        assertTrue(source.contains("rootMethod.apply { isAccessible = true }.invoke(activity) as? View"))
         assertFalse(source.contains("installForExpandedActivityRoot"))
         assertFalse(source.contains("playerRootFromActivity"))
     }
@@ -262,9 +272,17 @@ class DualPaneStructuralRegressionTest {
     @Test
     fun `returns the official stacked holder before the flat holder can be constructed`() {
         assertTrue(source.contains("AppleMusicSymbols.PlayerActivityCreateStackedNavigationHolder"))
-        assertTrue(source.contains("installNativeStackedNavigationHolderHook(activityResolution.valueOrNull())"))
-        assertTrue(source.contains("nested.simpleName == \"StackedBottomNavigationHolder\""))
+        assertTrue(source.contains("AppleMusicSymbols.PlayerActivityRoot"))
+        assertTrue(source.contains("AppleMusicSymbols.PlayerActivityBehaviorField"))
+        assertTrue(source.contains("activityRootResolution.valueOrNull()"))
+        assertTrue(source.contains("behaviorFieldResolution.valueOrNull()"))
+        assertFalse(source.contains("findField(activityClass, \"c1\")"))
+        assertFalse(source.contains("ModernXposedRuntime.callMethod(activity, \"n0\")"))
+        assertFalse(source.contains("com.apple.android.music.player.PlayerBottomSheetBehavior"))
+        assertTrue(source.contains("behaviorField.type"))
+        assertTrue(source.contains("it.simpleName == \"StackedBottomNavigationHolder\""))
         assertTrue(source.contains("override fun beforeHookedMethod(param: MethodHookParam)"))
+        assertTrue(source.contains("activity.findViewById<View>(id)"))
         assertTrue(source.contains("constructor.newInstance(activity, navigationRoot, behavior)"))
         assertTrue(source.contains("param.result = stackedHolder"))
         assertTrue(source.contains("if (!TabletModeQualifier.isEligible(activity)) return"))

--- a/app/src/test/java/dev/amenhancer/module/hook/FlatLandscapeWindowPolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/FlatLandscapeWindowPolicyTest.kt
@@ -76,4 +76,16 @@ class FlatLandscapeWindowPolicyTest {
             ),
         )
     }
+
+    @Test
+    fun `verified profile does not bypass ordinary tablet ratio gate`() {
+        assertFalse(
+            FlatLandscapeWindowPolicy.shouldInstallBoundarySync(
+                windowWidthDp = 1413,
+                windowHeightDp = 1000,
+                physicalWidthPx = 1413,
+                physicalHeightPx = 1000,
+            ),
+        )
+    }
 }

--- a/app/src/test/java/dev/amenhancer/module/hook/FlatPlayerBoundaryPolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/FlatPlayerBoundaryPolicyTest.kt
@@ -14,11 +14,12 @@ class FlatPlayerBoundaryPolicyTest {
             sheetBottom = 1080,
             tabsTop = 954,
             tabsHeight = 126,
+            navigationInset = 16,
             wasNavigationSpaceReserved = false,
         )
 
         assertTrue(decision.reserveNavigationSpace)
-        assertEquals(126, decision.bottomMargin)
+        assertEquals(16, decision.bottomMargin)
         assertTrue(decision.tabsVisible)
     }
 
@@ -30,11 +31,12 @@ class FlatPlayerBoundaryPolicyTest {
             sheetBottom = 954,
             tabsTop = 954,
             tabsHeight = 126,
+            navigationInset = 16,
             wasNavigationSpaceReserved = true,
         )
 
         assertTrue(decision.reserveNavigationSpace)
-        assertEquals(126, decision.bottomMargin)
+        assertEquals(16, decision.bottomMargin)
         assertTrue(decision.tabsVisible)
     }
 
@@ -46,6 +48,7 @@ class FlatPlayerBoundaryPolicyTest {
             sheetBottom = 744,
             tabsTop = 744,
             tabsHeight = 56,
+            navigationInset = 16,
             wasNavigationSpaceReserved = false,
         )
 
@@ -62,6 +65,7 @@ class FlatPlayerBoundaryPolicyTest {
             sheetBottom = 1080,
             tabsTop = 954,
             tabsHeight = 126,
+            navigationInset = 16,
             wasNavigationSpaceReserved = false,
         )
 
@@ -78,6 +82,7 @@ class FlatPlayerBoundaryPolicyTest {
             sheetBottom = 900,
             tabsTop = 954,
             tabsHeight = 126,
+            navigationInset = 16,
             wasNavigationSpaceReserved = false,
         )
 
@@ -94,11 +99,63 @@ class FlatPlayerBoundaryPolicyTest {
             sheetBottom = 1080,
             tabsTop = 954,
             tabsHeight = 126,
+            navigationInset = 16,
             wasNavigationSpaceReserved = true,
         )
 
         assertTrue(decision.reserveNavigationSpace)
         assertEquals(0, decision.bottomMargin)
         assertFalse(decision.tabsVisible)
+    }
+
+    @Test
+    fun `collapsed wide sheet reserves only the navigation inset`() {
+        val decision = FlatPlayerBoundaryPolicy.decide(
+            rootHeight = 1440,
+            sheetTop = 1066,
+            sheetBottom = 1296,
+            tabsTop = 1296,
+            tabsHeight = 144,
+            navigationInset = 32,
+            wasNavigationSpaceReserved = true,
+        )
+
+        assertTrue(decision.reserveNavigationSpace)
+        assertEquals(32, decision.bottomMargin)
+        assertTrue(decision.tabsVisible)
+    }
+
+    @Test
+    fun `fresh collapsed overlap uses the dynamic inset`() {
+        val decision = FlatPlayerBoundaryPolicy.decide(
+            rootHeight = 1440,
+            sheetTop = 1178,
+            sheetBottom = 1408,
+            tabsTop = 1296,
+            tabsHeight = 144,
+            navigationInset = 32,
+            wasNavigationSpaceReserved = false,
+        )
+
+        assertTrue(decision.reserveNavigationSpace)
+        assertEquals(32, decision.bottomMargin)
+        assertTrue(decision.tabsVisible)
+    }
+
+    @Test
+    fun `zero navigation inset keeps the detected geometry unchanged`() {
+        val decision = FlatPlayerBoundaryPolicy.decide(
+            rootHeight = 1080,
+            sheetTop = 982,
+            sheetBottom = 1080,
+            tabsTop = 954,
+            tabsHeight = 126,
+            navigationInset = 0,
+            wasNavigationSpaceReserved = false,
+        )
+
+        assertTrue(decision.reserveNavigationSpace)
+        assertEquals(0, decision.bottomMargin)
+        assertTrue(decision.tabsVisible)
     }
 }

--- a/app/src/test/java/dev/amenhancer/module/hook/FlatPlayerBoundaryPolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/FlatPlayerBoundaryPolicyTest.kt
@@ -55,11 +55,27 @@ class FlatPlayerBoundaryPolicyTest {
     }
 
     @Test
-    fun `expanded sheet remains inert before an overlap has been observed`() {
+    fun `expanded sheet remains native before a reservation is observed`() {
         val decision = FlatPlayerBoundaryPolicy.decide(
             rootHeight = 1080,
             sheetTop = 0,
             sheetBottom = 1080,
+            tabsTop = 954,
+            tabsHeight = 126,
+            wasNavigationSpaceReserved = false,
+        )
+
+        assertFalse(decision.reserveNavigationSpace)
+        assertEquals(0, decision.bottomMargin)
+        assertTrue(decision.tabsVisible)
+    }
+
+    @Test
+    fun `expanded sheet stays visible when it does not cover the navigation area`() {
+        val decision = FlatPlayerBoundaryPolicy.decide(
+            rootHeight = 1080,
+            sheetTop = 0,
+            sheetBottom = 900,
             tabsTop = 954,
             tabsHeight = 126,
             wasNavigationSpaceReserved = false,

--- a/app/src/test/java/dev/amenhancer/module/hook/LayoutInflationRegistryInferenceTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/LayoutInflationRegistryInferenceTest.kt
@@ -1,0 +1,50 @@
+package dev.amenhancer.module.hook
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class LayoutInflationRegistryInferenceTest {
+    @Test
+    fun `queue layout is not inferred as lyrics sheet`() {
+        val queueNames = setOf(
+            "recycler_view_gradients",
+            "current_player_item",
+            "queue_main_content",
+        )
+
+        assertNull(LayoutInflationRegistry.inferLayoutNameByResourceNames(queueNames::contains))
+        assertNull(infer("recycler_view_gradients", "current_player_item"))
+    }
+
+    @Test
+    fun `lyrics sheet inference requires all dedicated markers`() {
+        assertNull(infer("recycler_view_gradients", "lyrics_main_content"))
+        assertNull(infer("current_player_item", "lyrics_main_content"))
+    }
+
+    @Test
+    fun `lyrics sheet keeps its dedicated layout inference`() {
+        val lyricsNames = setOf(
+            "recycler_view_gradients",
+            "current_player_item",
+            "lyrics_main_content",
+        )
+
+        assertEquals(
+            "fragment_player_lyrics_sheet",
+            LayoutInflationRegistry.inferLayoutNameByResourceNames(lyricsNames::contains),
+        )
+    }
+
+    @Test
+    fun `other inferred layouts keep their existing names`() {
+        assertEquals("mini_player", infer("mini_player_content"))
+        assertEquals("bottom_navigation", infer("bottom_navigation"))
+        assertEquals("lyrics_word_karaoke", infer("song_lyrics_word"))
+        assertEquals("lyrics_line", infer("song_lyrics_line"))
+    }
+
+    private fun infer(vararg names: String): String? =
+        LayoutInflationRegistry.inferLayoutNameByResourceNames(names.toSet()::contains)
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/TargetSymbolsTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/TargetSymbolsTest.kt
@@ -131,11 +131,52 @@ class TargetSymbolsTest {
     }
 
     @Test
+    fun `650 profile resolves the holder root method and behavior field`() {
+        val activityName = "com.apple.android.music.common.activity.PlayerActivity"
+        val resolver = IndexedTargetSymbolResolver(
+            build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.0", 1580L),
+            source = FakeTargetClassSource(classes = mapOf(activityName to DualPaneActivityFixture::class.java)),
+        )
+
+        val root = resolver.resolve(AppleMusicSymbols.PlayerActivityRoot)
+        val behavior = resolver.resolve(AppleMusicSymbols.PlayerActivityBehaviorField)
+
+        assertTrue(root is TargetResolution.Found)
+        assertEquals(SymbolMatch.VERSION_PROFILE, (root as TargetResolution.Found).match)
+        assertEquals("n0", root.value.name)
+        assertTrue(behavior is TargetResolution.Found)
+        assertEquals(SymbolMatch.VERSION_PROFILE, (behavior as TargetResolution.Found).match)
+        assertEquals("c1", behavior.value.name)
+    }
+
+    @Test
+    fun `unknown build structurally resolves unique holder root and behavior contracts`() {
+        val activityName = "com.apple.android.music.common.activity.PlayerActivity"
+        val resolver = IndexedTargetSymbolResolver(
+            build = TargetBuild.UNKNOWN,
+            source = FakeTargetClassSource(
+                names = listOf(activityName),
+                classes = mapOf(activityName to ObfuscatedDualPaneActivityFixture::class.java),
+            ),
+        )
+
+        val root = resolver.resolve(AppleMusicSymbols.PlayerActivityRoot)
+        val behavior = resolver.resolve(AppleMusicSymbols.PlayerActivityBehaviorField)
+
+        assertTrue(root is TargetResolution.Found)
+        assertEquals(SymbolMatch.STRUCTURAL_FALLBACK, (root as TargetResolution.Found).match)
+        assertEquals("x0", root.value.name)
+        assertTrue(behavior is TargetResolution.Found)
+        assertEquals(SymbolMatch.STRUCTURAL_FALLBACK, (behavior as TargetResolution.Found).match)
+        assertEquals("z7", behavior.value.name)
+    }
+
+    @Test
     fun `651 profile resolves migrated dual pane and view model owners without scanning dex`() {
         val source = FakeTargetClassSource(
             classes = mapOf(
                 "com.apple.android.music.player.fragment.q0" to DualPaneControllerFixture::class.java,
-                "com.apple.android.music.common.activity.PlayerActivity" to DualPaneActivityFixture::class.java,
+                "com.apple.android.music.common.activity.PlayerActivity" to DualPaneActivity651Fixture::class.java,
                 "com.apple.android.music.player.fragment.PlayerLyricsViewFragment" to
                     DualPaneLyricsFragmentFixture::class.java,
                 "com.apple.android.music.player.fragment.d" to DualPaneLyricsChromeFixture::class.java,
@@ -149,7 +190,7 @@ class TargetSymbolsTest {
             source = source,
         )
 
-        listOf(
+        val resolutions = listOf(
             resolver.resolve(AppleMusicSymbols.StackedNavigationMenuOnMeasure),
             resolver.resolve(AppleMusicSymbols.LyricsFragmentOnResume),
             resolver.resolve(AppleMusicSymbols.LyricsChromeAnimate),
@@ -160,12 +201,33 @@ class TargetSymbolsTest {
             resolver.resolve(AppleMusicSymbols.PlayerActivityCreateStackedNavigationHolder),
             resolver.resolve(AppleMusicSymbols.LyricsViewModelNotifyWordHighlight),
             resolver.resolve(AppleMusicSymbols.LyricsViewModelSetCurrentHighlightedLine),
-        ).forEach { resolution ->
+        )
+        resolutions.forEach { resolution ->
             assertTrue(resolution is TargetResolution.Found)
             assertEquals(SymbolMatch.VERSION_PROFILE, (resolution as TargetResolution.Found).match)
             assertEquals("apple-music-6.5.1-1583", resolution.profileId)
         }
+        assertEquals("j1", (resolutions[7] as TargetResolution.Found).value.name)
         assertEquals(0, source.classNameReads)
+    }
+
+    @Test
+    fun `651 profile resolves holder support contracts through the activity hierarchy`() {
+        val activityName = "com.apple.android.music.common.activity.PlayerActivity"
+        val resolver = IndexedTargetSymbolResolver(
+            build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.1", 1583L),
+            source = FakeTargetClassSource(classes = mapOf(activityName to DualPaneActivity651Fixture::class.java)),
+        )
+
+        val root = resolver.resolve(AppleMusicSymbols.PlayerActivityRoot)
+        val behavior = resolver.resolve(AppleMusicSymbols.PlayerActivityBehaviorField)
+
+        assertTrue(root is TargetResolution.Found)
+        assertEquals(SymbolMatch.VERSION_PROFILE, (root as TargetResolution.Found).match)
+        assertEquals("l1", root.value.name)
+        assertTrue(behavior is TargetResolution.Found)
+        assertEquals(SymbolMatch.VERSION_PROFILE, (behavior as TargetResolution.Found).match)
+        assertEquals("c1", behavior.value.name)
     }
 
     @Test
@@ -725,6 +787,8 @@ class TargetSymbolsTest {
             AppleMusicSymbols.PlayerControllerCreateView,
             AppleMusicSymbols.PlayerControllerSelectPane,
             AppleMusicSymbols.PlayerActivityCreateStackedNavigationHolder,
+            AppleMusicSymbols.PlayerActivityRoot,
+            AppleMusicSymbols.PlayerActivityBehaviorField,
             AppleMusicSymbols.LyricsViewModelNotifyWordHighlight,
             AppleMusicSymbols.LyricsViewModelSetCurrentHighlightedLine,
         ).forEach { symbol ->
@@ -1169,10 +1233,33 @@ private class ControllerInitializeOnlyFixture {
     fun w1(config: BagConfig) = Unit
 }
 
-private class DualPaneActivityFixture {
+private open class BaseDualPaneActivityFixture {
+    @Suppress("unused")
+    private val c1 = com.apple.android.music.player.PlayerBottomSheetBehavior()
+
+    fun n0(): View = throw UnsupportedOperationException()
+}
+
+private class DualPaneActivityFixture : BaseDualPaneActivityFixture() {
     fun k1(): com.apple.android.music.common.activity.PlayerActivity.m =
         com.apple.android.music.common.activity.PlayerActivity.m()
 }
+
+private class DualPaneActivity651Fixture : BaseDualPaneActivityFixture() {
+    fun j1(): com.apple.android.music.common.activity.PlayerActivity.m =
+        com.apple.android.music.common.activity.PlayerActivity.m()
+
+    fun l1(): View = throw UnsupportedOperationException()
+}
+
+private open class ObfuscatedBaseDualPaneActivityFixture {
+    @Suppress("unused")
+    private val z7 = com.apple.android.music.player.PlayerBottomSheetBehavior()
+
+    fun x0(): View = throw UnsupportedOperationException()
+}
+
+private class ObfuscatedDualPaneActivityFixture : ObfuscatedBaseDualPaneActivityFixture()
 
 private class DualPaneLyricsFragmentFixture {
     fun onResume() = Unit

--- a/scripts/verify-device-dual-pane.ps1
+++ b/scripts/verify-device-dual-pane.ps1
@@ -57,8 +57,16 @@ $left = [int]$miniPlayer.Groups[1].Value
 $top = [int]$miniPlayer.Groups[2].Value
 $right = [int]$miniPlayer.Groups[3].Value
 $bottom = [int]$miniPlayer.Groups[4].Value
-$x = [int](($left + $right) / 2)
-$y = [int](($top + $bottom) / 2)
+$miniPlayerContent = [regex]::Match(
+    $collapsedUi,
+    'resource-id="com\.apple\.android\.music:id/mini_player_content"[^>]*bounds="\[(\d+),(\d+)\]\[(\d+),(\d+)\]"'
+)
+$tapLeft = if ($miniPlayerContent.Success) { [int]$miniPlayerContent.Groups[1].Value } else { $left }
+$tapTop = if ($miniPlayerContent.Success) { [int]$miniPlayerContent.Groups[2].Value } else { $top }
+$tapRight = if ($miniPlayerContent.Success) { [int]$miniPlayerContent.Groups[3].Value } else { $right }
+$tapBottom = if ($miniPlayerContent.Success) { [int]$miniPlayerContent.Groups[4].Value } else { $bottom }
+$x = [int](($tapLeft + $tapRight) / 2)
+$y = $tapTop + [int]([Math]::Min(64, ($tapBottom - $tapTop) / 2))
 Invoke-Adb @("shell", "input", "tap", "$x", "$y") | Out-Null
 Start-Sleep -Seconds 3
 


### PR DESCRIPTION
修复平板窄屏底栏与迷你播放器几何、队列布局误识别，并将模块版本升级到 1.3.6（versionCode 93）。验证：全量 JVM、Debug/Release 构建、Release lint、git diff --check，以及 emulator-5554 收起/展开 bounds 回归均通过。