### PR TITLE
release: AM++ 1.4.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,8 +35,8 @@ android {
         applicationId = "dev.amenhancer.module"
         minSdk = 26
         targetSdk = 37
-        versionCode = 96
-        versionName = "1.3.9"
+        versionCode = 97
+        versionName = "1.4.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/dev/amenhancer/module/hook/LyricBlurRenderer.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/LyricBlurRenderer.kt
@@ -32,10 +32,6 @@ internal class LyricBlurRenderer {
             .toList()
             .forEach(::clear)
         targets.forEach { (view, target) ->
-            if (target <= 0f) {
-                clear(view)
-                return@forEach
-            }
             val state = transitions[view]
             val current = state?.radiusAt(now) ?: 0f
             if (state != null && state.targetRadius == target) return@forEach
@@ -88,6 +84,7 @@ internal class LyricBlurRenderer {
     private fun renderFrame(nowMs: Long) {
         var needsAnotherFrame = false
         transitions.forEach { (view, state) ->
+            if (state.startRadius == state.targetRadius) return@forEach
             val radius = state.radiusAt(nowMs)
             val quantized = BidirectionalBlurPolicy.quantize(radius)
             if (quantized != state.appliedRadius) {
@@ -98,7 +95,6 @@ internal class LyricBlurRenderer {
                 needsAnotherFrame = true
             } else {
                 state.startRadius = state.targetRadius
-                state.startedAtMs = nowMs
             }
         }
         if (needsAnotherFrame) scheduleFrame()

--- a/app/src/test/java/dev/amenhancer/module/hook/FutureLyricBlurStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/FutureLyricBlurStructuralRegressionTest.kt
@@ -59,12 +59,40 @@ class FutureLyricBlurStructuralRegressionTest {
     }
 
     @Test
-    fun `highlighted rows clear immediately while nonzero blur still animates`() {
-        val compactRenderer = rendererSource.replace(Regex("\\s+"), " ")
+    fun `highlighted rows transition to zero radius instead of clearing immediately`() {
+        val animateToBody = rendererSource
+            .substringAfter("fun animateTo(")
+            .substringBefore("fun applyImmediately(")
+        val compactBody = animateToBody.replace(Regex("\\s+"), " ")
 
-        assertTrue(compactRenderer.contains("if (target <= 0f) { clear(view) return@forEach }"))
-        assertTrue(rendererSource.contains("Transition("))
-        assertTrue(rendererSource.contains("scheduleFrame()"))
+        assertFalse("animateTo must not clear target views directly", compactBody.contains("clear("))
+        assertFalse("animateTo must not special-case zero targets", compactBody.contains("target <= 0f"))
+        assertTrue("zero targets still build a Transition through the shared path", compactBody.contains("targetRadius = target"))
+        assertTrue("transitions are driven by the shared frame callback", rendererSource.contains("scheduleFrame()"))
+    }
+
+    @Test
+    fun `settled transitions converge without rewinding timing or re-arming frames`() {
+        val renderFrameBody = rendererSource
+            .substringAfter("private fun renderFrame(")
+            .substringBefore("private fun applyRadius(")
+        val compactBody = renderFrameBody.replace(Regex("\\s+"), " ")
+
+        assertTrue("completion must converge startRadius onto targetRadius", compactBody.contains("state.startRadius = state.targetRadius"))
+        assertFalse("completion must not rewind startedAtMs", compactBody.contains("startedAtMs = nowMs"))
+        assertTrue("stable transitions must be skipped so they cannot re-arm the frame", compactBody.contains("state.startRadius == state.targetRadius"))
+        assertTrue("frames are only re-armed while a transition is unfinished", compactBody.contains("if (needsAnotherFrame) scheduleFrame()"))
+    }
+
+    @Test
+    fun `applyRadius settles a zero quantized radius onto a null render effect`() {
+        val applyRadiusBody = rendererSource
+            .substringAfter("private fun applyRadius(")
+            .substringBefore("private fun scheduleFrame(")
+        val compactBody = applyRadiusBody.replace(Regex("\\s+"), " ")
+
+        assertTrue("a settled zero radius must map to a null effect", compactBody.contains("if (quantized == 0) { null }"))
+        assertTrue("the resolved effect must reach the view", compactBody.contains("view.setRenderEffect(effect)"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- animate lyric blur transitions from a non-zero radius to clear over the existing 300ms frame transition
- stop settled blur transitions from re-arming Choreographer frames
- bump the module to version 1.4.0 (versionCode 97)

## Validation
- :app:testDebugUnitTest --offline --no-daemon
- :app:assembleDebug --offline --no-daemon
- :app:assembleRelease --offline --no-daemon
- :app:lintVitalRelease --offline --no-daemon
- git diff --check