### PR TITLE
release: AM++ 1.4.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,8 +35,8 @@ android {
         applicationId = "dev.amenhancer.module"
         minSdk = 26
         targetSdk = 37
-        versionCode = 98
-        versionName = "1.4.1"
+        versionCode = 99
+        versionName = "1.4.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicCustomLyricsTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicCustomLyricsTarget.kt
@@ -98,16 +98,20 @@ internal class AppleMusicCustomLyricsTarget(
             ),
             logger = ModernXposedRuntime::log,
         )
+        val fragmentUsable = fragmentIsAddedPredicate(installMethod.declaringClass)
         readyReapply = CustomLyricsReadyReapply(
             installMethod = installMethod,
             seam = seam,
             readyReplacementFor = session::readyReplacementFor,
-            isFragmentUsable = fragmentIsAddedPredicate(installMethod.declaringClass),
+            isFragmentUsable = fragmentUsable,
+            currentSong = currentSong,
             logger = ModernXposedRuntime::log,
         )
+        val itemUpdateContext = LyricsItemUpdateContext()
         val hooked = runCatching {
             ModernXposedRuntime.hookMethod(installMethod, object : ModernMethodHook() {
                 override fun beforeHookedMethod(param: MethodHookParam) {
+                    itemUpdateContext.markAppleInvokedI2()
                     runCatching {
                         if (!acceptsLyricsInstallArguments(param.args, ptrClass)) return@runCatching
                         val original = param.args[0]
@@ -157,6 +161,62 @@ internal class AppleMusicCustomLyricsTarget(
                 "PlayerLyricsViewFragment.I2 could not be hooked; ${installMethodResolution.summary}",
             )
         }
+        val itemUpdateResolution = symbols.resolve(AppleMusicSymbols.LyricsItemUpdateMethod)
+        val itemUpdateMethod = itemUpdateResolution.valueOrNull()
+        if (itemUpdateMethod != null) {
+            val coordinator = runCatching {
+                LyricsItemUpdateCoordinator(
+                    installMethod = installMethod,
+                    flags = ItemUpdateFlags(itemUpdateMethod.parameterTypes[2]),
+                    seam = seam,
+                    readyReplacementFor = session::readyReplacementFor,
+                    isTracking = session::isTracking,
+                    isFragmentUsable = fragmentUsable,
+                    readyReapply = readyReapply,
+                    logger = ModernXposedRuntime::log,
+                )
+            }.getOrNull()
+            if (coordinator != null) {
+                val itemUpdateHooked = runCatching {
+                    ModernXposedRuntime.hookMethod(itemUpdateMethod, object : ModernMethodHook() {
+                        override fun beforeHookedMethod(param: MethodHookParam) {
+                            itemUpdateContext.enterO2()
+                        }
+
+                        override fun afterHookedMethod(param: MethodHookParam) {
+                            try {
+                                val fragment = param.thisObject
+                                val appleInvokedI2 = itemUpdateContext.appleInvokedI2DuringO2()
+                                val flagsHolder = param.args.getOrNull(2)
+                                itemUpdateContext.reentering {
+                                    runCatching {
+                                        fragment?.let { currentFragment ->
+                                            coordinator.onItemUpdate(
+                                                fragment = currentFragment,
+                                                flagsHolder = flagsHolder,
+                                                appleInvokedI2 = appleInvokedI2,
+                                            )
+                                        }
+                                    }.onFailure { error ->
+                                        ModernXposedRuntime.log(
+                                            "custom lyrics item update hook failed: $error",
+                                        )
+                                    }
+                                }
+                            } finally {
+                                itemUpdateContext.exitO2()
+                            }
+                        }
+                    })
+                }.isSuccess
+                if (!itemUpdateHooked) {
+                    ModernXposedRuntime.log(
+                        "PlayerLyricsViewFragment.o2 could not be hooked; " +
+                            itemUpdateResolution.summary,
+                    )
+                }
+            }
+        }
         val availabilityResolution = symbols.resolve(AppleMusicSymbols.LyricsAvailabilityPredicate)
         val availabilityMethod = availabilityResolution.valueOrNull()
         val availabilityHooked = availabilityMethod != null && runCatching {
@@ -200,6 +260,7 @@ internal class AppleMusicCustomLyricsTarget(
                 listOf(
                     installMethodResolution.summary,
                     availabilityResolution.summary,
+                    itemUpdateResolution.summary,
                     ptrResolution.summary,
                     nativeResolution.summary,
                     parserResolution.summary,

--- a/app/src/main/java/dev/amenhancer/module/hook/CustomLyricsReadyReapply.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/CustomLyricsReadyReapply.kt
@@ -10,8 +10,16 @@ import java.lang.reflect.Method
  * background session publishes the replacement pointer and this ledger is
  * invoked, every still-live waiting entry for that ID is consumed and I2 is
  * re-entered with the ready replacement — but only while the same fragment
- * is still usable, still reports the same Apple Music ID, and the
- * replacement is still ready.
+ * is still usable, the replacement is still ready, and the fragment still
+ * reports the same Apple Music ID. The ready replacement is confirmed before
+ * any identity read or rebind, so a stale fragment is never rebound for an
+ * ID whose replacement is no longer ready. A fragment that still reports the
+ * previous song may then be rebound to the exact published current item,
+ * using the same recently-current identity guard as the I2 hook, so an
+ * I2(null) entry recorded while the new song's mapping was still preparing
+ * can still be applied; when the replacement is missing or any guard fails,
+ * the fragment identity is left untouched and the entry is dropped with the
+ * native pointer staying installed.
  *
  * The ledger is keyed by fragment identity, never equals, so a replacement
  * fragment with equal state can never be confused with the recorded one.
@@ -28,6 +36,7 @@ internal class CustomLyricsReadyReapply(
     private val seam: CurrentItemIdentitySeam,
     private val readyReplacementFor: (Long) -> Any?,
     private val isFragmentUsable: (Any) -> Boolean,
+    private val currentSong: CurrentSongIdentityCache,
     private val logger: (String) -> Unit,
 ) {
     /**
@@ -89,13 +98,41 @@ internal class CustomLyricsReadyReapply(
         for (fragment in waiting) {
             try {
                 if (!isFragmentUsable(fragment)) continue
-                if (seam.currentItemAdamIdOf(fragment) != appleMusicId) continue
                 val replacement = readyReplacementFor(appleMusicId) ?: continue
+                val fragmentAdamId = seam.currentItemAdamIdOf(fragment)
+                var rebound = false
+                if (fragmentAdamId != appleMusicId) {
+                    rebound = rebindStaleFragmentToCurrent(fragment, fragmentAdamId, appleMusicId)
+                    if (!rebound) continue
+                }
                 installMethod.invoke(fragment, replacement)
             } catch (error: Throwable) {
                 logger("custom lyrics ready-late re-entry failed: $error")
             }
         }
+    }
+
+    /**
+     * Rebinds a stale lyrics fragment to the exact published current item
+     * before ready-late re-entry. Called only after the ready replacement has
+     * been confirmed and with the already-read [fragmentAdamId], so no second
+     * identity reflection is needed. The fragment is rebound only when the
+     * verified current song is exactly [appleMusicId] and the fragment's
+     * stale identity was itself recently observed as current — the same
+     * identity guard the I2 hook applies — and the exact current item can be
+     * bound; otherwise the fragment identity is left untouched, the entry is
+     * dropped and the native pointer stays.
+     */
+    private fun rebindStaleFragmentToCurrent(
+        fragment: Any,
+        fragmentAdamId: Long?,
+        appleMusicId: Long,
+    ): Boolean {
+        val published = currentSong.current() ?: return false
+        val publishedAdamId = published.details.appleMusicId
+        if (publishedAdamId != appleMusicId) return false
+        if (!currentSong.canRebind(fragmentAdamId, publishedAdamId)) return false
+        return seam.bindCurrentItemOf(fragment, published.item)
     }
 
     /** Removes entries whose fragment has been collected. Must hold [pending]. */

--- a/app/src/main/java/dev/amenhancer/module/hook/LyricsItemUpdateCoordinator.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/LyricsItemUpdateCoordinator.kt
@@ -1,0 +1,241 @@
+package dev.amenhancer.module.hook
+
+import java.lang.ref.WeakReference
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+
+/**
+ * Phase 152 natural-transition lyrics refresh seam. Apple's
+ * `PlayerLyricsViewFragment.o2` receives every playback metadata publish with
+ * a context item and a per-version flags holder whose `a` field is Apple's own
+ * item-changed signal. On 6.5.1 the context item is a Playlist (`pl.*` id), not
+ * the track Adam ID; after Apple's body returns, the fragment's verified
+ * current-item field is the authoritative track identity. Apple's native tail
+ * only calls I2 while the adapter still has no rows, so a natural A→B
+ * transition with stale rows never installs B's pointer. This coordinator
+ * re-enters the exact I2 path after Apple has updated that field — with the
+ * ready replacement when one exists, or through the ready-late ledger when B
+ * is still preparing — and otherwise leaves Apple's behavior untouched.
+ *
+ * The hook path is pure coordination: no IO, no network, no native parse, no
+ * lyric-state mutation. [decideLyricsItemUpdate] rejects same-item metadata
+ * refreshes, o2 calls whose tail already invoked I2 (Apple's own install),
+ * untracked songs, dead fragments and invalid ids; every other gate fails
+ * open. The handled-id ledger is keyed by fragment identity, never equals,
+ * holds fragments weakly and is bounded, so a replacement fragment with equal
+ * state can never be confused with a handled one and repeated same-item
+ * metadata publishes cannot loop I2.
+ */
+internal class LyricsItemUpdateCoordinator(
+    private val installMethod: Method,
+    private val flags: ItemUpdateFlags,
+    private val seam: CurrentItemIdentitySeam,
+    private val readyReplacementFor: (Long) -> Any?,
+    private val isTracking: (Long) -> Boolean,
+    private val isFragmentUsable: (Any) -> Boolean,
+    private val readyReapply: CustomLyricsReadyReapply,
+    private val logger: (String) -> Unit,
+) {
+    private val handled = mutableListOf<HandledItem>()
+
+    /**
+     * o2 after-hook entry: reads Apple's verified item-changed flag from the
+     * flags holder, then reads the exact current item from the fragment field
+     * after Apple's body has updated it. It either re-enters I2 with the ready
+     * replacement or records a ready-late miss. All failures fail open,
+     * leaving the native pointer path untouched.
+     */
+    fun onItemUpdate(fragment: Any, flagsHolder: Any?, appleInvokedI2: Boolean) {
+        val itemChanged = flags.isItemChanged(flagsHolder)
+        val appleMusicId = if (itemChanged) seam.currentItemAdamIdOf(fragment) else null
+        val replacement = if (appleMusicId == null) null else readyReplacementFor(appleMusicId)
+        when (
+            decideLyricsItemUpdate(
+                itemChanged = itemChanged,
+                appleInvokedI2 = appleInvokedI2,
+                fragmentUsable = isFragmentUsable(fragment),
+                itemAdamId = appleMusicId,
+                previouslyHandledAdamId = handledAdamIdOf(fragment),
+                tracked = appleMusicId != null && isTracking(appleMusicId),
+                replacementReady = replacement != null,
+            )
+        ) {
+            LyricsItemUpdateAction.IGNORE -> Unit
+            LyricsItemUpdateAction.RECORD_MISS -> {
+                val appleMusicId = appleMusicId ?: return
+                recordHandled(fragment, appleMusicId)
+                readyReapply.recordMiss(fragment, appleMusicId)
+            }
+            LyricsItemUpdateAction.REENTER -> {
+                val appleMusicId = appleMusicId ?: return
+                recordHandled(fragment, appleMusicId)
+                readyReapply.dismiss(fragment)
+                if (replacement == null) {
+                    readyReapply.recordMiss(fragment, appleMusicId)
+                } else {
+                    try {
+                        installMethod.invoke(fragment, replacement)
+                    } catch (error: Throwable) {
+                        logger("custom lyrics item update re-entry failed: $error")
+                    }
+                }
+            }
+        }
+    }
+
+    private fun handledAdamIdOf(fragment: Any): Long? = synchronized(handled) {
+        sweepCleared()
+        handled.firstOrNull { it.key.get() === fragment }?.appleMusicId
+    }
+
+    private fun recordHandled(fragment: Any, appleMusicId: Long) {
+        synchronized(handled) {
+            sweepCleared()
+            handled.firstOrNull { it.key.get() === fragment }?.let { existing ->
+                existing.appleMusicId = appleMusicId
+                return@synchronized
+            }
+            if (handled.size >= MAX_HANDLED) handled.removeAt(0)
+            handled += HandledItem(FragmentKey(fragment), appleMusicId)
+        }
+    }
+
+    private fun sweepCleared() {
+        val iterator = handled.iterator()
+        while (iterator.hasNext()) {
+            if (iterator.next().key.get() == null) {
+                iterator.remove()
+            }
+        }
+    }
+
+    private data class HandledItem(
+        val key: FragmentKey,
+        var appleMusicId: Long,
+    )
+
+    /**
+     * The list owns this wrapper, while the wrapper owns only a weak reference
+     * to the Fragment — the same identity-keying pattern as the ready-late
+     * ledger, so a dead fragment cannot keep an entry alive.
+     */
+    private class FragmentKey(referent: Any) : WeakReference<Any>(referent)
+
+    private companion object {
+        const val MAX_HANDLED = 16
+    }
+}
+
+/**
+ * Reads the verified item-changed flag (`a`) from Apple's per-version o2
+ * flags holder (`e$c` on 6.5.0, `d$c` on 6.5.1). The field is public,
+ * non-static, boolean and declared on the exact flags type carried by the
+ * resolved o2 method, so a holder of any other shape is rejected.
+ */
+internal class ItemUpdateFlags(flagsType: Class<*>) {
+    private val changedField: Field = flagsType.getField("a").apply {
+        require(!Modifier.isStatic(modifiers) && type == java.lang.Boolean.TYPE)
+        isAccessible = true
+    }
+
+    fun isItemChanged(flagsHolder: Any?): Boolean =
+        flagsHolder != null && runCatching { changedField.getBoolean(flagsHolder) }
+            .getOrDefault(false)
+}
+
+internal enum class LyricsItemUpdateAction {
+    /** Leave Apple's own behavior untouched. */
+    IGNORE,
+
+    /** Re-enter the exact I2 path with the ready replacement now. */
+    REENTER,
+
+    /** The replacement is still preparing; hand the fragment to the ready-late ledger. */
+    RECORD_MISS,
+}
+
+/**
+ * Pure item-update decision. The verified flags `a` field is Apple's own
+ * item-changed signal; the previously-handled id prevents repeated I2 on
+ * same-item metadata updates; an o2 call whose tail already invoked I2 needs
+ * no module re-entry; untracked songs, unusable fragments and invalid ids
+ * keep the native path untouched.
+ */
+internal fun decideLyricsItemUpdate(
+    itemChanged: Boolean,
+    appleInvokedI2: Boolean,
+    fragmentUsable: Boolean,
+    itemAdamId: Long?,
+    previouslyHandledAdamId: Long?,
+    tracked: Boolean,
+    replacementReady: Boolean,
+): LyricsItemUpdateAction {
+    if (!itemChanged || appleInvokedI2 || !fragmentUsable) return LyricsItemUpdateAction.IGNORE
+    val id = itemAdamId ?: return LyricsItemUpdateAction.IGNORE
+    if (id <= 0L) return LyricsItemUpdateAction.IGNORE
+    if (id == previouslyHandledAdamId) return LyricsItemUpdateAction.IGNORE
+    if (!tracked) return LyricsItemUpdateAction.IGNORE
+    return if (replacementReady) {
+        LyricsItemUpdateAction.REENTER
+    } else {
+        LyricsItemUpdateAction.RECORD_MISS
+    }
+}
+
+/**
+ * Minimal thread-local o2 update context shared by the I2 and o2 hooks. Apple
+ * calls I2 from inside the o2 body on the same thread; the marker set by the
+ * I2 hook is consumed by the o2 after-hook so a re-entry is never added on
+ * top of Apple's own install. Module re-entries run under [reentering] so
+ * they never mark the context, and the marker is cleared on every o2 entry so
+ * an I2 invocation outside an o2 call can never leak into the next one.
+ */
+internal class LyricsItemUpdateContext {
+    private val threadState: ThreadLocal<O2State> = ThreadLocal.withInitial { O2State() }
+
+    fun enterO2() {
+        val state = currentState()
+        state.insideO2 = true
+        state.appleInvokedI2 = false
+    }
+
+    fun exitO2() {
+        val state = currentState()
+        state.insideO2 = false
+        state.appleInvokedI2 = false
+    }
+
+    fun markAppleInvokedI2() {
+        val state = currentState()
+        if (state.insideO2 && !state.reentering) state.appleInvokedI2 = true
+    }
+
+    /** Reads and consumes the marker, so it is reported for at most one o2 call. */
+    fun appleInvokedI2DuringO2(): Boolean {
+        val state = currentState()
+        val reported = state.appleInvokedI2
+        state.appleInvokedI2 = false
+        return reported
+    }
+
+    fun <T> reentering(block: () -> T): T {
+        val state = currentState()
+        state.reentering = true
+        try {
+            return block()
+        } finally {
+            state.reentering = false
+        }
+    }
+
+    private fun currentState(): O2State = threadState.get() ?: O2State().also {
+        threadState.set(it)
+    }
+
+    private class O2State {
+        var insideO2 = false
+        var appleInvokedI2 = false
+        var reentering = false
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/hook/TargetSymbols.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/TargetSymbols.kt
@@ -254,6 +254,7 @@ internal enum class TargetSymbolId {
     SONG_INFO_NATIVE,
     TTML_PARSER_NATIVE,
     LYRICS_CURRENT_ITEM_FIELD,
+    LYRICS_ITEM_UPDATE_METHOD,
     PLAYER_METADATA_HUB,
     METADATA_TO_ITEM_CONVERTER,
     LYRICS_AVAILABILITY_OWNER,
@@ -292,6 +293,7 @@ private object AppleMusicProfiles {
         exactMethods = mapOf(
             TargetSymbolId.PLAYER_ACTIVITY_CREATE_STACKED_NAVIGATION_HOLDER to "k1",
             TargetSymbolId.PLAYER_ACTIVITY_ROOT to "n0",
+            TargetSymbolId.LYRICS_ITEM_UPDATE_METHOD to "o2",
         ),
         exactFields = mapOf(
             TargetSymbolId.PLAYER_ACTIVITY_BEHAVIOR_FIELD to "c1",
@@ -330,6 +332,7 @@ private object AppleMusicProfiles {
         exactMethods = mapOf(
             TargetSymbolId.PLAYER_ACTIVITY_CREATE_STACKED_NAVIGATION_HOLDER to "j1",
             TargetSymbolId.PLAYER_ACTIVITY_ROOT to "l1",
+            TargetSymbolId.LYRICS_ITEM_UPDATE_METHOD to "o2",
         ),
         exactFields = mapOf(
             TargetSymbolId.PLAYER_ACTIVITY_BEHAVIOR_FIELD to "c1",
@@ -619,6 +622,26 @@ internal object AppleMusicSymbols {
         profileOwner = TargetSymbolId.LYRICS_FRAGMENT,
         fallbackOwner = { it.endsWith(".PlayerLyricsViewFragment") },
         contract = ::isLyricsInstallMethod,
+    )
+
+    /**
+     * PlayerLyricsViewFragment.o2(v3.v, BaseContentItem, flags$c) — the
+     * natural-transition item update entry point. The contract requires the
+     * exact name "o2", the verified v3.v and BaseContentItem parameter types,
+     * and a flags holder declared as a member of the fragment's immediate
+     * superclass whose only boolean fields are exactly {a, b, c}; Apple's own
+     * item-changed signal is the flags holder's `a` field. A version whose
+     * o2 shape differs resolves Missing or Ambiguous instead of silently
+     * selecting an unrelated method.
+     */
+    val LyricsItemUpdateMethod = methodSymbol(
+        id = "lyrics-item-update-method",
+        profileOwner = TargetSymbolId.LYRICS_FRAGMENT,
+        profilePolicy = ProfilePolicy.EXACT_PREFERRED,
+        exactMethodId = TargetSymbolId.LYRICS_ITEM_UPDATE_METHOD,
+        fallbackOwner = { it.endsWith(".PlayerLyricsViewFragment") },
+        contract = ::isLyricsItemUpdateMethod,
+        structuralContract = ::isLyricsItemUpdateMethod,
     )
 
     val PlayerMetadataPublishMethod = TargetSymbolKey(
@@ -1001,6 +1024,34 @@ private fun isLyricsInstallMethod(method: Method): Boolean =
         method.parameterTypes[0].name.endsWith(
             ".ttml.javanative.model.SongInfo\$SongInfoPtr",
         )
+
+/**
+ * The verified o2 contract: exact name, void return, the v3.v metadata type,
+ * the BaseContentItem current item, and a flags holder declared as a member
+ * of the fragment's immediate superclass whose non-static boolean fields are
+ * exactly {a, b, c}. Both verified profiles (6.5.0 `e$c`, 6.5.1 `d$c`) carry
+ * that exact shape, so the contract can never silently select an unrelated
+ * three-argument method.
+ */
+private fun isLyricsItemUpdateMethod(method: Method): Boolean =
+    !Modifier.isStatic(method.modifiers) &&
+        method.name == "o2" &&
+        method.returnType == Void.TYPE &&
+        method.parameterTypes.size == 3 &&
+        method.parameterTypes[0].name == "v3.v" &&
+        method.parameterTypes[1].name == "com.apple.android.music.model.BaseContentItem" &&
+        isLyricsItemUpdateFlagsType(method.parameterTypes[2], method.declaringClass)
+
+private fun isLyricsItemUpdateFlagsType(flagsType: Class<*>, fragmentType: Class<*>): Boolean {
+    val base = fragmentType.superclass ?: return false
+    if (flagsType.declaringClass != base) return false
+    if (base.declaredClasses.none { it == flagsType }) return false
+    val booleanFields = flagsType.declaredFields
+        .filter { !Modifier.isStatic(it.modifiers) && it.type == java.lang.Boolean.TYPE }
+        .map(Field::getName)
+        .toSet()
+    return booleanFields == setOf("a", "b", "c")
+}
 
 private fun isPlayerMetadataPublishMethod(method: Method): Boolean =
     !Modifier.isStatic(method.modifiers) &&

--- a/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsItemUpdateStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsItemUpdateStructuralRegressionTest.kt
@@ -1,0 +1,116 @@
+package dev.amenhancer.module.hook
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Phase 152 item-update (o2) hook contract tests: the o2 seam resolves only
+ * through the profile-backed symbol, re-enters the exact I2 path with a ready
+ * replacement after Apple has updated the current item, records ready-late
+ * misses otherwise, and never performs IO, native parsing, or lyric-state
+ * mutation on the hook path.
+ */
+class CustomLyricsItemUpdateStructuralRegressionTest {
+    private fun projectFile(relativePath: String): String = sequenceOf(
+        File(relativePath),
+        File("../$relativePath"),
+    ).firstOrNull(File::isFile)?.readText()
+        ?: error("$relativePath was not found from the unit-test working directory")
+
+    @Test
+    fun `o2 hook resolves the profile backed symbol and registers after i2`() {
+        val target = projectFile(
+            "app/src/main/java/dev/amenhancer/module/hook/AppleMusicCustomLyricsTarget.kt",
+        )
+        val symbols = projectFile(
+            "app/src/main/java/dev/amenhancer/module/hook/TargetSymbols.kt",
+        )
+
+        assertTrue(target.contains("AppleMusicSymbols.LyricsItemUpdateMethod"))
+        assertTrue(target.contains("LyricsItemUpdateCoordinator("))
+        assertTrue(
+            target.indexOf("AppleMusicSymbols.LyricsInstallMethod") <
+                target.indexOf("AppleMusicSymbols.LyricsItemUpdateMethod"),
+        )
+        assertTrue(symbols.contains("LyricsItemUpdateMethod"))
+        assertTrue(symbols.contains("TargetSymbolId.LYRICS_ITEM_UPDATE_METHOD"))
+        assertEquals(
+            2,
+            Regex("TargetSymbolId\\.LYRICS_ITEM_UPDATE_METHOD to \"o2\"").findAll(symbols).count(),
+        )
+    }
+
+    @Test
+    fun `o2 hook enters a thread local context before apple and exits after`() {
+        val target = projectFile(
+            "app/src/main/java/dev/amenhancer/module/hook/AppleMusicCustomLyricsTarget.kt",
+        )
+
+        assertTrue(target.contains("itemUpdateContext.enterO2()"))
+        assertTrue(target.contains("itemUpdateContext.exitO2()"))
+        assertTrue(target.contains("itemUpdateContext.appleInvokedI2DuringO2()"))
+        assertTrue(target.contains("itemUpdateContext.markAppleInvokedI2()"))
+    }
+
+    @Test
+    fun `o2 hook coordinates the exact current item and flags holder after apple ran`() {
+        val target = projectFile(
+            "app/src/main/java/dev/amenhancer/module/hook/AppleMusicCustomLyricsTarget.kt",
+        )
+        val o2Hook = target.substringAfter(
+            "override fun afterHookedMethod(param: MethodHookParam)",
+        )
+
+        assertTrue(o2Hook.contains("coordinator.onItemUpdate("))
+        assertTrue(o2Hook.contains("param.thisObject"))
+        assertTrue(o2Hook.contains("param.args.getOrNull(2)"))
+    }
+
+    @Test
+    fun `o2 hook path never loads lyrics writes results or hooks resume`() {
+        val target = projectFile(
+            "app/src/main/java/dev/amenhancer/module/hook/AppleMusicCustomLyricsTarget.kt",
+        )
+        val o2Hook = target.substringAfter(
+            "AppleMusicSymbols.LyricsItemUpdateMethod",
+        )
+
+        assertFalse(o2Hook.contains("loadLyrics"))
+        assertFalse(o2Hook.contains("onResume"))
+        assertFalse(o2Hook.contains("mLyricsResult"))
+        assertFalse(o2Hook.contains("openRemoteFile"))
+        assertFalse(o2Hook.contains("readTtml"))
+        assertFalse(o2Hook.contains("parseTtml"))
+        assertFalse(o2Hook.contains("HttpLyricTransport"))
+    }
+
+    @Test
+    fun `coordinator uses ready only lookup, the i2 identity seam, and the ready late ledger`() {
+        val coordinator = projectFile(
+            "app/src/main/java/dev/amenhancer/module/hook/LyricsItemUpdateCoordinator.kt",
+        )
+
+        assertTrue(coordinator.contains("fun decideLyricsItemUpdate("))
+        assertTrue(coordinator.contains("enum class LyricsItemUpdateAction"))
+        assertTrue(coordinator.contains("readyReplacementFor(appleMusicId)"))
+        assertTrue(coordinator.contains("isTracking(appleMusicId)"))
+        assertTrue(coordinator.contains("seam.currentItemAdamIdOf(fragment)"))
+        assertFalse(coordinator.contains("seam.detailsOfItem(item)"))
+        assertTrue(coordinator.contains("readyReapply.recordMiss(fragment, appleMusicId)"))
+        assertTrue(coordinator.contains("readyReapply.dismiss(fragment)"))
+        assertTrue(coordinator.contains("installMethod.invoke(fragment, replacement)"))
+        assertTrue(coordinator.contains("WeakReference<Any>"))
+        assertTrue(coordinator.contains("ThreadLocal"))
+        assertFalse(coordinator.contains("ensureRequested"))
+        assertFalse(coordinator.contains("openRemoteFile"))
+        assertFalse(coordinator.contains("readTtml"))
+        assertFalse(coordinator.contains("parseTtml"))
+        assertFalse(coordinator.contains("HttpLyricTransport"))
+        assertFalse(coordinator.contains("loadLyrics"))
+        assertFalse(coordinator.contains("onResume"))
+        assertFalse(coordinator.contains("mLyricsResult"))
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsReadyLateStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsReadyLateStructuralRegressionTest.kt
@@ -55,7 +55,12 @@ class CustomLyricsReadyLateStructuralRegressionTest {
         assertTrue(reapply.contains("synchronized(pending)"))
         assertTrue(reapply.contains("iterator.remove()"))
         assertTrue(reapply.contains("installMethod.invoke(fragment, replacement)"))
-        assertTrue(reapply.contains("seam.currentItemAdamIdOf(fragment) != appleMusicId"))
+        assertTrue(reapply.contains("val fragmentAdamId = seam.currentItemAdamIdOf(fragment)"))
+        assertTrue(reapply.contains("fragmentAdamId != appleMusicId"))
+        assertTrue(
+            reapply.indexOf("val replacement = readyReplacementFor(appleMusicId)") <
+                reapply.indexOf("val fragmentAdamId = seam.currentItemAdamIdOf(fragment)"),
+        )
         assertTrue(reapply.contains("fun dismiss(fragment: Any)"))
         assertTrue(reapply.contains("shouldRecordReadyLateMiss"))
         assertFalse(reapply.contains("IdentityHashMap<Any, Long>"))

--- a/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsReadyReapplyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CustomLyricsReadyReapplyTest.kt
@@ -1,5 +1,6 @@
 package dev.amenhancer.module.hook
 
+import dev.amenhancer.module.CurrentSongDetails
 import java.lang.ref.WeakReference
 import java.lang.reflect.Field
 import java.lang.reflect.Method
@@ -59,7 +60,7 @@ class CustomLyricsReadyReapplyTest {
     }
 
     @Test
-    fun `a changed song on the same fragment skips the stale re-entry`() {
+    fun `a changed song on the same fragment skips re-entry without verified current identity`() {
         val fragment = LyricsFragment(LyricsItem("42"))
         val pointer = Any()
         val (reapply, _) = reapply(fragment, ready = { pointer })
@@ -70,6 +71,81 @@ class CustomLyricsReadyReapplyTest {
 
         assertNull(fragment.installed)
         assertEquals(0, fragment.installs)
+    }
+
+    @Test
+    fun `ready late publish rebinds a stale fragment to the exact current item before re-entry`() {
+        val currentItem = LyricsItem("77")
+        val fragment = LyricsFragment(LyricsItem("42"))
+        val pointer = Any()
+        val cache = CurrentSongIdentityCache().apply {
+            publish(LyricsItem("42"), CurrentSongDetails(42L))
+            publish(currentItem, CurrentSongDetails(77L))
+        }
+        val (reapply, _) = reapply(fragment, ready = { pointer }, cache = cache)
+
+        reapply.recordMiss(fragment, 77L)
+        reapply.onReplacementPublished(77L)
+
+        assertTrue(fragment.c === currentItem)
+        assertSame(pointer, fragment.installed)
+        assertEquals(1, fragment.installs)
+    }
+
+    @Test
+    fun `ready late publish never rebinds a stale fragment when the replacement is no longer ready`() {
+        val currentItem = LyricsItem("77")
+        val fragment = LyricsFragment(LyricsItem("42"))
+        val cache = CurrentSongIdentityCache().apply {
+            publish(LyricsItem("42"), CurrentSongDetails(42L))
+            publish(currentItem, CurrentSongDetails(77L))
+        }
+        val (reapply, _) = reapply(fragment, cache = cache)
+
+        reapply.recordMiss(fragment, 77L)
+        reapply.onReplacementPublished(77L)
+
+        assertNull(fragment.installed)
+        assertEquals(0, fragment.installs)
+        assertEquals("42", fragment.c?.getId())
+    }
+
+    @Test
+    fun `ready late publish never rebinds from an identity that was not recently current`() {
+        val currentItem = LyricsItem("77")
+        val fragment = LyricsFragment(LyricsItem("999"))
+        val pointer = Any()
+        val cache = CurrentSongIdentityCache().apply {
+            publish(LyricsItem("42"), CurrentSongDetails(42L))
+            publish(currentItem, CurrentSongDetails(77L))
+        }
+        val (reapply, _) = reapply(fragment, ready = { pointer }, cache = cache)
+
+        reapply.recordMiss(fragment, 77L)
+        reapply.onReplacementPublished(77L)
+
+        assertNull(fragment.installed)
+        assertEquals(0, fragment.installs)
+        assertEquals("999", fragment.c?.getId())
+    }
+
+    @Test
+    fun `ready late publish never rebinds when the current song moved past the ready id`() {
+        val fragment = LyricsFragment(LyricsItem("42"))
+        val pointer = Any()
+        val cache = CurrentSongIdentityCache().apply {
+            publish(LyricsItem("42"), CurrentSongDetails(42L))
+            publish(LyricsItem("77"), CurrentSongDetails(77L))
+            publish(LyricsItem("99"), CurrentSongDetails(99L))
+        }
+        val (reapply, _) = reapply(fragment, ready = { pointer }, cache = cache)
+
+        reapply.recordMiss(fragment, 77L)
+        reapply.onReplacementPublished(77L)
+
+        assertNull(fragment.installed)
+        assertEquals(0, fragment.installs)
+        assertEquals("42", fragment.c?.getId())
     }
 
     @Test
@@ -281,6 +357,7 @@ class CustomLyricsReadyReapplyTest {
         fragment: Any,
         ready: (Long) -> Any? = { null },
         usable: (Any) -> Boolean = { true },
+        cache: CurrentSongIdentityCache = CurrentSongIdentityCache(),
     ): Pair<CustomLyricsReadyReapply, MutableList<String>> {
         val logs = mutableListOf<String>()
         val fragmentClass = fragment.javaClass
@@ -297,6 +374,7 @@ class CustomLyricsReadyReapplyTest {
             seam = seam,
             readyReplacementFor = ready,
             isFragmentUsable = usable,
+            currentSong = cache,
             logger = { logs += it },
         ) to logs
     }

--- a/app/src/test/java/dev/amenhancer/module/hook/LyricsItemUpdateCoordinatorTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/LyricsItemUpdateCoordinatorTest.kt
@@ -1,0 +1,501 @@
+package dev.amenhancer.module.hook
+
+import com.apple.android.music.model.BaseContentItem
+import dev.amenhancer.module.CurrentSongDetails
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Phase 152 item-update decision/coordinator tests: the o2 hook must only
+ * re-enter I2 for a real tracked item change after Apple's own o2 tail has
+ * run, and must never touch same-item metadata refreshes, Apple's own I2
+ * invocation, untracked songs, dead fragments or invalid ids.
+ */
+class LyricsItemUpdateCoordinatorTest {
+
+    @Test
+    fun `a real item change with a ready replacement re-enters i2 exactly once`() {
+        val fragment = ItemUpdateFragment()
+        val pointer = Any()
+        val (coordinator, reapply, _) = coordinator(fragment, ready = { pointer })
+
+        update(coordinator, fragment, "77")
+
+        assertSame(pointer, fragment.installed)
+        assertEquals(1, fragment.installs)
+    }
+
+    @Test
+    fun `the same item update never re-enters i2 twice`() {
+        val fragment = ItemUpdateFragment()
+        val pointer = Any()
+        val (coordinator, _, _) = coordinator(fragment, ready = { pointer })
+
+        update(coordinator, fragment, "77")
+        update(coordinator, fragment, "77")
+
+        assertEquals(1, fragment.installs)
+    }
+
+    @Test
+    fun `a new generation of a handled id re-enters after an intervening item`() {
+        val fragment = ItemUpdateFragment()
+        val pointer = Any()
+        var ready: Any? = pointer
+        val (coordinator, _, _) = coordinator(fragment, ready = { ready })
+
+        update(coordinator, fragment, "77")
+        ready = null
+        update(coordinator, fragment, "99")
+        ready = pointer
+        update(coordinator, fragment, "77")
+
+        assertEquals(2, fragment.installs)
+    }
+
+    @Test
+    fun `an item change without a ready replacement records a ready late miss`() {
+        val fragment = ItemUpdateFragment()
+        var ready: Any? = null
+        val pointer = Any()
+        val cache = CurrentSongIdentityCache().apply {
+            publish(item("77"), CurrentSongDetails(77L))
+        }
+        val (coordinator, reapply, _) = coordinator(fragment, ready = { ready }, cache = cache)
+
+        update(coordinator, fragment, "77")
+
+        assertNull(fragment.installed)
+        assertEquals(0, fragment.installs)
+        assertEquals(1, pending(reapply).size)
+
+        ready = pointer
+        reapply.onReplacementPublished(77L)
+
+        assertSame(pointer, fragment.installed)
+        assertEquals(1, fragment.installs)
+    }
+
+    @Test
+    fun `apple o2 tail invocation of i2 suppresses the module re-entry`() {
+        val fragment = ItemUpdateFragment()
+        val pointer = Any()
+        val (coordinator, reapply, _) = coordinator(fragment, ready = { pointer })
+
+        update(coordinator, fragment, "77", appleInvokedI2 = true)
+
+        assertEquals(0, fragment.installs)
+        assertNull(fragment.installed)
+        assertEquals(0, pending(reapply).size)
+    }
+
+    @Test
+    fun `a same item metadata refresh with the changed flag off is ignored`() {
+        val fragment = ItemUpdateFragment()
+        val pointer = Any()
+        val (coordinator, reapply, _) = coordinator(fragment, ready = { pointer })
+
+        update(coordinator, fragment, "77", changed = false)
+
+        assertEquals(0, fragment.installs)
+        assertNull(fragment.installed)
+        assertEquals(0, pending(reapply).size)
+    }
+
+    @Test
+    fun `an untracked item keeps the native path untouched`() {
+        val fragment = ItemUpdateFragment()
+        val pointer = Any()
+        val (coordinator, reapply, _) = coordinator(
+            fragment,
+            ready = { pointer },
+            tracking = { false },
+        )
+
+        update(coordinator, fragment, "77")
+
+        assertEquals(0, fragment.installs)
+        assertNull(fragment.installed)
+        assertEquals(0, pending(reapply).size)
+    }
+
+    @Test
+    fun `an unusable fragment never records a miss or re-enters`() {
+        val fragment = ItemUpdateFragment()
+        val pointer = Any()
+        val (coordinator, reapply, _) = coordinator(
+            fragment,
+            ready = { pointer },
+            usable = { false },
+        )
+
+        update(coordinator, fragment, "77")
+
+        assertEquals(0, fragment.installs)
+        assertNull(fragment.installed)
+        assertEquals(0, pending(reapply).size)
+    }
+
+    @Test
+    fun `an invalid item id is ignored`() {
+        val fragment = ItemUpdateFragment()
+        val pointer = Any()
+        val (coordinator, reapply, _) = coordinator(fragment, ready = { pointer })
+
+        update(coordinator, fragment, "0")
+
+        assertEquals(0, fragment.installs)
+        assertNull(fragment.installed)
+        assertEquals(0, pending(reapply).size)
+    }
+
+    @Test
+    fun `the handled ledger is identity based like the ready late ledger`() {
+        val first = ItemUpdateFragment()
+        val second = ItemUpdateFragment()
+        val pointer = Any()
+        val (coordinator, _, _) = coordinator(first, ready = { pointer })
+
+        update(coordinator, first, "77")
+        update(coordinator, second, "77")
+
+        assertEquals(1, first.installs)
+        assertEquals(1, second.installs)
+
+        update(coordinator, first, "77")
+        assertEquals(1, first.installs)
+    }
+
+    @Test
+    fun `a failing re-entry is logged once and fails open`() {
+        val fragment = ItemUpdateFragment(failOnInstall = true)
+        val pointer = Any()
+        val (coordinator, _, logs) = coordinator(fragment, ready = { pointer })
+
+        update(coordinator, fragment, "77")
+        update(coordinator, fragment, "77")
+
+        assertEquals(1, fragment.attempts)
+        assertEquals(1, logs.size)
+        assertTrue(logs.single().contains("item update re-entry failed"))
+    }
+
+    @Test
+    fun `re-entry dismisses pending entries so a late publish cannot double install`() {
+        val fragment = ItemUpdateFragment()
+        val pointer = Any()
+        var ready: Any? = null
+        val (coordinator, reapply, _) = coordinator(fragment, ready = { ready })
+
+        update(coordinator, fragment, "77")
+        assertEquals(1, pending(reapply).size)
+
+        ready = pointer
+        update(coordinator, fragment, "99")
+        assertSame(pointer, fragment.installed)
+        assertEquals(1, fragment.installs)
+        assertEquals(0, pending(reapply).size)
+
+        reapply.onReplacementPublished(77L)
+        assertEquals(1, fragment.installs)
+    }
+
+    @Test
+    fun `an i2 mark outside an o2 call is never seen by the next o2 call`() {
+        val context = LyricsItemUpdateContext()
+        val fragment = ItemUpdateFragment()
+        val pointer = Any()
+        val (coordinator, _, _) = coordinator(fragment, ready = { pointer })
+
+        context.markAppleInvokedI2()
+        assertFalse(context.appleInvokedI2DuringO2())
+
+        context.enterO2()
+        fragment.c = item("77")
+        coordinator.onItemUpdate(
+            fragment,
+            flagsHolder = flags(changed = true),
+            appleInvokedI2 = context.appleInvokedI2DuringO2(),
+        )
+        context.exitO2()
+
+        assertEquals(1, fragment.installs)
+    }
+
+    @Test
+    fun `the apple i2 marker is consumed once and suppressed while re-entering`() {
+        val context = LyricsItemUpdateContext()
+
+        context.enterO2()
+        context.markAppleInvokedI2()
+        assertTrue(context.appleInvokedI2DuringO2())
+        assertFalse(context.appleInvokedI2DuringO2())
+        context.exitO2()
+
+        context.enterO2()
+        context.reentering { context.markAppleInvokedI2() }
+        assertFalse(context.appleInvokedI2DuringO2())
+        context.exitO2()
+    }
+
+    @Test
+    fun `decision ignores same item metadata refreshes`() {
+        assertEquals(
+            LyricsItemUpdateAction.IGNORE,
+            decideLyricsItemUpdate(
+                itemChanged = false,
+                appleInvokedI2 = false,
+                fragmentUsable = true,
+                itemAdamId = 77L,
+                previouslyHandledAdamId = null,
+                tracked = true,
+                replacementReady = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `decision ignores apple i2 already invoked in the same o2 call`() {
+        assertEquals(
+            LyricsItemUpdateAction.IGNORE,
+            decideLyricsItemUpdate(
+                itemChanged = true,
+                appleInvokedI2 = true,
+                fragmentUsable = true,
+                itemAdamId = 77L,
+                previouslyHandledAdamId = null,
+                tracked = true,
+                replacementReady = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `decision ignores unusable fragments`() {
+        assertEquals(
+            LyricsItemUpdateAction.IGNORE,
+            decideLyricsItemUpdate(
+                itemChanged = true,
+                appleInvokedI2 = false,
+                fragmentUsable = false,
+                itemAdamId = 77L,
+                previouslyHandledAdamId = null,
+                tracked = true,
+                replacementReady = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `decision ignores null and non positive item ids`() {
+        listOf(null, 0L).forEach { id ->
+            assertEquals(
+                LyricsItemUpdateAction.IGNORE,
+                decideLyricsItemUpdate(
+                    itemChanged = true,
+                    appleInvokedI2 = false,
+                    fragmentUsable = true,
+                    itemAdamId = id,
+                    previouslyHandledAdamId = null,
+                    tracked = true,
+                    replacementReady = true,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `decision ignores untracked items even when a replacement is ready`() {
+        assertEquals(
+            LyricsItemUpdateAction.IGNORE,
+            decideLyricsItemUpdate(
+                itemChanged = true,
+                appleInvokedI2 = false,
+                fragmentUsable = true,
+                itemAdamId = 77L,
+                previouslyHandledAdamId = null,
+                tracked = false,
+                replacementReady = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `decision ignores an item already handled for the same fragment`() {
+        assertEquals(
+            LyricsItemUpdateAction.IGNORE,
+            decideLyricsItemUpdate(
+                itemChanged = true,
+                appleInvokedI2 = false,
+                fragmentUsable = true,
+                itemAdamId = 77L,
+                previouslyHandledAdamId = 77L,
+                tracked = true,
+                replacementReady = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `decision re-enters when the replacement is ready`() {
+        assertEquals(
+            LyricsItemUpdateAction.REENTER,
+            decideLyricsItemUpdate(
+                itemChanged = true,
+                appleInvokedI2 = false,
+                fragmentUsable = true,
+                itemAdamId = 77L,
+                previouslyHandledAdamId = null,
+                tracked = true,
+                replacementReady = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `decision records a miss when the replacement is still preparing`() {
+        assertEquals(
+            LyricsItemUpdateAction.RECORD_MISS,
+            decideLyricsItemUpdate(
+                itemChanged = true,
+                appleInvokedI2 = false,
+                fragmentUsable = true,
+                itemAdamId = 77L,
+                previouslyHandledAdamId = null,
+                tracked = true,
+                replacementReady = false,
+            ),
+        )
+    }
+
+    private fun item(id: String): BaseContentItem = BaseContentItem(id)
+
+    private fun flags(changed: Boolean): ItemUpdateFragmentBase.c =
+        ItemUpdateFragmentBase.c().apply { a = changed }
+
+    private fun update(
+        coordinator: LyricsItemUpdateCoordinator,
+        fragment: ItemUpdateFragment,
+        id: String,
+        changed: Boolean = true,
+        appleInvokedI2: Boolean = false,
+    ) {
+        fragment.c = item(id)
+        coordinator.onItemUpdate(
+            fragment,
+            flagsHolder = flags(changed),
+            appleInvokedI2 = appleInvokedI2,
+        )
+    }
+
+    private fun coordinator(
+        fragment: Any,
+        ready: (Long) -> Any? = { null },
+        tracking: (Long) -> Boolean = { true },
+        usable: (Any) -> Boolean = { true },
+        cache: CurrentSongIdentityCache = CurrentSongIdentityCache(),
+    ): Triple<LyricsItemUpdateCoordinator, CustomLyricsReadyReapply, MutableList<String>> {
+        val logs = mutableListOf<String>()
+        val fragmentClass = fragment.javaClass
+        val installMethod = fragmentClass.getDeclaredMethod("I2", Any::class.java)
+        val itemUpdateMethod = fragmentClass.getDeclaredMethod(
+            "o2",
+            v3.v::class.java,
+            BaseContentItem::class.java,
+            ItemUpdateFragmentBase.c::class.java,
+        )
+        val seam = CurrentItemIdentitySeam(
+            ItemUpdateResolver(
+                field = fragmentClass.getDeclaredField("c"),
+                installMethod = installMethod,
+            ),
+        )
+        seam.resolve(installMethod)
+        val reapply = CustomLyricsReadyReapply(
+            installMethod = installMethod,
+            seam = seam,
+            readyReplacementFor = ready,
+            isFragmentUsable = usable,
+            currentSong = cache,
+            logger = { logs += it },
+        )
+        val coordinator = LyricsItemUpdateCoordinator(
+            installMethod = installMethod,
+            flags = ItemUpdateFlags(itemUpdateMethod.parameterTypes[2]),
+            seam = seam,
+            readyReplacementFor = ready,
+            isTracking = tracking,
+            isFragmentUsable = usable,
+            readyReapply = reapply,
+            logger = { logs += it },
+        )
+        return Triple(coordinator, reapply, logs)
+    }
+
+    private fun pending(reapply: CustomLyricsReadyReapply): MutableList<*> {
+        val field = CustomLyricsReadyReapply::class.java.getDeclaredField("pending")
+        field.isAccessible = true
+        return field.get(reapply) as MutableList<*>
+    }
+
+    private class ItemUpdateResolver(
+        private val field: Field,
+        private val installMethod: Method,
+    ) : TargetSymbolResolver {
+        override fun <T : Any> resolve(symbol: TargetSymbolKey<T>): TargetResolution<T> {
+            @Suppress("UNCHECKED_CAST")
+            return when (symbol.id) {
+                AppleMusicSymbols.LyricsCurrentItemField.id ->
+                    TargetResolution.Found(symbol.id, field, SymbolMatch.VERSION_PROFILE, "test")
+                AppleMusicSymbols.LyricsInstallMethod.id ->
+                    TargetResolution.Found(
+                        symbol.id,
+                        installMethod,
+                        SymbolMatch.VERSION_PROFILE,
+                        "test",
+                    )
+                else -> TargetResolution.Missing(symbol.id, "test")
+            } as TargetResolution<T>
+        }
+    }
+
+    private open class ItemUpdateFragmentBase {
+        class c {
+            @JvmField
+            var a: Boolean = false
+
+            @JvmField
+            var b: Boolean = false
+
+            @JvmField
+            var c: Boolean = false
+        }
+    }
+
+    private class ItemUpdateFragment(private val failOnInstall: Boolean = false) :
+        ItemUpdateFragmentBase() {
+        @JvmField
+        var c: BaseContentItem? = null
+
+        var installed: Any? = null
+        var installs: Int = 0
+        var attempts: Int = 0
+
+        @Suppress("UNUSED_PARAMETER")
+        fun I2(ptr: Any) {
+            attempts += 1
+            if (failOnInstall) throw IllegalStateException("I2 exploded")
+            installed = ptr
+            installs += 1
+        }
+
+        @Suppress("UNUSED_PARAMETER")
+        fun o2(metadata: v3.v, item: BaseContentItem, flags: ItemUpdateFragmentBase.c) = Unit
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/TargetSymbolsTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/TargetSymbolsTest.kt
@@ -466,6 +466,129 @@ class TargetSymbolsTest {
     }
 
     @Test
+    fun `650 profile resolves the exact o2 item update method without scanning dex`() {
+        val fragmentName = "com.apple.android.music.player.fragment.PlayerLyricsViewFragment"
+        val source = FakeTargetClassSource(
+            classes = mapOf(fragmentName to ItemUpdateFragmentFixture650::class.java),
+        )
+        val resolver = IndexedTargetSymbolResolver(
+            build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.0", 1580L),
+            source = source,
+        )
+
+        val resolution = resolver.resolve(AppleMusicSymbols.LyricsItemUpdateMethod)
+
+        assertTrue(resolution is TargetResolution.Found)
+        val found = resolution as TargetResolution.Found
+        assertEquals("o2", found.value.name)
+        assertEquals(SymbolMatch.VERSION_PROFILE, found.match)
+        assertEquals("apple-music-6.5.0-1580", found.profileId)
+        assertEquals(3, found.value.parameterTypes.size)
+        assertEquals(
+            ItemUpdateFlagsBaseFixture650.c::class.java,
+            found.value.parameterTypes[2],
+        )
+        assertEquals(0, source.classNameReads)
+    }
+
+    @Test
+    fun `651 profile resolves the migrated o2 item update method without scanning dex`() {
+        val fragmentName = "com.apple.android.music.player.fragment.PlayerLyricsViewFragment"
+        val source = FakeTargetClassSource(
+            classes = mapOf(fragmentName to ItemUpdateFragmentFixture651::class.java),
+        )
+        val resolver = IndexedTargetSymbolResolver(
+            build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.1", 1583L),
+            source = source,
+        )
+
+        val resolution = resolver.resolve(AppleMusicSymbols.LyricsItemUpdateMethod)
+
+        assertTrue(resolution is TargetResolution.Found)
+        val found = resolution as TargetResolution.Found
+        assertEquals("o2", found.value.name)
+        assertEquals(SymbolMatch.VERSION_PROFILE, found.match)
+        assertEquals("apple-music-6.5.1-1583", found.profileId)
+        assertEquals(0, source.classNameReads)
+    }
+
+    @Test
+    fun `structural fallback never selects an o2 without the verified flags contract`() {
+        val source = FakeTargetClassSource(
+            names = listOf(
+                "com.apple.android.music.player.fragment.PlayerLyricsViewFragment",
+            ),
+            classes = mapOf(
+                "com.apple.android.music.player.fragment.PlayerLyricsViewFragment" to
+                    BrokenItemUpdateFlagsFragmentFixture::class.java,
+            ),
+        )
+        val resolver = IndexedTargetSymbolResolver(TargetBuild.UNKNOWN, source)
+
+        val resolution = resolver.resolve(AppleMusicSymbols.LyricsItemUpdateMethod)
+
+        assertTrue(resolution is TargetResolution.Missing)
+    }
+
+    @Test
+    fun `structural fallback resolves an exact o2 when the profile is unknown`() {
+        val source = FakeTargetClassSource(
+            names = listOf(
+                "com.apple.android.music.player.fragment.PlayerLyricsViewFragment",
+            ),
+            classes = mapOf(
+                "com.apple.android.music.player.fragment.PlayerLyricsViewFragment" to
+                    ItemUpdateFragmentFixture650::class.java,
+            ),
+        )
+        val resolver = IndexedTargetSymbolResolver(TargetBuild.UNKNOWN, source)
+
+        val resolution = resolver.resolve(AppleMusicSymbols.LyricsItemUpdateMethod)
+
+        assertTrue(resolution is TargetResolution.Found)
+        assertEquals("o2", (resolution as TargetResolution.Found).value.name)
+        assertEquals(SymbolMatch.STRUCTURAL_FALLBACK, resolution.match)
+    }
+
+    @Test
+    fun `two same-shaped o2 fragments resolve ambiguous instead of silently choosing`() {
+        val source = FakeTargetClassSource(
+            names = listOf(
+                "com.apple.android.music.player.fragment.PlayerLyricsViewFragment",
+                "com.apple.android.music.player2.PlayerLyricsViewFragment",
+            ),
+            classes = mapOf(
+                "com.apple.android.music.player.fragment.PlayerLyricsViewFragment" to
+                    ItemUpdateFragmentFixture650::class.java,
+                "com.apple.android.music.player2.PlayerLyricsViewFragment" to
+                    ItemUpdateFragmentFixture651::class.java,
+            ),
+        )
+        val resolver = IndexedTargetSymbolResolver(TargetBuild.UNKNOWN, source)
+
+        val resolution = resolver.resolve(AppleMusicSymbols.LyricsItemUpdateMethod)
+
+        assertTrue(resolution is TargetResolution.Ambiguous)
+        assertEquals(2, (resolution as TargetResolution.Ambiguous).candidates.size)
+    }
+
+    @Test
+    fun `a fragment without the o2 item update contract stays missing under the profile`() {
+        val fragmentName = "com.apple.android.music.player.fragment.PlayerLyricsViewFragment"
+        val source = FakeTargetClassSource(
+            classes = mapOf(fragmentName to LyricsInstallFixture::class.java),
+        )
+        val resolver = IndexedTargetSymbolResolver(
+            build = TargetBuild(ModuleConstants.TARGET_PACKAGE, "6.5.0", 1580L),
+            source = source,
+        )
+
+        val resolution = resolver.resolve(AppleMusicSymbols.LyricsItemUpdateMethod)
+
+        assertTrue(resolution is TargetResolution.Missing)
+    }
+
+    @Test
     fun `650 profile resolves the player metadata identity funnel`() {
         val source = FakeTargetClassSource(
             classes = mapOf(
@@ -1054,6 +1177,55 @@ private class LyricsInstallFixture {
 private class LyricsR2OnlyFixture {
     @Suppress("UNUSED_PARAMETER")
     fun R2(ptr: SongInfo.SongInfoPtr) = Unit
+}
+
+private open class ItemUpdateFlagsBaseFixture650 {
+    class c {
+        @JvmField
+        var a: Boolean = false
+
+        @JvmField
+        var b: Boolean = false
+
+        @JvmField
+        var c: Boolean = false
+    }
+}
+
+private class ItemUpdateFragmentFixture650 : ItemUpdateFlagsBaseFixture650() {
+    @Suppress("UNUSED_PARAMETER")
+    fun o2(metadata: v3.v, item: BaseContentItem, flags: ItemUpdateFlagsBaseFixture650.c) = Unit
+}
+
+private open class ItemUpdateFlagsBaseFixture651 {
+    class c {
+        @JvmField
+        var a: Boolean = false
+
+        @JvmField
+        var b: Boolean = false
+
+        @JvmField
+        var c: Boolean = false
+    }
+}
+
+private class ItemUpdateFragmentFixture651 : ItemUpdateFlagsBaseFixture651() {
+    @Suppress("UNUSED_PARAMETER")
+    fun o2(metadata: v3.v, item: BaseContentItem, flags: ItemUpdateFlagsBaseFixture651.c) = Unit
+}
+
+/** Same binary fragment name and o2 name but a flags holder without the exact field set. */
+private open class BrokenItemUpdateFlagsBaseFixture {
+    class c {
+        @JvmField
+        var a: Boolean = false
+    }
+}
+
+private class BrokenItemUpdateFlagsFragmentFixture : BrokenItemUpdateFlagsBaseFixture() {
+    @Suppress("UNUSED_PARAMETER")
+    fun o2(metadata: v3.v, item: BaseContentItem, flags: BrokenItemUpdateFlagsBaseFixture.c) = Unit
 }
 
 private class PlayerMetadataHubFixture {


### PR DESCRIPTION
## Summary
- Fix custom lyrics refresh during natural playback transitions from native lyrics to an AM++-mapped track.
- Resolve the exact PlayerLyricsViewFragment.o2 seam for Apple Music 6.5.0/6.5.1 and use the Fragment current-item field after Apple's update.
- Preserve ready-late, fail-open, duplicate-I2, and native playback behavior.
- Bump version to 1.4.2 (versionCode 99).

## Validation
- :app:testDebugUnitTest --offline --rerun-tasks
- :app:assembleDebug --offline --rerun-tasks
- :app:assembleRelease --offline --rerun-tasks
- :app:lintVitalRelease --offline --rerun-tasks
- git diff --check
- Verified on Apple Music 6.5.1/1583 with the natural cross-song scenario.

Full lintRelease still reports the repository's existing unrelated lint errors in SettingsActivity, LyricBlurRenderer, and AppleMusicCurrentSongIdentityTarget.