### PR TITLE
fix: close Catalog retry and action-sheet state leaks

### DIFF
--- a/app/src/main/java/dev/amenhancer/module/hook/ActionSheetArtistIdTracker.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/ActionSheetArtistIdTracker.kt
@@ -1,0 +1,116 @@
+package dev.amenhancer.module.hook
+
+import java.util.ArrayDeque
+import java.util.LinkedHashMap
+
+/**
+ * Bounded hand-off state for the artist id attached to one player action
+ * sheet.  The sheet entry point and its response callback are not guaranteed
+ * to run back-to-back (or on the same thread), so ids are retained until the
+ * response consumes them or the short TTL expires.  A new sheet deliberately
+ * does not clear older entries: a concurrent or delayed response still owns
+ * the id it was given.
+ *
+ * The state is intentionally a tiny synchronized map of bounded request-token
+ * queues rather than a process-lifetime concurrent set.  Every public
+ * operation performs bounded expiry work and [consume] removes one token under
+ * the same lock as the lookup, making consumption atomic even when response
+ * maps are delivered in parallel or the same artist is opened twice.
+ */
+internal class ActionSheetArtistIdTracker(
+    private val maxEntries: Int = DEFAULT_MAX_ENTRIES,
+    private val ttlMillis: Long = DEFAULT_TTL_MILLIS,
+    private val clock: () -> Long = { System.nanoTime() / NANOS_PER_MILLISECOND },
+) {
+    init {
+        require(maxEntries > 0) { "maxEntries must be positive" }
+        require(ttlMillis > 0) { "ttlMillis must be positive" }
+    }
+
+    private val lock = Any()
+    private val entries = LinkedHashMap<String, ArrayDeque<Long>>(maxEntries)
+    private var tokenCount = 0
+
+    /** Records one action-sheet request token. Blank ids are ignored. */
+    fun record(id: String?) {
+        val normalized = normalize(id) ?: return
+        synchronized(lock) {
+            val now = clock()
+            evictExpiredLocked(now)
+            entries.getOrPut(normalized) { ArrayDeque() }.addLast(now)
+            tokenCount += 1
+            while (tokenCount > maxEntries) evictOldestTokenLocked()
+        }
+    }
+
+    /**
+     * Atomically checks and consumes [id]. A consumed id cannot be reused by a
+     * later response, while a different id remains available for its own
+     * delayed/concurrent response.
+     */
+    fun consume(id: String?): Boolean {
+        val normalized = normalize(id) ?: return false
+        return synchronized(lock) {
+            val now = clock()
+            evictExpiredLocked(now)
+            val timestamps = entries[normalized]
+            if (timestamps == null) {
+                false
+            } else {
+                timestamps.removeFirst()
+                tokenCount -= 1
+                if (timestamps.isEmpty()) entries.remove(normalized)
+                true
+            }
+        }
+    }
+
+    /** Current non-expired request-token count, bounded by [maxEntries]. */
+    val size: Int
+        get() = synchronized(lock) {
+            val now = clock()
+            evictExpiredLocked(now)
+            tokenCount
+        }
+
+    private fun evictExpiredLocked(now: Long) {
+        val iterator = entries.entries.iterator()
+        while (iterator.hasNext()) {
+            val timestamps = iterator.next().value
+            while (timestamps.isNotEmpty()) {
+                val recordedAt = timestamps.first
+                if (now < recordedAt || now - recordedAt < ttlMillis) break
+                timestamps.removeFirst()
+                tokenCount -= 1
+            }
+            if (timestamps.isEmpty()) iterator.remove()
+        }
+    }
+
+    private fun evictOldestTokenLocked() {
+        var oldestId: String? = null
+        var oldestAt = Long.MAX_VALUE
+        entries.forEach { (id, timestamps) ->
+            val recordedAt = timestamps.firstOrNull() ?: return@forEach
+            if (recordedAt < oldestAt) {
+                oldestAt = recordedAt
+                oldestId = id
+            }
+        }
+        val id = oldestId ?: return
+        val timestamps = entries[id] ?: return
+        timestamps.removeFirst()
+        tokenCount -= 1
+        if (timestamps.isEmpty()) entries.remove(id)
+    }
+
+    private fun normalize(id: String?): String? = id
+        ?.trim()
+        ?.takeIf(String::isNotEmpty)
+
+    private companion object {
+        const val DEFAULT_MAX_ENTRIES = 64
+        const val DEFAULT_TTL_MILLIS = 30_000L
+        const val NANOS_PER_MILLISECOND = 1_000_000L
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicTitleCorrectionTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicTitleCorrectionTarget.kt
@@ -2,7 +2,6 @@ package dev.amenhancer.module.hook
 
 import android.app.Application
 import java.lang.reflect.Method
-import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Corrects only titles for which Apple already supplied a catalog relation.
@@ -31,8 +30,12 @@ internal class AppleMusicTitleCorrectionTarget(
 
     /** Prevent our reflective getter calls from re-entering this target. */
     private val callbackGuard: ThreadLocal<Boolean> = ThreadLocal.withInitial { false }
-    /** Only the artist row created by the current action sheet may use artist-id semantics. */
-    private val actionSheetArtistIds = ConcurrentHashMap.newKeySet<String>()
+    /**
+     * Only the artist row created by an action sheet may use artist-id
+     * semantics.  Responses can be concurrent or late, so this is not reset
+     * when a new sheet opens; each matching response consumes its own id.
+     */
+    private val actionSheetArtistIds = ActionSheetArtistIdTracker()
 
     /**
      * Attributes are bound as one object: title, artist and album share a
@@ -654,8 +657,10 @@ internal class AppleMusicTitleCorrectionTarget(
                 runGuarded {
                     val playbackItem = param.args.getOrNull(0)
                     val collectionView = param.args.getOrNull(1)
-                    val artistId = param.args.getOrNull(2) as? String
-                    artistId?.takeIf(String::isNotBlank)?.let(actionSheetArtistIds::add)
+                    val artistId = (param.args.getOrNull(2) as? String)
+                        ?.trim()
+                        ?.takeIf(String::isNotEmpty)
+                    actionSheetArtistIds.record(artistId)
                     // AMTool resolves artist/title with the playback item's id,
                     // but resolves the collection name with getCollectionId().
                     // Keep that identity split when both objects are supplied.
@@ -677,9 +682,14 @@ internal class AppleMusicTitleCorrectionTarget(
                     runGuarded {
                         val map = param.args.firstOrNull() as? Map<*, *> ?: return@runGuarded
                         map.entries.forEach { (key, value) ->
-                            if (value == null) return@forEach
                             val keyId = key?.toString()
-                            if (keyId == null || keyId !in actionSheetArtistIds) return@forEach
+                                ?.trim()
+                                ?.takeIf(String::isNotEmpty)
+                            // Consume before touching the value or attempting
+                            // correction so null/blank/failed rows cannot
+                            // leave a stale id for a later response.
+                            if (keyId == null || !actionSheetArtistIds.consume(keyId)) return@forEach
+                            if (value == null) return@forEach
                             val raw = callString(value, "getTitle") ?: return@forEach
                             titleCache.correctedArtistById(keyId, raw)
                                 ?.let { corrected -> callSetter(value, "setTitle", corrected) }

--- a/app/src/main/java/dev/amenhancer/module/hook/CatalogMissBackfillCoordinator.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/CatalogMissBackfillCoordinator.kt
@@ -126,6 +126,7 @@ internal class CatalogMissBackfillCoordinator(
         }
         if (batch.isEmpty()) return
 
+        val capturedIds = LinkedHashSet<String>()
         runCatching {
             val requested = batch.toHashSet()
             val cache = cacheProvider()
@@ -133,15 +134,23 @@ internal class CatalogMissBackfillCoordinator(
                 val id = LibraryRefreshHost.readString(entity, "getId") ?: return@forEach
                 if (id !in requested) return@forEach
                 cache.captureCatalogMetadataForId(id, entity, "songs")
+                capturedIds += id
             }
         }.onSuccess {
             synchronized(lock) {
                 batch.forEach { id ->
                     inFlight -= id
-                    retryable -= id
-                    completed += id
-                    while (completed.size > MAX_COMPLETED_IDS) {
-                        completed.remove(completed.first())
+                    if (id in capturedIds) {
+                        retryable -= id
+                        completed += id
+                        while (completed.size > MAX_COMPLETED_IDS) {
+                            completed.remove(completed.first())
+                        }
+                    } else {
+                        // A successful lookup may still omit requested IDs.
+                        // Keep those IDs retryable instead of treating the
+                        // whole batch as captured.
+                        rememberRetryableLocked(id)
                     }
                 }
             }

--- a/app/src/test/java/dev/amenhancer/module/hook/ActionSheetArtistIdTrackerTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/ActionSheetArtistIdTrackerTest.kt
@@ -1,0 +1,126 @@
+package dev.amenhancer.module.hook
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Behavior coverage for the bounded hand-off between an action-sheet request
+ * and its asynchronous artist response map.
+ */
+class ActionSheetArtistIdTrackerTest {
+    @Test
+    fun `recorded id is consumed exactly once`() {
+        val clock = MutableTrackerClock()
+        val tracker = ActionSheetArtistIdTracker(
+            maxEntries = 8,
+            ttlMillis = 100,
+            clock = clock,
+        )
+
+        tracker.record("artist-1")
+
+        assertTrue(tracker.consume("artist-1"))
+        assertFalse(tracker.consume("artist-1"))
+        assertEquals(0, tracker.size)
+    }
+
+    @Test
+    fun `same id can represent two concurrent action sheets`() {
+        val clock = MutableTrackerClock()
+        val tracker = ActionSheetArtistIdTracker(
+            maxEntries = 4,
+            ttlMillis = 100,
+            clock = clock,
+        )
+
+        tracker.record("artist-reentrant")
+        clock.nowMillis = 1
+        tracker.record("artist-reentrant")
+
+        assertEquals(2, tracker.size)
+        assertTrue(tracker.consume("artist-reentrant"))
+        assertTrue(tracker.consume("artist-reentrant"))
+        assertFalse(tracker.consume("artist-reentrant"))
+    }
+
+    @Test
+    fun `expired id is not consumable and is removed from size`() {
+        val clock = MutableTrackerClock()
+        val tracker = ActionSheetArtistIdTracker(
+            maxEntries = 8,
+            ttlMillis = 100,
+            clock = clock,
+        )
+
+        tracker.record("artist-expired")
+        clock.nowMillis = 100
+
+        assertFalse(tracker.consume("artist-expired"))
+        assertEquals(0, tracker.size)
+    }
+
+    @Test
+    fun `capacity evicts oldest ids while retaining newer concurrent sheets`() {
+        val clock = MutableTrackerClock()
+        val tracker = ActionSheetArtistIdTracker(
+            maxEntries = 2,
+            ttlMillis = 10_000,
+            clock = clock,
+        )
+
+        tracker.record("artist-a")
+        clock.nowMillis += 1
+        tracker.record("artist-b")
+        clock.nowMillis += 1
+        tracker.record("artist-c")
+
+        assertEquals(2, tracker.size)
+        assertFalse(tracker.consume("artist-a"))
+        assertTrue(tracker.consume("artist-b"))
+        assertTrue(tracker.consume("artist-c"))
+    }
+
+    @Test
+    fun `duplicate id retains the newer token after the older one expires`() {
+        val clock = MutableTrackerClock()
+        val tracker = ActionSheetArtistIdTracker(
+            maxEntries = 2,
+            ttlMillis = 100,
+            clock = clock,
+        )
+
+        tracker.record("artist-refresh")
+        clock.nowMillis = 90
+        tracker.record("artist-refresh")
+        clock.nowMillis = 150
+
+        assertEquals(1, tracker.size)
+        assertTrue(tracker.consume("artist-refresh"))
+    }
+
+    @Test
+    fun `unconsumed ids remain bounded`() {
+        val clock = MutableTrackerClock()
+        val tracker = ActionSheetArtistIdTracker(
+            maxEntries = 3,
+            ttlMillis = 10_000,
+            clock = clock,
+        )
+
+        repeat(100) { index ->
+            tracker.record("artist-$index")
+        }
+
+        assertEquals(3, tracker.size)
+        assertFalse(tracker.consume("artist-0"))
+        assertTrue(tracker.consume("artist-99"))
+    }
+
+    private class MutableTrackerClock(
+        var nowMillis: Long = 0,
+    ) : () -> Long {
+        override fun invoke(): Long = nowMillis
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/CatalogMissBackfillCoordinatorTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CatalogMissBackfillCoordinatorTest.kt
@@ -181,6 +181,83 @@ class CatalogMissBackfillCoordinatorTest {
         assertEquals(2, attempts)
     }
 
+    @Test
+    fun `partial lookup keeps omitted id retryable for a later miss`() {
+        val idA = "song-partial-a"
+        val idB = "song-partial-b"
+        val entityA = TestCatalogSong(idA, "部分歌曲 A")
+        val entityB = TestCatalogSong(idB, "部分歌曲 B")
+        val requests = mutableListOf<List<String>>()
+        val scheduler = RecordingCatalogMissScheduler()
+        var firstLookup = true
+        val coordinator = CatalogMissBackfillCoordinator(
+            cache = testCache(),
+            lookup = CatalogSongLookup { ids ->
+                requests += ids.toList()
+                if (firstLookup) {
+                    firstLookup = false
+                    listOf(entityA)
+                } else {
+                    listOf(entityB)
+                }
+            },
+            scheduler = scheduler,
+        )
+
+        coordinator.enqueue(idA)
+        coordinator.enqueue(idB)
+        scheduler.runAll()
+
+        assertEquals(listOf(listOf(idA, idB)), requests)
+        assertEquals(1, coordinator.capturedCount)
+        assertEquals(1, coordinator.retryableCount)
+
+        coordinator.enqueue(idB)
+        scheduler.runAll()
+
+        assertEquals(listOf(listOf(idA, idB), listOf(idB)), requests)
+        assertEquals(2, coordinator.capturedCount)
+        assertEquals(0, coordinator.retryableCount)
+    }
+
+    @Test
+    fun `empty lookup keeps every requested id retryable`() {
+        val idA = "song-empty-a"
+        val idB = "song-empty-b"
+        val entityB = TestCatalogSong(idB, "空结果后歌曲 B")
+        val requests = mutableListOf<List<String>>()
+        val scheduler = RecordingCatalogMissScheduler()
+        var firstLookup = true
+        val coordinator = CatalogMissBackfillCoordinator(
+            cache = testCache(),
+            lookup = CatalogSongLookup { ids ->
+                requests += ids.toList()
+                if (firstLookup) {
+                    firstLookup = false
+                    emptyList()
+                } else {
+                    listOf(entityB)
+                }
+            },
+            scheduler = scheduler,
+        )
+
+        coordinator.enqueue(idA)
+        coordinator.enqueue(idB)
+        scheduler.runAll()
+
+        assertEquals(listOf(listOf(idA, idB)), requests)
+        assertEquals(0, coordinator.capturedCount)
+        assertEquals(2, coordinator.retryableCount)
+
+        coordinator.enqueue(idB)
+        scheduler.runAll()
+
+        assertEquals(listOf(listOf(idA, idB), listOf(idB)), requests)
+        assertEquals(1, coordinator.capturedCount)
+        assertEquals(1, coordinator.retryableCount)
+    }
+
     private fun testCache(): CatalogTitleCache = CatalogTitleCache(
         CoordinatorTestApplication(inMemoryPreferences(linkedMapOf())),
         "zh-CN",


### PR DESCRIPTION
## 变更

修复 PR #40 合并后审查发现的两项状态问题：

- Catalog 批量查询返回部分或空结果时，只将实际捕获的歌曲 ID 标记为 completed；遗漏 ID 保留为有界 retryable，后续 miss 可以再次查询。
- 将 action-sheet artist ID 的进程级永久集合替换为有界 tracker：64 个请求令牌、30 秒 TTL、原子消费、ID 规范化，并支持迟到响应和同 ID 并发 action sheet。
- 响应 map 在读取 value、raw 文本或执行修正前消费匹配 ID，避免空值或异常留下 stale 状态。
- 新增 partial/empty Catalog 和 tracker 生命周期回归测试。

## 根因

原实现把整个成功请求 batch 视为已捕获，即使 Catalog 只返回子集；action-sheet artist ID 只增不删，未绑定响应生命周期。

## 验证

- 全量 JVM：721 tests / 0 failures / 0 errors / 0 skipped
- lintDebug
- lintVitalRelease
- assembleDebug
- assembleRelease
- Release APK v2 签名校验通过

仅修改独立模块，未修改嵌入版。