### PR TITLE
fix(ui): allow custom lyrics search to open IME

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,8 +35,8 @@ android {
         applicationId = "dev.amenhancer.module"
         minSdk = 26
         targetSdk = 37
-        versionCode = 102
-        versionName = "1.5.1"
+        versionCode = 103
+        versionName = "1.5.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/dev/amenhancer/module/ui/EmbeddedSettingsHost.kt
+++ b/app/src/main/java/dev/amenhancer/module/ui/EmbeddedSettingsHost.kt
@@ -32,6 +32,8 @@ import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver
+import android.view.WindowManager
+import android.view.inputmethod.EditorInfo
 import android.widget.Button
 import android.widget.EditText
 import android.widget.FrameLayout
@@ -2144,7 +2146,16 @@ internal class EmbeddedSettingsHost private constructor(
             .create()
         dialog.setOnShowListener {
             dialogReady = true
-            dialog.window?.setBackgroundDrawable(android.graphics.drawable.ColorDrawable(Color.TRANSPARENT))
+            dialog.window?.let { window ->
+                // Apple Music's host window marks injected AlertDialogs as
+                // ALT_FOCUSABLE_IM. That leaves the search EditText focused
+                // while InputMethodManager keeps serving the host RecyclerView.
+                // Let this dialog participate in IME focus and resize for the
+                // keyboard instead of relying on the host's window policy.
+                window.clearFlags(WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM)
+                window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+                window.setBackgroundDrawable(android.graphics.drawable.ColorDrawable(Color.TRANSPARENT))
+            }
             syncBottomCloseButton()
             syncDialogLayout()
         }
@@ -2362,7 +2373,10 @@ internal class EmbeddedSettingsHost private constructor(
 
             val search = EditText(activity).apply {
                 hint = "搜索名称或 Apple Music ID"
-            textSize = embeddedTextSize(activity, 14f, 13f)
+                textSize = embeddedTextSize(activity, 14f, 13f)
+                inputType = InputType.TYPE_CLASS_TEXT
+                imeOptions = EditorInfo.IME_ACTION_SEARCH
+                showSoftInputOnFocus = true
                 isSingleLine = true
                 includeFontPadding = false
                 setText(customLyricsSearchQuery)

--- a/app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt
+++ b/app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt
@@ -20,6 +20,7 @@ import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowInsets
+import android.view.inputmethod.EditorInfo
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
@@ -828,6 +829,9 @@ class SettingsActivity : Activity() {
         EditText(this).apply {
             hint = "搜索名称或 Apple Music ID"
             textSize = 14f
+            inputType = InputType.TYPE_CLASS_TEXT
+            imeOptions = EditorInfo.IME_ACTION_SEARCH
+            showSoftInputOnFocus = true
             setTextColor(palette.onSurface)
             setHintTextColor(palette.onSurfaceVariant)
             isSingleLine = true

--- a/app/src/test/java/dev/amenhancer/module/ui/CustomLyricsListPageStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/ui/CustomLyricsListPageStructuralRegressionTest.kt
@@ -81,4 +81,26 @@ class CustomLyricsListPageStructuralRegressionTest {
         assertTrue(activity.contains("没有匹配的歌词"))
         assertTrue(activity.contains("已配置 \${manifest.entries.size} 首；更改后重开 Apple Music 生效"))
     }
+
+    @Test
+    fun `configures both custom lyrics search fields for text IME input`() {
+        val activity = projectFile("app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt")
+        val embeddedHost = projectFile(
+            "app/src/main/java/dev/amenhancer/module/ui/EmbeddedSettingsHost.kt",
+        )
+        val standaloneSearch = activity
+            .substringAfter("private fun customLyricsSearchInput(")
+            .substringBefore("private fun customLyricsEntriesRegion(")
+        val embeddedSearch = embeddedHost
+            .substringAfter("private fun renderEmbeddedCustomLyricsPage(")
+            .substringBefore("private fun embeddedCustomLyricsEntryRow(")
+
+        listOf(standaloneSearch, embeddedSearch).forEach { searchSource ->
+            assertTrue(searchSource.contains("inputType = InputType.TYPE_CLASS_TEXT"))
+            assertTrue(searchSource.contains("imeOptions = EditorInfo.IME_ACTION_SEARCH"))
+            assertTrue(searchSource.contains("showSoftInputOnFocus = true"))
+        }
+        assertTrue(embeddedHost.contains("clearFlags(WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM)"))
+        assertTrue(embeddedHost.contains("setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)"))
+    }
 }


### PR DESCRIPTION
## Summary
- Make both custom-lyrics search fields explicit text editors with the Search IME action.
- Clear `FLAG_ALT_FOCUSABLE_IM` from the embedded settings dialog and use `SOFT_INPUT_ADJUST_RESIZE` so the dialog can receive IME focus.
- Add structural regression coverage for both search paths and the dialog window contract.

## Root cause
On the embedded Apple Music settings page, the search `EditText` received view focus, but the injected `AlertDialog` had `ALT_FOCUSABLE_IM`. `InputMethodManager` therefore continued serving the host `RecyclerView` and kept the keyboard hidden.

## Validation
- `:app:testDebugUnitTest`: 844 tests, 0 failures
- `:app:lintDebug`
- `:app:lintVitalRelease`
- `:app:assembleRelease`
- `git diff --check`
- Device smoke on `emulator-5554` after restarting Apple Music: `mInputShown=true`, served view is `android.widget.EditText`, and typing `Good` updates the filtered results.