### PR TITLE
fix: bottom bar overlap with player and broken compensation feature in Apple Music 6.5.2 tablet UI

### DIFF
--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
@@ -420,6 +420,9 @@ internal class AppleMusicDualPaneTarget(
             activityRootResolution.valueOrNull(),
             behaviorFieldResolution.valueOrNull(),
         )
+        StaticCollapsedInterceptGuard.install(
+            behaviorFieldResolution.valueOrNull()?.declaringClass?.classLoader,
+        )
         val lyricsFragmentResolution = symbols.resolve(AppleMusicSymbols.LyricsFragment)
         val lyricsFragmentClass = lyricsFragmentResolution.valueOrNull()
         val lyricsChromeResolution = symbols.resolve(AppleMusicSymbols.LyricsChromeAnimate)
@@ -742,8 +745,14 @@ internal class AppleMusicDualPaneTarget(
                 override fun beforeHookedMethod(param: MethodHookParam) {
                     val requested = param.args.firstOrNull() as? Enum<*> ?: return
                     val controllerInstance = param.thisObject ?: return
-                    if (requested.name != LYRICS_STATE || stateFor(controllerInstance) == null) return
-                    param.result = null
+                    val state = stateFor(controllerInstance) ?: return
+                    if (!TabletModeQualifier.isEligible(state.root.context)) {
+                        state.root.setTag(R.id.am_enhancer_dual_pane_state, null)
+                        return
+                    }
+                    if (requested.name == LYRICS_STATE) {
+                        param.result = null
+                    }
                 }
             })
         ) {
@@ -753,9 +762,10 @@ internal class AppleMusicDualPaneTarget(
     }
 
     /**
-     * Return Apple Music's own phone holder before k1() can instantiate the
-     * tablet holder. The native object then owns slide interpolation, peek
-     * height, navigation translation, colors and system-bar transitions.
+     * Keep the native flat holder for the transformed landscape root. Only
+     * return the native stacked holder when the actual root is stacked; the
+     * holder owns slide interpolation, peek height, navigation translation,
+     * colors and system-bar transitions.
      */
     private fun installNativeStackedNavigationHolderHook(
         method: Method?,
@@ -807,6 +817,21 @@ internal class AppleMusicDualPaneTarget(
                         "id",
                         ModuleConstants.TARGET_PACKAGE,
                     )
+                    val flatRoot = if (flatRootId != 0) {
+                        root.findViewById<View>(flatRootId)
+                            ?: activity.findViewById<View>(flatRootId)
+                    } else {
+                        null
+                    }
+                    // 6.5.2 selects the flat holder whenever the
+                    // landscape resource exposes the flat root. Preserve
+                    // that native holder: it owns the full-player lifecycle.
+                    // The stacked holder is only valid for a real stacked
+                    // root, not for the transformed landscape flat layout.
+                    if (flatRoot != null) {
+                        debug("preserving native flat bottom navigation holder")
+                        return
+                    }
                     val navigationRoot = sequenceOf(stackedRootId, flatRootId)
                         .filter { it != 0 }
                         .mapNotNull(root::findViewById)
@@ -965,9 +990,7 @@ internal class AppleMusicDualPaneTarget(
                 System.identityHashCode(rootGroup) +
                 " attached=" + rootGroup.isAttachedToWindow,
         )
-        if (DualPaneShell.installImmediately(rootGroup) != null) {
-            attachLyricsPane(controller, rootGroup)
-        }
+        if (DualPaneShell.installImmediately(rootGroup) != null) attachLyricsPane(controller, rootGroup)
     }
 }
 
