### PR TITLE
fix: preserve lyric blur around instrumental rows

### DIFF
--- a/app/src/main/java/dev/amenhancer/module/hook/BidirectionalBlurPolicy.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/BidirectionalBlurPolicy.kt
@@ -28,10 +28,25 @@ internal object BidirectionalBlurPolicy {
     fun selectInstrumentalGapAnchor(
         active: Set<Int>,
         isGap: Boolean,
+        isOpeningHighlight: Boolean,
         instrumentalPositions: List<Int>,
+        visiblePositions: List<Int>,
     ): Int {
-        if (active.isNotEmpty() && !isGap) return -1
         val referencePosition = active.maxOrNull()
+        if (active.isNotEmpty() && !isGap) {
+            if (!isOpeningHighlight) return -1
+            val earliestVisible = visiblePositions
+                .asSequence()
+                .filter { position -> position >= 0 }
+                .minOrNull()
+                ?: return -1
+            if (!active.contains(earliestVisible)) return -1
+            return instrumentalPositions
+                .asSequence()
+                .filter { position -> position >= 0 && position < earliestVisible }
+                .maxOrNull()
+                ?: -1
+        }
         return instrumentalPositions
             .asSequence()
             .filter { position -> position >= 0 }

--- a/app/src/main/java/dev/amenhancer/module/hook/LyricBlurRenderer.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/LyricBlurRenderer.kt
@@ -71,7 +71,6 @@ internal class LyricBlurRenderer {
     fun clear(view: View) {
         transitions.remove(view)
         view.setRenderEffect(null)
-        view.alpha = 1f
     }
 
     fun clearAll() {

--- a/app/src/main/java/dev/amenhancer/module/hook/LyricHighlightSession.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/LyricHighlightSession.kt
@@ -6,6 +6,11 @@ internal class LyricHighlightSession {
     private val highlightedLineIds = mutableSetOf<Int>()
     private val completedOverlapLineIds = mutableSetOf<Int>()
     private var gap = false
+    private var openingHighlight = false
+
+    // Explicit "first non-empty highlight since enter" state; the highlighted set alone
+    // would conflate "never highlighted" with "set empty at this moment".
+    private var hasReceivedNonEmptyHighlight = false
 
     @Synchronized
     fun enter(newToken: Any): Boolean {
@@ -14,6 +19,8 @@ internal class LyricHighlightSession {
         highlightedLineIds.clear()
         completedOverlapLineIds.clear()
         gap = false
+        openingHighlight = false
+        hasReceivedNonEmptyHighlight = false
         return true
     }
 
@@ -25,6 +32,12 @@ internal class LyricHighlightSession {
         }
         gap = false
         if (incoming == highlightedLineIds) return snapshotLocked()
+        if (!hasReceivedNonEmptyHighlight) {
+            hasReceivedNonEmptyHighlight = true
+            openingHighlight = true
+        } else {
+            openingHighlight = false
+        }
         val completedOverlap = if (
             highlightedLineIds.size > 1 && highlightedLineIds.containsAll(incoming)
         ) {
@@ -45,6 +58,17 @@ internal class LyricHighlightSession {
     @Synchronized
     fun replace(lineId: Int) {
         gap = false
+        val isRepeat = highlightedLineIds.size == 1 &&
+            completedOverlapLineIds.isEmpty() &&
+            highlightedLineIds.contains(lineId)
+        if (!isRepeat) {
+            if (!hasReceivedNonEmptyHighlight) {
+                hasReceivedNonEmptyHighlight = true
+                openingHighlight = true
+            } else {
+                openingHighlight = false
+            }
+        }
         completedOverlapLineIds.clear()
         highlightedLineIds.clear()
         highlightedLineIds.add(lineId)
@@ -55,6 +79,9 @@ internal class LyricHighlightSession {
 
     @Synchronized
     fun isGap(): Boolean = gap
+
+    @Synchronized
+    fun isOpeningHighlight(): Boolean = openingHighlight
 
     private fun snapshotLocked(): Set<Int> = highlightedLineIds + completedOverlapLineIds
 }

--- a/app/src/main/java/dev/amenhancer/module/hook/OpenSourceLyricBlurPort.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/OpenSourceLyricBlurPort.kt
@@ -250,7 +250,9 @@ internal class OpenSourceLyricBlurPort(
         val gapAnchorPosition = BidirectionalBlurPolicy.selectInstrumentalGapAnchor(
             active = activeIds,
             isGap = highlightSession.isGap(),
+            isOpeningHighlight = highlightSession.isOpeningHighlight(),
             instrumentalPositions = instrumentalRows.map { (_, position) -> position },
+            visiblePositions = visibleRows.map { (_, position) -> position },
         )
         val effectiveIds = BidirectionalBlurPolicy.resolveDisplayHighlights(
             active = activeIds,

--- a/app/src/test/java/dev/amenhancer/module/hook/BidirectionalBlurPolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/BidirectionalBlurPolicyTest.kt
@@ -49,7 +49,9 @@ class BidirectionalBlurPolicyTest {
             BidirectionalBlurPolicy.selectInstrumentalGapAnchor(
                 active = emptySet(),
                 isGap = false,
+                isOpeningHighlight = false,
                 instrumentalPositions = listOf(0),
+                visiblePositions = emptyList(),
             ),
         )
         assertEquals(
@@ -57,7 +59,9 @@ class BidirectionalBlurPolicyTest {
             BidirectionalBlurPolicy.selectInstrumentalGapAnchor(
                 active = setOf(4),
                 isGap = true,
+                isOpeningHighlight = false,
                 instrumentalPositions = listOf(5),
+                visiblePositions = listOf(3, 4, 6),
             ),
         )
         assertEquals(
@@ -65,7 +69,76 @@ class BidirectionalBlurPolicyTest {
             BidirectionalBlurPolicy.selectInstrumentalGapAnchor(
                 active = setOf(4),
                 isGap = false,
+                isOpeningHighlight = false,
                 instrumentalPositions = listOf(5),
+                visiblePositions = listOf(3, 4, 6),
+            ),
+        )
+    }
+
+    @Test
+    fun `opening highlight before the earliest visible lyric anchors the three-dot intro`() {
+        assertEquals(
+            0,
+            BidirectionalBlurPolicy.selectInstrumentalGapAnchor(
+                active = setOf(1),
+                isGap = false,
+                isOpeningHighlight = true,
+                instrumentalPositions = listOf(0),
+                visiblePositions = listOf(1, 2, 3),
+            ),
+        )
+        assertEquals(
+            -1,
+            BidirectionalBlurPolicy.selectInstrumentalGapAnchor(
+                active = setOf(1),
+                isGap = false,
+                isOpeningHighlight = true,
+                instrumentalPositions = emptyList(),
+                visiblePositions = listOf(1, 2, 3),
+            ),
+        )
+    }
+
+    @Test
+    fun `interlude geometry alone never anchors a mid-song first line`() {
+        assertEquals(
+            -1,
+            BidirectionalBlurPolicy.selectInstrumentalGapAnchor(
+                active = setOf(9),
+                isGap = false,
+                isOpeningHighlight = false,
+                instrumentalPositions = listOf(8),
+                visiblePositions = listOf(9, 10, 11),
+            ),
+        )
+    }
+
+    @Test
+    fun `opening state alone never anchors when the active line is not earliest visible`() {
+        assertEquals(
+            -1,
+            BidirectionalBlurPolicy.selectInstrumentalGapAnchor(
+                active = setOf(11),
+                isGap = false,
+                isOpeningHighlight = true,
+                instrumentalPositions = listOf(8),
+                visiblePositions = listOf(9, 10, 11),
+            ),
+        )
+    }
+
+    @Test
+    fun `mid-song instrumentals never anchor a non-gap active highlight`() {
+        assertEquals(
+            -1,
+            BidirectionalBlurPolicy.selectInstrumentalGapAnchor(
+                active = setOf(13),
+                isGap = false,
+                isOpeningHighlight = false,
+                instrumentalPositions = listOf(12),
+                // Visible lyric rows exclude the instrumental row (see applyBlur partitioning).
+                visiblePositions = listOf(13, 14, 15),
             ),
         )
     }

--- a/app/src/test/java/dev/amenhancer/module/hook/LyricBlurClearAlphaStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/LyricBlurClearAlphaStructuralRegressionTest.kt
@@ -1,0 +1,43 @@
+package dev.amenhancer.module.hook
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * STRUCTURAL EXPERIMENT TEST (no Android View test dependencies in this project):
+ * guards the single-variable experiment that [LyricBlurRenderer.clear] must stop
+ * force-writing `view.alpha = 1f` on instrumental rows. Hypothesis: that write
+ * stomps the instrumental interlude three-dot animation, which animates row alpha.
+ * [clearAll] (fragment destruction) is deliberately out of scope and keeps its write.
+ */
+class LyricBlurClearAlphaStructuralRegressionTest {
+    private val rendererSource: String by lazy {
+        sourceFile("LyricBlurRenderer.kt").readText()
+    }
+
+    private val clearBody: String by lazy {
+        rendererSource.substringAfter("fun clear(view: View)")
+            .substringBefore("fun clearAll()")
+    }
+
+    @Test
+    fun `instrumental row clear path stops force-writing alpha`() {
+        assertFalse(
+            "LyricBlurRenderer.clear() must not write view.alpha = 1f; it may stomp the interlude dot animation",
+            clearBody.contains("view.alpha = 1f"),
+        )
+    }
+
+    @Test
+    fun `clear path keeps its blur state and render effect duties`() {
+        assertTrue(clearBody.contains("transitions.remove(view)"))
+        assertTrue(clearBody.contains("view.setRenderEffect(null)"))
+    }
+
+    private fun sourceFile(name: String): File = sequenceOf(
+        File("src/main/java/dev/amenhancer/module/hook/$name"),
+        File("app/src/main/java/dev/amenhancer/module/hook/$name"),
+    ).firstOrNull(File::isFile) ?: error("$name was not found from the unit-test working directory")
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/LyricHighlightSessionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/LyricHighlightSessionTest.kt
@@ -113,6 +113,99 @@ class LyricHighlightSessionTest {
     }
 
     @Test
+    fun `initial empty callbacks do not count as the opening highlight`() {
+        val session = LyricHighlightSession()
+        val song = Any()
+
+        assertTrue(session.enter(song))
+        assertFalse(session.isOpeningHighlight())
+        session.update(emptySet())
+        assertFalse(session.isOpeningHighlight())
+        session.update(emptySet())
+        assertFalse(session.isOpeningHighlight())
+    }
+
+    @Test
+    fun `the first non-empty update marks the opening highlight`() {
+        val session = LyricHighlightSession()
+
+        session.update(emptySet())
+        assertFalse(session.isOpeningHighlight())
+
+        session.update(setOf(46))
+        assertTrue(session.isOpeningHighlight())
+    }
+
+    @Test
+    fun `repeating the first snapshot keeps the opening highlight`() {
+        val session = LyricHighlightSession()
+
+        session.update(setOf(46))
+        assertTrue(session.isOpeningHighlight())
+
+        session.update(setOf(46))
+        assertTrue(session.isOpeningHighlight())
+
+        session.update(emptySet())
+        assertTrue(session.isOpeningHighlight())
+
+        session.update(setOf(46))
+        assertTrue(session.isOpeningHighlight())
+    }
+
+    @Test
+    fun `the next distinct snapshot clears the opening highlight`() {
+        val session = LyricHighlightSession()
+
+        session.update(setOf(46))
+        assertTrue(session.isOpeningHighlight())
+
+        session.update(setOf(47))
+        assertFalse(session.isOpeningHighlight())
+    }
+
+    @Test
+    fun `fallback replacement as the first highlight marks the opening`() {
+        val session = LyricHighlightSession()
+
+        session.update(emptySet())
+        session.replace(47)
+        assertTrue(session.isOpeningHighlight())
+
+        session.replace(47)
+        assertTrue(session.isOpeningHighlight())
+    }
+
+    @Test
+    fun `fallback replacement after a real highlight clears the opening`() {
+        val session = LyricHighlightSession()
+
+        session.update(setOf(46))
+        assertTrue(session.isOpeningHighlight())
+
+        session.replace(47)
+        assertFalse(session.isOpeningHighlight())
+    }
+
+    @Test
+    fun `entering another song resets the opening highlight`() {
+        val session = LyricHighlightSession()
+        val firstSong = Any()
+        val nextSong = Any()
+
+        session.enter(firstSong)
+        session.update(setOf(46))
+        assertTrue(session.isOpeningHighlight())
+
+        assertTrue(session.enter(nextSong))
+        assertFalse(session.isOpeningHighlight())
+        session.update(emptySet())
+        assertFalse(session.isOpeningHighlight())
+        session.update(setOf(1))
+        assertTrue(session.isOpeningHighlight())
+    }
+
+    @Test
     fun `song boundaries use pointer identity rather than value equality`() {
         val session = LyricHighlightSession()
         val firstWrapper = EqualToken(7)


### PR DESCRIPTION
修复歌词模糊与间奏三个点相关的问题：

- 移除 LyricBlurRenderer.clear() 对 instrumental 行的 lpha = 1f 强制写入，避免打断 Apple 原生三个点动画（出现→消失→再出现）。
- 修复歌曲开头存在 instrumental 三个点时，其后第一句未进入预期模糊的问题：仅当本首歌首个非空高亮且该高亮为最早可见歌词、前方存在 instrumental 行时，三个点作为清晰锚点。
- 补充会话状态、策略回归和结构实验测试。

验证：定向/全量 JVM、Release、lint 均通过；设备上用户确认间奏动画与开头三个点行为正常。