@@ -1022,7 +1045,7 @@ internal data class FlatPlayerBoundaryDecision(
 /**
  * Phase 109 settled visual compensation: expanded always settles at
  * translationY 0, a settled collapsed sheet settles at exactly
- * -navigationInset. The decision stays binary on `expanded` (sheetTop <=
+ * -tabsHeight. The decision stays binary on `expanded` (sheetTop <=
  * rootHeight / 2) on purpose: the collapsed peek geometry is owned by
  * Apple's holder and is not measurable here, so no continuous
  * sheetTop-to-collapsed mapping could be verified. It is applied as visual
@@ -1037,7 +1060,6 @@ internal object FlatPlayerBoundaryPolicy {
         sheetBottom: Int,
         tabsTop: Int,
         tabsHeight: Int,
-        navigationInset: Int,
         wasNavigationSpaceReserved: Boolean,
     ): FlatPlayerBoundaryDecision {
         require(rootHeight > 0) { "rootHeight must be positive" }
@@ -1049,11 +1071,11 @@ internal object FlatPlayerBoundaryPolicy {
         val reserveNavigationSpace = wasNavigationSpaceReserved || collapsedOverlap
         return FlatPlayerBoundaryDecision(
             reserveNavigationSpace = reserveNavigationSpace,
-            // Expanded is the settled zero; a reserved collapsed sheet
-            // settles at the negative navigation inset. The reservation
-            // latch makes the collapsed state sticky so the binary flip
-            // cannot oscillate around the midpoint.
-            translationY = if (!expanded && reserveNavigationSpace) -navigationInset else 0,
+            // Expanded is the settled zero; a reserved collapsed sheet must
+            // clear the complete tabs frame, not only its 16dp breathing
+            // space. The reservation latch makes the collapsed state sticky
+            // so the binary flip cannot oscillate around the midpoint.
+            translationY = if (!expanded && reserveNavigationSpace) -tabsHeight else 0,
             // Let the native holder own an expanded transition until the
             // collapsed geometry has established a navigation reservation.
             tabsVisible = !reserveNavigationSpace || !expanded,
@@ -1174,8 +1196,8 @@ private object ConstraintLayoutPane {
 
     /**
      * Mirrors the modified layout-land/bottom_navigation.xml by converting the
-     * stock flat resource tree into full-width stacked chrome. Apple Music's
-     * native StackedBottomNavigationHolder owns its peek height and transitions.
+     * stock flat resource tree into full-width tablet chrome. Apple Music's
+     * native bottom-navigation holder owns its peek height and transitions.
      */
     fun installLandscapeBottomNavigation(root: ViewGroup) {
         if (!TabletModeQualifier.isEligible(root.context)) {
@@ -1217,7 +1239,6 @@ private object ConstraintLayoutPane {
                 playerContainer,
                 tabsFrame,
                 tabsHeight,
-                (tabsHeight - menuHeight).coerceAtLeast(0),
             )
             installTabsDivider(tabsFrame, resources)
 
@@ -1380,7 +1401,6 @@ private object ConstraintLayoutPane {
         playerContainer: View,
         tabsFrame: View,
         tabsHeight: Int,
-        navigationInset: Int,
     ) {
         if (!FlatLandscapeWindowPolicy.shouldInstallBoundarySync(root.context)) return
         val sheetId = targetId(root.resources, PLAYER_SHEET_CONTAINER)
@@ -1419,12 +1439,10 @@ private object ConstraintLayoutPane {
                 sheetBottom = sheetTop + sheet.height,
                 tabsTop = tabsLocation[1] - rootTop,
                 tabsHeight = tabsHeight,
-                navigationInset = navigationInset,
                 wasNavigationSpaceReserved = reserveNavigationSpace,
             )
             reserveNavigationSpace = decision.reserveNavigationSpace
-            val desired = decision.translationY
-            val desiredTranslation = desired.toFloat()
+            val desiredTranslation = decision.translationY.toFloat()
             val translationChanged = playerContainer.translationY != desiredTranslation
             val desiredTabsVisibility = if (decision.tabsVisible) View.VISIBLE else View.INVISIBLE
             val tabsVisibilityChanged = tabsFrame.visibility != desiredTabsVisibility

--- a/app/src/main/java/dev/amenhancer/module/hook/StaticCollapsedInterceptGuard.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/StaticCollapsedInterceptGuard.kt
@@ -1,0 +1,51 @@
+package dev.amenhancer.module.hook
+
+import android.view.View
+import java.lang.reflect.Modifier
+
+/**
+ * Counteracts a landscape regression introduced by keeping the native flat
+ * bottom-navigation holder: that holder feeds the static-collapsed behavior's
+ * slide offset once the player sheet expands, and a non-zero offset makes the
+ * behavior's onInterceptTouchEvent swallow every touch over the tabs frame.
+ *
+ * In the transformed landscape layout the tabs frame sits directly under the
+ * left pane's lyrics/queue buttons, so the intercept collapses the player
+ * instead of letting the buttons receive their taps. On the dual-pane tablet
+ * the sheet already overlays the tabs frame, so the intercept is pure
+ * misrouting: force it off there. The touch then flows naturally — the pane
+ * buttons consume their taps, while untouched areas still bubble back to the
+ * behavior's onTouchEvent to preserve the native collapse behaviour.
+ */
+internal object StaticCollapsedInterceptGuard {
+    fun install(classLoader: ClassLoader?): Boolean {
+        classLoader ?: return false
+        return runCatching {
+            val behaviorClass = Class.forName(
+                "com.apple.android.music.common.behavior.StaticCollapsedBottomSheetBehavior",
+                false,
+                classLoader,
+            )
+            val intercept = behaviorClass.declaredMethods.firstOrNull { method ->
+                !Modifier.isStatic(method.modifiers) &&
+                    method.name == "h" &&
+                    method.returnType == Boolean::class.javaPrimitiveType &&
+                    method.parameterTypes.map { it.name } == listOf(
+                        "androidx.coordinatorlayout.widget.CoordinatorLayout",
+                        "android.view.View",
+                        "android.view.MotionEvent",
+                    )
+            } ?: return@runCatching false
+            ModernXposedRuntime.hookMethod(intercept, object : ModernMethodHook() {
+                override fun beforeHookedMethod(param: MethodHookParam) {
+                    val coordinator = param.args[0] as? View ?: return
+                    if (!TabletModeQualifier.isEligible(coordinator.context)) return
+                    param.result = false
+                }
+            })
+            true
+        }.onFailure {
+            ModernXposedRuntime.log("static-collapsed intercept guard failed", it)
+        }.getOrDefault(false)
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/DualPaneStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/DualPaneStructuralRegressionTest.kt
@@ -174,8 +174,8 @@ class DualPaneStructuralRegressionTest {
 
     @Test
     fun `limits flat player boundary sync to the compensation switch`() {
-        assertTrue(source.contains("tabsHeight - menuHeight"))
-        assertTrue(source.contains("navigationInset = navigationInset"))
+        assertTrue(source.contains("val tabsHeight = stackedTabsContainerHeight(root.context, menuHeight)"))
+        assertTrue(source.contains("translationY = if (!expanded && reserveNavigationSpace) -tabsHeight else 0"))
         assertTrue(source.contains("if (!FlatLandscapeWindowPolicy.shouldInstallBoundarySync(root.context)) return"))
         assertFalse(source.contains("display.getRealMetrics(metrics)"))
         assertFalse(source.contains("physicalWidthPx = metrics?.widthPixels ?: 0"))
@@ -184,7 +184,7 @@ class DualPaneStructuralRegressionTest {
         assertTrue(source.contains("sheet.getLocationInWindow(sheetLocation)"))
         assertTrue(source.contains("tabsFrame.getLocationInWindow(tabsLocation)"))
         assertTrue(source.contains("reserveNavigationSpace = decision.reserveNavigationSpace"))
-        assertTrue(source.contains("val desired = decision.translationY"))
+        assertTrue(source.contains("val desiredTranslation = decision.translationY.toFloat()"))
         assertTrue(source.contains("playerContainer.translationY = desiredTranslation"))
         assertFalse(source.contains("params.bottomMargin = desired"))
     }
@@ -195,7 +195,7 @@ class DualPaneStructuralRegressionTest {
         assertTrue(source.contains("sheet.viewTreeObserver.addOnPreDrawListener"))
         assertTrue(source.contains("removeOnPreDrawListener"))
         assertTrue(source.contains("sheet.addOnAttachStateChangeListener"))
-        assertTrue(source.contains("tabsHeight - menuHeight"))
+        assertTrue(source.contains("translationY = if (!expanded && reserveNavigationSpace) -tabsHeight else 0"))
         assertTrue(source.contains("val desiredTabsVisibility = if (decision.tabsVisible) View.VISIBLE else View.INVISIBLE"))
         assertTrue(source.contains("tabsFrame.visibility = desiredTabsVisibility"))
         assertFalse(source.contains("miniPlayerId"))
@@ -239,6 +239,28 @@ class DualPaneStructuralRegressionTest {
         assertFalse(synchronousInstallSource.contains("addOnAttachStateChangeListener"))
         assertFalse(synchronousInstallSource.contains("onViewAttachedToWindow"))
         assertTrue(source.contains("[AMENH-2]"))
+    }
+
+    @Test
+    fun `does not intercept lyrics after leaving tablet landscape`() {
+        assertTrue(source.contains("val state = stateFor(controllerInstance) ?: return"))
+        assertTrue(source.contains("if (!TabletModeQualifier.isEligible(state.root.context))"))
+        assertTrue(source.contains("state.root.setTag(R.id.am_enhancer_dual_pane_state, null)"))
+        assertTrue(source.contains("if (requested.name == LYRICS_STATE)"))
+    }
+
+    @Test
+    fun `leaves queue selection and player transitions to native Apple Music`() {
+        assertFalse(source.contains("QUEUE_STATE"))
+        assertFalse(source.contains("paneSwitchInProgress"))
+        assertFalse(source.contains("expandPlayerSheet"))
+    }
+
+    @Test
+    fun `preserves the flat holder for the landscape flat root`() {
+        assertTrue(source.contains("preserving native flat bottom navigation holder"))
+        assertTrue(source.contains("if (flatRoot != null)"))
+        assertTrue(source.contains("constructor.newInstance(activity, navigationRoot, behavior)"))
     }
 
     @Test

--- a/app/src/test/java/dev/amenhancer/module/hook/FlatPlayerBoundaryPolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/FlatPlayerBoundaryPolicyTest.kt
@@ -10,7 +10,7 @@ import org.junit.Test
  *
  * The policy never mutates layout geometry: it produces a visual
  * translationY for the outer player container. Expanded is always settled at
- * 0; a settled collapsed sheet settles at exactly -navigationInset. The
+ * 0; a settled collapsed sheet settles at exactly -tabsHeight. The
  * decision stays binary on `expanded` (sheetTop <= rootHeight / 2) on
  * purpose: the collapsed peek geometry is owned by Apple's holder and is not
  * measurable here, so no continuous sheetTop -> collapsed mapping can be
@@ -26,12 +26,11 @@ class FlatPlayerBoundaryPolicyTest {
             sheetBottom = 1080,
             tabsTop = 954,
             tabsHeight = 126,
-            navigationInset = 16,
             wasNavigationSpaceReserved = false,
         )
 
         assertTrue(decision.reserveNavigationSpace)
-        assertEquals(-16, decision.translationY)
+        assertEquals(-126, decision.translationY)
         assertTrue(decision.tabsVisible)
     }
 
@@ -43,12 +42,11 @@ class FlatPlayerBoundaryPolicyTest {
             sheetBottom = 954,
             tabsTop = 954,
             tabsHeight = 126,
-            navigationInset = 16,
             wasNavigationSpaceReserved = true,
         )
 
         assertTrue(decision.reserveNavigationSpace)
-        assertEquals(-16, decision.translationY)
+        assertEquals(-126, decision.translationY)
         assertTrue(decision.tabsVisible)
     }
 
@@ -60,7 +58,6 @@ class FlatPlayerBoundaryPolicyTest {
             sheetBottom = 744,
             tabsTop = 744,
             tabsHeight = 56,
-            navigationInset = 16,
             wasNavigationSpaceReserved = false,
         )
 
@@ -77,7 +74,6 @@ class FlatPlayerBoundaryPolicyTest {
             sheetBottom = 1080,
             tabsTop = 954,
             tabsHeight = 126,
-            navigationInset = 16,
             wasNavigationSpaceReserved = false,
         )
 
@@ -94,7 +90,6 @@ class FlatPlayerBoundaryPolicyTest {
             sheetBottom = 900,
             tabsTop = 954,
             tabsHeight = 126,
-            navigationInset = 16,
             wasNavigationSpaceReserved = false,
         )
 
@@ -111,7 +106,6 @@ class FlatPlayerBoundaryPolicyTest {
             sheetBottom = 1080,
             tabsTop = 954,
             tabsHeight = 126,
-            navigationInset = 16,
             wasNavigationSpaceReserved = true,
         )
 
@@ -128,12 +122,11 @@ class FlatPlayerBoundaryPolicyTest {
             sheetBottom = 1296,
             tabsTop = 1296,
             tabsHeight = 144,
-            navigationInset = 32,
             wasNavigationSpaceReserved = true,
         )
 
         assertTrue(decision.reserveNavigationSpace)
-        assertEquals(-32, decision.translationY)
+        assertEquals(-144, decision.translationY)
         assertTrue(decision.tabsVisible)
     }
 
@@ -145,29 +138,27 @@ class FlatPlayerBoundaryPolicyTest {
             sheetBottom = 1408,
             tabsTop = 1296,
             tabsHeight = 144,
-            navigationInset = 32,
             wasNavigationSpaceReserved = false,
         )
 
         assertTrue(decision.reserveNavigationSpace)
-        assertEquals(-32, decision.translationY)
+        assertEquals(-144, decision.translationY)
         assertTrue(decision.tabsVisible)
     }
 
     @Test
-    fun `zero navigation inset keeps the detected geometry unchanged`() {
+    fun `reserved collapsed sheet clears the full tabs frame`() {
         val decision = FlatPlayerBoundaryPolicy.decide(
             rootHeight = 1080,
             sheetTop = 982,
             sheetBottom = 1080,
             tabsTop = 954,
             tabsHeight = 126,
-            navigationInset = 0,
             wasNavigationSpaceReserved = false,
         )
 
         assertTrue(decision.reserveNavigationSpace)
-        assertEquals(0, decision.translationY)
+        assertEquals(-126, decision.translationY)
         assertTrue(decision.tabsVisible)
     }
 
@@ -179,7 +170,6 @@ class FlatPlayerBoundaryPolicyTest {
             sheetBottom = 1080,
             tabsTop = 200,
             tabsHeight = 126,
-            navigationInset = 16,
             wasNavigationSpaceReserved = false,
         )
 
@@ -213,11 +203,10 @@ class FlatPlayerBoundaryPolicyTest {
             sheetBottom = 900,
             tabsTop = 954,
             tabsHeight = 126,
-            navigationInset = 16,
             wasNavigationSpaceReserved = true,
         )
 
-        assertEquals(-16, decision.translationY)
+        assertEquals(-126, decision.translationY)
 
         // Without the correction the same raw window top reads as expanded
         // and would drop the compensation back to 0.
@@ -227,7 +216,6 @@ class FlatPlayerBoundaryPolicyTest {
             sheetBottom = 900,
             tabsTop = 954,
             tabsHeight = 126,
-            navigationInset = 16,
             wasNavigationSpaceReserved = true,
         )
         assertEquals(0, raw.translationY)


### PR DESCRIPTION
修复Apple Music 6.5.2版本中平板界面底栏与播放器重合，且补偿功能失效的问题