### PR TITLE
fix: align fixed-region metadata with HLE resolver

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,7 +36,7 @@ android {
         minSdk = 26
         targetSdk = 37
         versionCode = 103
-        versionName = "1.5.3"
+        versionName = "1.5.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/dev/amenhancer/module/ModuleConstants.kt
+++ b/app/src/main/java/dev/amenhancer/module/ModuleConstants.kt
@@ -4,7 +4,7 @@ object ModuleConstants {
     const val MODULE_PACKAGE = "dev.amenhancer.module"
     const val TARGET_PACKAGE = "com.apple.android.music"
     const val REMOTE_PREFERENCES_GROUP = "settings"
-    const val CONFIG_SCHEMA_VERSION = 11
+    const val CONFIG_SCHEMA_VERSION = 12
 
     const val FEATURE_DUAL_PANE = "dual_pane"
     const val FEATURE_EDITORIAL_VIDEO = "editorial_video"

--- a/app/src/main/java/dev/amenhancer/module/config/CatalogLanguagePolicy.kt
+++ b/app/src/main/java/dev/amenhancer/module/config/CatalogLanguagePolicy.kt
@@ -33,6 +33,7 @@ internal object CatalogLanguagePolicy {
     fun headerLanguage(tag: String): String = when (val normalized = normalize(tag)) {
         "zh-CN", "zh-SG" -> DEFAULT_SCRIPT_SIMPLIFIED
         "zh-TW", "zh-HK", "zh-MO" -> DEFAULT_SCRIPT_TRADITIONAL
+        "ja-JP" -> "ja"
         else -> normalized
     }
 

--- a/app/src/main/java/dev/amenhancer/module/config/EmbeddedConfigurationSession.kt
+++ b/app/src/main/java/dev/amenhancer/module/config/EmbeddedConfigurationSession.kt
@@ -74,7 +74,7 @@ internal class EmbeddedConfigurationSession(
     private val writable: Boolean = true,
 ) : ConfigurationReader {
     init {
-        if (writable) storage.removeValues(ModuleSettingsSchema.obsoleteKeys, synchronous = true)
+        if (writable) migrateLegacyValuesBeforeCleanup()
     }
     private val indexRepository = CustomLyricsIndexRepository(
         newIndexFileId = newIndexFileId,
@@ -164,6 +164,24 @@ internal class EmbeddedConfigurationSession(
 
     override fun openFileDescriptor(name: String): ParcelFileDescriptor? =
         storage.openFileDescriptor(name)
+
+    /**
+     * Existing host-private stores may already be marked initialized, which
+     * intentionally bypasses remote migration.  Convert the legacy title
+     * correction value locally before deleting its old key; if publication
+     * fails, leave the legacy key intact so the next process can retry.
+     */
+    private fun migrateLegacyValuesBeforeCleanup() {
+        val values = runCatching { storage.values() }.getOrNull() ?: return
+        val migration = ModuleSettingsSchema.legacyTitleCorrectionMigrationValues(values)
+        if (migration.isNotEmpty() && !runCatching {
+                storage.writeValues(migration, synchronous = true)
+            }.getOrDefault(false)
+        ) {
+            return
+        }
+        storage.removeValues(ModuleSettingsSchema.obsoleteKeys, synchronous = true)
+    }
 
     private companion object {
         val INDEX_MUTATION_LOCK = Any()

--- a/app/src/main/java/dev/amenhancer/module/config/ModuleSettingsSchema.kt
+++ b/app/src/main/java/dev/amenhancer/module/config/ModuleSettingsSchema.kt
@@ -6,8 +6,8 @@ import dev.amenhancer.module.model.LyricsFontManifest
 import dev.amenhancer.module.model.ModuleSettings
 
 internal object ModuleSettingsSchema {
-    /** Kept for storage callers; all previously obsolete settings are now gone. */
-    internal val obsoleteKeys: Set<String> = emptySet()
+    /** Keys removed by the profile migration. */
+    internal val obsoleteKeys: Set<String> = setOf(KEY_TITLE_CORRECTION_TARGET_LANGUAGE)
 
     fun decode(values: Map<String, *>): ModuleSettings = ModuleSettings(
         dualPaneEnabled = values.boolean(KEY_DUAL_PANE, default = true),
@@ -37,9 +37,7 @@ internal object ModuleSettingsSchema {
             KEY_TITLE_CORRECTION_ENABLED,
             default = false,
         ),
-        titleCorrectionTargetLanguage = CatalogLanguagePolicy.normalize(
-            values.string(KEY_TITLE_CORRECTION_TARGET_LANGUAGE),
-        ),
+        titleCorrectionMode = values.titleCorrectionMode(),
         customLyricsEnabled = values.boolean(
             KEY_CUSTOM_LYRICS_ENABLED,
             default = values.boolean(KEY_LEGACY_ONLINE_LYRIC_REPLACEMENT, default = false),
@@ -75,9 +73,7 @@ internal object ModuleSettingsSchema {
                 ModuleSettings.MAX_LYRIC_BLUR_RADIUS_OFFSET_PX,
             ),
             KEY_TITLE_CORRECTION_ENABLED to settings.titleCorrectionEnabled,
-            KEY_TITLE_CORRECTION_TARGET_LANGUAGE to CatalogLanguagePolicy.normalize(
-                settings.titleCorrectionTargetLanguage,
-            ),
+            KEY_TITLE_CORRECTION_MODE to settings.titleCorrectionMode.storageValue,
             KEY_CUSTOM_LYRICS_ENABLED to settings.customLyricsEnabled,
             KEY_AUTOMATIC_LYRICS_ENABLED to settings.automaticLyricsEnabled,
         )
@@ -160,6 +156,17 @@ internal object ModuleSettingsSchema {
     private fun Map<String, *>.customLyricsManifest(): CustomLyricsManifest =
         decodeLegacyCustomLyricsManifest(this)
 
+    private fun Map<String, *>.titleCorrectionMode(): TitleCorrectionMode {
+        val storedMode = string(KEY_TITLE_CORRECTION_MODE)
+        if (storedMode.isNotBlank()) return TitleCorrectionMode.decode(storedMode)
+        if (!boolean(KEY_TITLE_CORRECTION_ENABLED, default = false)) {
+            return TitleCorrectionMode.ORIGINAL_HYPER
+        }
+        return TitleCorrectionMode.fromLegacyTargetLanguage(
+            string(KEY_TITLE_CORRECTION_TARGET_LANGUAGE),
+        )
+    }
+
     private fun Map<String, *>.string(key: String): String = this[key] as? String ?: ""
 
     private fun Map<String, *>.long(key: String): Long? = when (val value = this[key]) {
@@ -198,6 +205,7 @@ internal object ModuleSettingsSchema {
         KEY_NAVIGATION_COMPENSATION,
         KEY_LYRIC_BLUR_RADIUS_OFFSET,
         KEY_TITLE_CORRECTION_ENABLED,
+        KEY_TITLE_CORRECTION_MODE,
         KEY_TITLE_CORRECTION_TARGET_LANGUAGE,
         KEY_CUSTOM_LYRICS_ENABLED,
         KEY_AUTOMATIC_LYRICS_ENABLED,
@@ -226,6 +234,7 @@ internal object ModuleSettingsSchema {
     private const val KEY_NAVIGATION_COMPENSATION = "navigation_compensation_enabled"
     private const val KEY_LYRIC_BLUR_RADIUS_OFFSET = "lyric_blur_radius_offset_px"
     private const val KEY_TITLE_CORRECTION_ENABLED = "title_correction_enabled"
+    private const val KEY_TITLE_CORRECTION_MODE = "title_correction_mode"
     private const val KEY_TITLE_CORRECTION_TARGET_LANGUAGE = "title_correction_target_language"
     private const val KEY_CUSTOM_LYRICS_ENABLED = "custom_lyrics_enabled"
     private const val KEY_AUTOMATIC_LYRICS_ENABLED = "automatic_lyrics_enabled"

--- a/app/src/main/java/dev/amenhancer/module/config/ModuleSettingsSchema.kt
+++ b/app/src/main/java/dev/amenhancer/module/config/ModuleSettingsSchema.kt
@@ -167,6 +167,24 @@ internal object ModuleSettingsSchema {
         )
     }
 
+    /**
+     * Returns the host-local values required before removing the v11 target
+     * language key.  This is intentionally independent of the schema version:
+     * an already-initialized embedded store skips remote migration, so it must
+     * still be able to upgrade its own legacy value in place.
+     */
+    internal fun legacyTitleCorrectionMigrationValues(values: Map<String, *>): Map<String, Any> {
+        if (!values.containsKey(KEY_TITLE_CORRECTION_TARGET_LANGUAGE) ||
+            values.string(KEY_TITLE_CORRECTION_MODE).isNotBlank()
+        ) {
+            return emptyMap()
+        }
+        return linkedMapOf(
+            KEY_TITLE_CORRECTION_MODE to values.titleCorrectionMode().storageValue,
+            KEY_SCHEMA_VERSION to ModuleConstants.CONFIG_SCHEMA_VERSION,
+        )
+    }
+
     private fun Map<String, *>.string(key: String): String = this[key] as? String ?: ""
 
     private fun Map<String, *>.long(key: String): Long? = when (val value = this[key]) {

--- a/app/src/main/java/dev/amenhancer/module/config/TitleCorrectionMode.kt
+++ b/app/src/main/java/dev/amenhancer/module/config/TitleCorrectionMode.kt
@@ -1,0 +1,60 @@
+package dev.amenhancer.module.config
+
+import com.juren233.hyperlyricsenhanced.common.RootConstants
+
+/**
+ * Metadata presentation profile used by the title-correction feature.
+ *
+ * The master switch remains the opt-in gate.  When it is off no profile is
+ * installed and Apple Music follows the account.  When it is on, one of the
+ * explicit profiles below owns both the request locale and its cache
+ * namespace for the lifetime of the Apple Music process.
+ */
+enum class TitleCorrectionMode(
+    val storageValue: String,
+    val displayName: String,
+    val contentUiLanguageSelection: Int,
+    val catalogStorefront: String?,
+    val catalogLanguage: String?,
+    val cacheNamespace: String,
+) {
+    ORIGINAL_HYPER(
+        storageValue = "original_hyper",
+        displayName = "按歌曲原地区修正",
+        contentUiLanguageSelection = RootConstants.APPLE_MUSIC_CONTENT_UI_LANGUAGE_NONE,
+        catalogStorefront = null,
+        catalogLanguage = null,
+        cacheNamespace = "original_hyper_v1",
+    ),
+    MAINLAND_CHINA(
+        storageValue = "mainland_china",
+        displayName = "固定中国大陆",
+        contentUiLanguageSelection = RootConstants.APPLE_MUSIC_CONTENT_UI_LANGUAGE_ZH_HANS_CN,
+        catalogStorefront = "cn",
+        catalogLanguage = "zh-CN",
+        cacheNamespace = "cn_v1",
+    ),
+    JAPAN(
+        storageValue = "japan",
+        displayName = "固定日本",
+        contentUiLanguageSelection = RootConstants.APPLE_MUSIC_CONTENT_UI_LANGUAGE_JA_JP,
+        catalogStorefront = "jp",
+        catalogLanguage = "ja-JP",
+        cacheNamespace = "jp_v1",
+    );
+
+    companion object {
+        fun decode(raw: String?): TitleCorrectionMode = values().firstOrNull {
+            it.storageValue.equals(raw?.trim(), ignoreCase = true)
+        } ?: ORIGINAL_HYPER
+
+        /** Maps the v11 target-language setting into the new profile model. */
+        fun fromLegacyTargetLanguage(raw: String?): TitleCorrectionMode = when (
+            CatalogLanguagePolicy.normalize(raw)
+        ) {
+            "zh-CN" -> MAINLAND_CHINA
+            "ja-JP" -> JAPAN
+            else -> ORIGINAL_HYPER
+        }
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicCatalogLanguageTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicCatalogLanguageTarget.kt
@@ -2,200 +2,23 @@ package dev.amenhancer.module.hook
 
 import dev.amenhancer.module.config.CatalogLanguagePolicy
 import io.github.proify.lyricon.amprovider.xposed.AppleInternalCatalogResolver
-import java.lang.reflect.Method
 import java.util.LinkedHashMap
 import java.util.Locale
 
 /**
- * Restores AM++'s lower-level Catalog request-language adaptation.
+ * Compatibility adapter for the former process-wide Catalog request-language adaptation.
  *
- * This target intentionally changes only ordinary host traffic. A map carrying
- * HLE's catalog token is left untouched so the original-region resolver can
- * query the locale it detected for that media item.
+ * The old target cannot safely distinguish all ordinary Apple Music requests from
+ * metadata lookups.  HLE now carries its locale in a resolver-owned token instead,
+ * so this adapter must never install global hooks.
  */
 internal class AppleMusicCatalogLanguageTarget(
     private val symbols: TargetSymbolResolver,
-    rawTargetLanguage: String,
+    private val rawTargetLanguage: String?,
 ) : CatalogLanguageTarget {
-    private val targetLanguage = CatalogLanguagePolicy.normalize(rawTargetLanguage)
-
-    override fun install(): TargetCapabilityInstall {
-        if (targetLanguage.isBlank()) {
-            return TargetCapabilityInstall.Degraded("Catalog target language was not configured")
-        }
-
-        val storefrontResolution = symbols.resolve(
-            AppleMusicSymbols.ConfigurationStoreStoreFrontLanguageMethod,
-        )
-        val headersResolution = symbols.resolve(AppleMusicSymbols.StoreApiHeadersSetMethod)
-        val arrayResolution = symbols.resolve(AppleMusicSymbols.StoreFrontLanguageArrayMethod)
-        val iCloudResolution = symbols.resolve(AppleMusicSymbols.ICloudAcceptLanguageHelperMethod)
-        val headerMapResolution = symbols.resolve(AppleMusicSymbols.StoreApiHeaderMapMethod)
-        val iTunesHeaderMapResolution = symbols.resolve(AppleMusicSymbols.ITunesGetHeadersMapMethod)
-        val localeHeaderMapResolution = symbols.resolve(AppleMusicSymbols.LocaleHeaderMapMethod)
-        val languageMapResolution = symbols.resolve(AppleMusicSymbols.MediaApiLanguageParamMethod)
-        val setParamResolution = symbols.resolve(AppleMusicSymbols.StoreLookupSetParamMethod)
-
-        var installed = 0
-        val errors = mutableListOf<String>()
-
-        if (installAfterStringHook(storefrontResolution, "storefront language hook", errors) { param ->
-                param.result = targetLanguage
-            }
-        ) installed++
-
-        if (installBeforeHook(headersResolution, "StoreApi header hook", errors) { param ->
-                val key = param.args.getOrNull(0) as? String
-                if (
-                    key != null &&
-                    key.equals("Accept-Language", ignoreCase = true) &&
-                    param.args.size > 1 &&
-                    (param.args[1] == null || param.args[1] is String)
-                ) {
-                    param.args[1] = CatalogLanguagePolicy.headerLanguage(targetLanguage)
-                }
-            }
-        ) installed++
-
-        if (installAfterValueHook(arrayResolution, "Accept-Language array hook", errors) { result, param ->
-                if (result is Array<*>) param.result = languageArrayFor(targetLanguage)
-            }
-        ) installed++
-
-        if (installAfterValueHook(iCloudResolution, "iCloud Accept-Language hook", errors) { result, param ->
-                if (result is String) {
-                    param.result = CatalogLanguagePolicy.headerLanguage(targetLanguage)
-                }
-            }
-        ) installed++
-
-        if (installAfterValueHook(headerMapResolution, "StoreApi header map hook", errors) { result, param ->
-                val map = result as? Map<*, *> ?: return@installAfterValueHook
-                val rewritten = CatalogLanguageRewritePolicy.withHeaderLanguageValue(map, targetLanguage)
-                if (rewritten !== map) param.result = rewritten
-            }
-        ) installed++
-
-        if (installAfterValueHook(
-                iTunesHeaderMapResolution,
-                "iTunes header map hook",
-                errors,
-            ) { result, param ->
-                val map = result as? Map<*, *> ?: return@installAfterValueHook
-                val rewritten = CatalogLanguageRewritePolicy.withHeaderLanguageValue(map, targetLanguage)
-                if (rewritten !== map) param.result = rewritten
-            }
-        ) installed++
-
-        if (installAfterValueHook(
-                localeHeaderMapResolution,
-                "locale header map hook",
-                errors,
-            ) { result, param ->
-                val map = result as? Map<*, *> ?: return@installAfterValueHook
-                val rewritten = CatalogLanguageRewritePolicy.withHeaderLanguageValue(map, targetLanguage)
-                if (rewritten !== map) param.result = rewritten
-            }
-        ) installed++
-
-        if (installAfterValueHook(
-                languageMapResolution,
-                "MediaApi language map hook",
-                errors,
-            ) { result, param ->
-                val map = result as? Map<*, *> ?: return@installAfterValueHook
-                val rewritten = CatalogLanguageRewritePolicy.withRawTagLanguageValue(map, targetLanguage)
-                if (rewritten !== map) param.result = rewritten
-            }
-        ) installed++
-
-        if (installBeforeHook(setParamResolution, "Store lookup setParam hook", errors) { param ->
-                val key = param.args.getOrNull(0)?.toString()?.lowercase(Locale.ROOT)
-                if (key in CatalogLanguageRewritePolicy.rawTagKeys && param.args.size > 1) {
-                    param.args[1] = targetLanguage
-                }
-            }
-        ) installed++
-
-        if (installed == 0) {
-            return TargetCapabilityInstall.Degraded(
-                errors.joinToString("; ").ifBlank {
-                    "Catalog language hooks could not be installed"
-                },
-            )
-        }
-        return TargetCapabilityInstall.Active(
-            "Ordinary Catalog requests use $targetLanguage; installed $installed hook(s)" +
-                if (errors.isEmpty()) "" else "; " + errors.joinToString("; "),
-        )
-    }
-
-    private fun languageArrayFor(language: String): Array<String> {
-        val primary = Locale.forLanguageTag(language).language.ifBlank { "en" }
-        return arrayOf(primary, "en")
-    }
-
-    private fun installAfterStringHook(
-        resolution: TargetResolution<Method>,
-        errorName: String,
-        errors: MutableList<String>,
-        block: (ModernMethodHook.MethodHookParam) -> Unit,
-    ): Boolean = installHook(resolution, errorName, errors) { method ->
-        ModernXposedRuntime.hookMethod(method, object : ModernMethodHook() {
-            override fun afterHookedMethod(param: ModernMethodHook.MethodHookParam) {
-                runCatching { block(param) }
-            }
-        })
-    }
-
-    private fun installAfterValueHook(
-        resolution: TargetResolution<Method>,
-        errorName: String,
-        errors: MutableList<String>,
-        block: (Any?, ModernMethodHook.MethodHookParam) -> Unit,
-    ): Boolean = installHook(resolution, errorName, errors) { method ->
-        ModernXposedRuntime.hookMethod(method, object : ModernMethodHook() {
-            override fun afterHookedMethod(param: ModernMethodHook.MethodHookParam) {
-                runCatching {
-                    if (!param.shouldReturnEarly()) block(param.result, param)
-                }
-            }
-        })
-    }
-
-    private fun installBeforeHook(
-        resolution: TargetResolution<Method>,
-        errorName: String,
-        errors: MutableList<String>,
-        block: (ModernMethodHook.MethodHookParam) -> Unit,
-    ): Boolean = installHook(resolution, errorName, errors) { method ->
-        ModernXposedRuntime.hookMethod(method, object : ModernMethodHook() {
-            override fun beforeHookedMethod(param: ModernMethodHook.MethodHookParam) {
-                runCatching { block(param) }
-            }
-        })
-    }
-
-    private fun installHook(
-        resolution: TargetResolution<Method>,
-        errorName: String,
-        errors: MutableList<String>,
-        install: (Method) -> Unit,
-    ): Boolean {
-        val method = resolution.valueOrNull()
-        if (method == null) {
-            errors += resolution.summary
-            return false
-        }
-        return runCatching {
-            method.isAccessible = true
-            install(method)
-            true
-        }.getOrElse {
-            errors += errorName + ": " + it.message.orEmpty()
-            false
-        }
-    }
+    override fun install(): TargetCapabilityInstall = TargetCapabilityInstall.Degraded(
+        "Global Catalog locale hooks disabled; locale is scoped to HLE metadata tokens",
+    )
 }
 
 internal fun interface CatalogLanguageTarget {

--- a/app/src/main/java/dev/amenhancer/module/hook/CatalogLanguageFeature.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/CatalogLanguageFeature.kt
@@ -1,26 +1,20 @@
 package dev.amenhancer.module.hook
 
 import dev.amenhancer.module.ModuleConstants
-import dev.amenhancer.module.config.CatalogLanguagePolicy
 
 /**
- * Optional request-language half of title correction.
+ * Legacy compatibility slot for the old global Catalog-language feature.
  *
- * It is deliberately installed before HLE metadata hooks. HLE's tokenized
- * resolver requests have their own locale and later take precedence, while
- * normal Apple Music Catalog requests retain the configured target language.
+ * Fixed-region title correction now scopes the locale to HLE's tokenized
+ * metadata requests. Installing the old process-wide hooks would change
+ * ordinary Apple Music traffic (and can make account-available songs appear
+ * unavailable), so this feature is intentionally inert for every mode.
  */
 internal class CatalogLanguageFeature : FeatureHook {
     override val key: String = ModuleConstants.FEATURE_CATALOG_LANGUAGE
 
-    override fun install(context: HookContext): FeatureInstallResult {
-        val settings = context.config.settings()
-        if (!settings.titleCorrectionEnabled) return FeatureInstallResult.disabled()
-        if (!CatalogLanguagePolicy.isConfigured(settings.titleCorrectionTargetLanguage)) {
-            return FeatureInstallResult.disabled(
-                "No target language configured; ordinary Catalog requests follow Apple Music",
-            )
-        }
-        return context.target.catalogLanguage.install().toFeatureInstallResult()
-    }
+    override fun install(context: HookContext): FeatureInstallResult =
+        FeatureInstallResult.disabled(
+            "Scoped to HLE metadata requests; ordinary Apple Music requests follow the account",
+        )
 }

--- a/app/src/main/java/dev/amenhancer/module/hook/FeatureInstallation.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/FeatureInstallation.kt
@@ -281,7 +281,6 @@ private fun productionFeatureInstallationModule(
                 registerResources = lyricsTypefaceSession::registerResources,
             ),
             FeatureInstallationPlan(feature = CurrentSongIdentityFeature()),
-            FeatureInstallationPlan(feature = CatalogLanguageFeature()),
             FeatureInstallationPlan(feature = TitleCorrectionFeature()),
             FeatureInstallationPlan(feature = CustomLyricsFeature()),
         ),

--- a/app/src/main/java/dev/amenhancer/module/hook/HleMetadataRuntime.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/HleMetadataRuntime.kt
@@ -1,8 +1,7 @@
 package dev.amenhancer.module.hook
 
 import android.app.Application
-import android.content.SharedPreferences
-import dev.amenhancer.module.ModuleConstants
+import dev.amenhancer.module.config.TitleCorrectionMode
 import io.github.libxposed.api.XposedModule
 import io.github.proify.lyricon.amprovider.xposed.AppleInternalCatalogResolver
 import io.github.proify.lyricon.amprovider.xposed.AppleMetadataOverrideStore
@@ -26,7 +25,6 @@ import io.github.proify.lyricon.amprovider.xposed.AppleActionSheetMetadataHooks
 import io.github.proify.lyricon.amprovider.xposed.AppleActionSheetMetadataHost
 import io.github.proify.lyricon.amprovider.xposed.InAppContainerKind
 import io.github.proify.lyricon.amprovider.xposed.validatedOriginalSongAlias
-import com.juren233.hyperlyricsenhanced.common.RootConstants
 import com.juren233.hyperlyricsenhanced.common.lyric.AppleOriginalMetadataPolicy
 
 /**
@@ -41,6 +39,7 @@ internal class HleMetadataRuntime(
     private val module: XposedModule,
     private val application: Application,
     private val classLoader: ClassLoader,
+    private val mode: TitleCorrectionMode = TitleCorrectionMode.ORIGINAL_HYPER,
 ) {
     private val version = runCatching {
         val info = application.packageManager.getPackageInfo(
@@ -71,12 +70,8 @@ internal class HleMetadataRuntime(
         classLoader = classLoader,
         hookResolver = hookResolver,
         mainHandler = runtime.mainHandler,
+        cacheNamespace = mode.cacheNamespace,
     )
-    private val remotePreferences: SharedPreferences? by lazy {
-        runCatching {
-            module.getRemotePreferences(ModuleConstants.REMOTE_PREFERENCES_GROUP)
-        }.getOrNull()
-    }
     private lateinit var contentLocalizationHooks: AppleContentLocalizationHooks
     private lateinit var frameworkHooks: AppleFrameworkMetadataHooks
     private lateinit var playbackCoordinator: ApplePlaybackMetadataCoordinator
@@ -130,12 +125,12 @@ internal class HleMetadataRuntime(
 
     fun install(): TargetCapabilityInstall {
         runtime.attach(application, hookResolver)
-        catalogResolver.applyContentUiLanguage(RootConstants.APPLE_MUSIC_CONTENT_UI_LANGUAGE_NONE)
+        MediaMetadataCache.setProfile(mode.cacheNamespace)
+        catalogResolver.applyContentUiLanguage(mode.contentUiLanguageSelection)
         catalogResolver.setPersistentLocalizedCacheEnabled(true)
 
         contentLocalizationHooks = AppleContentLocalizationHooks(
             runtime = runtime,
-            preferences = { remotePreferences },
             catalogResolver = { catalogResolver },
         )
         runCatching { contentLocalizationHooks.installMediaApiLocalization() }
@@ -382,6 +377,9 @@ internal class HleMetadataRuntime(
             contentItemHooks = contentItemHooks,
             queueMetadataHooks = queueMetadataHooks,
             actionSheetMetadataHooks = actionSheetMetadataHooks,
+            configuredContentUiLanguage = mode.contentUiLanguageSelection,
+            restoreOriginalMetadata = mode == TitleCorrectionMode.ORIGINAL_HYPER,
+            profileId = mode.cacheNamespace,
         )
         surfaceBridge.install()
         bridgeEnsureOverride = surfaceBridge::ensureOverride
@@ -425,11 +423,12 @@ internal class HleMetadataRuntime(
 
     private fun playbackHost() = object : ApplePlaybackMetadataCoordinatorHost {
         override fun activePlayer(): Any? = playbackHooks.activePlayer()
-        override fun configuredContentUiLanguage(): Int =
-            RootConstants.APPLE_MUSIC_CONTENT_UI_LANGUAGE_NONE
-        override fun shouldOverrideAccountLanguage(selection: Int): Boolean = false
+        override fun configuredContentUiLanguage(): Int = mode.contentUiLanguageSelection
+        override fun shouldOverrideAccountLanguage(selection: Int): Boolean =
+            mode.catalogLanguage != null
         override fun shouldRestoreCjkOriginalMetadata(metadata: MediaMetadataCache.Metadata): Boolean =
-            AppleOriginalMetadataPolicy.shouldProbeCjkOriginalMetadata(
+            mode == TitleCorrectionMode.ORIGINAL_HYPER &&
+                AppleOriginalMetadataPolicy.shouldProbeCjkOriginalMetadata(
                 mediaId = metadata.id,
                 title = metadata.title,
                 artist = metadata.artist,
@@ -460,6 +459,8 @@ internal class HleMetadataRuntime(
                     originalMetadata = originalMetadata,
                     originalMetadataConfirmed = originalMetadataConfirmed,
                 )
+            } else if (originalMetadata && mode != TitleCorrectionMode.ORIGINAL_HYPER) {
+                return
             } else if (originalMetadata) {
                 metadataStore.rememberOriginalMetadata(mediaId, alias, originalMetadataConfirmed)
             } else {
@@ -475,13 +476,11 @@ internal class HleMetadataRuntime(
             alias: AppleInternalCatalogResolver.Alias?,
             localizedTitle: String?,
             localizedArtist: String?,
-            allowArtistOnly: Boolean,
         ): AppleInternalCatalogResolver.Alias? =
             io.github.proify.lyricon.amprovider.xposed.validatedOriginalSongAlias(
                 alias = alias,
                 localizedTitle = localizedTitle,
                 localizedArtist = localizedArtist,
-                allowArtistOnly = allowArtistOnly,
             )
         override fun shouldShareOriginalSongLanguage(
             localizedTitle: String?,
@@ -501,7 +500,8 @@ internal class HleMetadataRuntime(
                 surfaceBridge.rememberOriginalLanguageForArtist(mediaId, language)
             }
         }
-        override fun isRestoreOriginalMetadataEnabled(): Boolean = true
+        override fun isRestoreOriginalMetadataEnabled(): Boolean =
+            mode == TitleCorrectionMode.ORIGINAL_HYPER
     }
 
     private fun effectiveAlias(mediaId: String): AppleInternalCatalogResolver.Alias? =

--- a/app/src/main/java/dev/amenhancer/module/hook/HleMetadataSurfaceBridge.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/HleMetadataSurfaceBridge.kt
@@ -22,6 +22,9 @@ internal class HleMetadataSurfaceBridge(
     private val contentItemHooks: AppleContentItemMetadataHooks,
     private val queueMetadataHooks: AppleQueueMetadataHooks,
     private val actionSheetMetadataHooks: AppleActionSheetMetadataHooks,
+    private val configuredContentUiLanguage: Int,
+    private val restoreOriginalMetadata: Boolean,
+    private val profileId: String,
 ) {
     private val traceSequence = AtomicLong(0L)
     private val registry = AppleInAppMetadataRegistry()
@@ -45,6 +48,7 @@ internal class HleMetadataSurfaceBridge(
     private lateinit var visibleMetadataDiagnostics: AppleVisibleMetadataDiagnostics
 
     fun install() {
+        MediaMetadataCache.setProfile(profileId)
         refreshQueue = AppleInAppMetadataRefreshQueue(
             postToMain = { callback -> runtime.mainHandler.post { callback() } },
             diagnostics = if (BuildConfig.DEBUG) {
@@ -149,7 +153,7 @@ internal class HleMetadataSurfaceBridge(
             metadataApplier = metadataApplier,
             surfaceRuntime = surfaceRuntime,
             dataBindingHooks = dataBindingHooks,
-            configuredContentUiLanguage = { 0 },
+            configuredContentUiLanguage = { this@HleMetadataSurfaceBridge.configuredContentUiLanguage },
         )
         visibleMetadataDiagnostics = AppleVisibleMetadataDiagnostics(
             runtime = runtime,
@@ -171,7 +175,7 @@ internal class HleMetadataSurfaceBridge(
             frameworkMetadataHooks = frameworkHooks,
             visibleMetadataDiagnostics = visibleMetadataDiagnostics,
             media3MetadataCoordinator = media3MetadataCoordinator,
-            configuredContentUiLanguage = { 0 },
+            configuredContentUiLanguage = { this@HleMetadataSurfaceBridge.configuredContentUiLanguage },
             traceSequence = traceSequence,
         )
         playbackItemConversionHooks = ApplePlaybackItemConversionHooks(
@@ -287,16 +291,24 @@ internal class HleMetadataSurfaceBridge(
         originalMetadataConfirmed: Boolean = false,
         artistOnly: Boolean = false,
         propagateArtistEntity: Boolean = true,
-    ) = metadataOverrideApplicationCoordinator.apply(
-        mediaId = mediaId,
-        alias = alias,
-        forceInAppRebind = forceInAppRebind,
-        rememberLocalizedArtist = rememberLocalizedArtist,
-        originalMetadata = originalMetadata,
-        originalMetadataConfirmed = originalMetadataConfirmed,
-        artistOnly = artistOnly,
-        propagateArtistEntity = propagateArtistEntity,
-    )
+    ) {
+        if (MediaMetadataCache.profile() != profileId) {
+            ProviderLogger.debug(
+                "忽略过期元数据 profile 回调: expected=$profileId, active=${MediaMetadataCache.profile()}"
+            )
+            return
+        }
+        metadataOverrideApplicationCoordinator.apply(
+            mediaId = mediaId,
+            alias = alias,
+            forceInAppRebind = forceInAppRebind,
+            rememberLocalizedArtist = rememberLocalizedArtist,
+            originalMetadata = originalMetadata,
+            originalMetadataConfirmed = originalMetadataConfirmed,
+            artistOnly = artistOnly,
+            propagateArtistEntity = propagateArtistEntity,
+        )
+    }
 
     private fun applyPlaybackMetadataOverrideFromHost(
         mediaId: String,
@@ -308,6 +320,7 @@ internal class HleMetadataSurfaceBridge(
         artistOnly: Boolean,
         propagateArtistEntity: Boolean,
     ) {
+        if (originalMetadata && !restoreOriginalMetadata) return
         if (::metadataOverrideApplicationCoordinator.isInitialized) {
             applyPlaybackMetadataOverride(
                 mediaId = mediaId,
@@ -362,14 +375,17 @@ internal class HleMetadataSurfaceBridge(
         localizedTitle: String?,
         localizedArtist: String?,
         alias: AppleInternalCatalogResolver.Alias?,
-    ): Boolean = resolutionCoordinator.shouldShareOriginalSongLanguage(
+    ): Boolean = restoreOriginalMetadata && resolutionCoordinator.shouldShareOriginalSongLanguage(
         localizedTitle = localizedTitle,
         localizedArtist = localizedArtist,
         alias = alias,
     )
 
-    fun rememberOriginalLanguageForArtist(mediaId: String, language: String) =
-        resolutionCoordinator.rememberOriginalLanguageForArtist(mediaId, language)
+    fun rememberOriginalLanguageForArtist(mediaId: String, language: String) {
+        if (restoreOriginalMetadata) {
+            resolutionCoordinator.rememberOriginalLanguageForArtist(mediaId, language)
+        }
+    }
 
     fun containerNavigationBinding(containerItem: Any): InAppContainerNavigationRef? =
         metadataRegistrationCoordinator.containerNavigationBinding(containerItem)
@@ -1089,7 +1105,7 @@ internal class HleMetadataSurfaceBridge(
                     localizedArtist: String?,
                     alias: AppleInternalCatalogResolver.Alias?,
                 ): Boolean = bridge.hostCall("mediaApi.shouldShareOriginalSongLanguage", false) {
-                    bridge.resolutionCoordinator.shouldShareOriginalSongLanguage(
+                    bridge.shouldShareOriginalSongLanguage(
                         localizedTitle = localizedTitle,
                         localizedArtist = localizedArtist,
                         alias = alias,
@@ -1098,7 +1114,7 @@ internal class HleMetadataSurfaceBridge(
 
                 override fun rememberOriginalLanguageForArtist(mediaId: String, language: String) =
                     bridge.hostCall("mediaApi.rememberOriginalLanguageForArtist", Unit) {
-                        bridge.resolutionCoordinator.rememberOriginalLanguageForArtist(mediaId, language)
+                        bridge.rememberOriginalLanguageForArtist(mediaId, language)
                     }
 
                 override fun hydrateSharedArtistOverrides(mediaId: String) =
@@ -1138,7 +1154,8 @@ internal class HleMetadataSurfaceBridge(
                     bridge.resolutionCoordinator.schedule(mediaIds, priority, originalResolutionMode)
                 }
 
-                override fun configuredContentUiLanguage(): Int = 0
+                override fun configuredContentUiLanguage(): Int =
+                    this@HleMetadataSurfaceBridge.configuredContentUiLanguage
 
                 override fun nextTraceSequence(): Long =
                     bridge.hostCall("mediaApi.nextTraceSequence", 0L) {
@@ -1151,11 +1168,13 @@ internal class HleMetadataSurfaceBridge(
                         bridge.playbackCoordinator.currentMetadataId()
                     }
 
-                override fun configuredContentUiLanguage(): Int = 0
+                override fun configuredContentUiLanguage(): Int =
+                    this@HleMetadataSurfaceBridge.configuredContentUiLanguage
 
-                override fun shouldOverrideAccountLanguage(selection: Int): Boolean = false
+                override fun shouldOverrideAccountLanguage(selection: Int): Boolean =
+                    this@HleMetadataSurfaceBridge.configuredContentUiLanguage != 0
 
-                override fun isRestoreOriginalEnabled(): Boolean = true
+                override fun isRestoreOriginalEnabled(): Boolean = restoreOriginalMetadata
 
                 override fun refreshRequestScope() =
                     bridge.hostCall("resolution.refreshRequestScope", Unit) {
@@ -1253,7 +1272,7 @@ internal class HleMetadataSurfaceBridge(
                     bridge.librarySurfaceHooks.enrichEntity(mediaId, entity, kind, attributes)
                 }
 
-                override fun isRestoreOriginalMetadataEnabled(): Boolean = true
+                override fun isRestoreOriginalMetadataEnabled(): Boolean = restoreOriginalMetadata
 
                 override fun shouldRetryOriginalMetadataCacheProbe(mediaId: String): Boolean =
                     bridge.hostCall("listenNow.shouldRetryOriginalMetadataCacheProbe", false) {
@@ -1265,12 +1284,14 @@ internal class HleMetadataSurfaceBridge(
                     alias: AppleInternalCatalogResolver.Alias,
                     confirmed: Boolean,
                 ) = bridge.hostCall("listenNow.rememberOriginalMetadataOverride", Unit) {
-                    bridge.metadataStore.rememberOriginalMetadata(mediaId, alias, confirmed)
+                    if (bridge.restoreOriginalMetadata) {
+                        bridge.metadataStore.rememberOriginalMetadata(mediaId, alias, confirmed)
+                    }
                 }
 
                 override fun rememberOriginalLanguageForArtist(mediaId: String, language: String) =
                     bridge.hostCall("listenNow.rememberOriginalLanguageForArtist", Unit) {
-                        bridge.resolutionCoordinator.rememberOriginalLanguageForArtist(mediaId, language)
+                        bridge.rememberOriginalLanguageForArtist(mediaId, language)
                     }
 
                 override fun resolveCachedOriginalEntityForInApp(

--- a/app/src/main/java/dev/amenhancer/module/hook/TargetAdaptation.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/TargetAdaptation.kt
@@ -28,8 +28,9 @@ internal data class TargetAdaptation(
     val currentSongIdentity: CurrentSongIdentityTarget = CurrentSongIdentityTarget {
         TargetCapabilityInstall.Degraded("Current song identity target was not configured")
     },
+    /** Retained only for compatibility; the former global target is never installed. */
     val catalogLanguage: CatalogLanguageTarget = CatalogLanguageTarget {
-        TargetCapabilityInstall.Degraded("Catalog language target was not configured")
+        TargetCapabilityInstall.Degraded("Catalog language target is intentionally disabled")
     },
     val hleMetadata: HleMetadataTarget = HleMetadataTarget {
         TargetCapabilityInstall.Degraded("HLE metadata target was not configured")
@@ -85,7 +86,7 @@ internal data class TargetAdaptation(
                 ),
                 catalogLanguage = AppleMusicCatalogLanguageTarget(
                     symbols = resolver,
-                    rawTargetLanguage = settings.titleCorrectionTargetLanguage,
+                    rawTargetLanguage = settings.titleCorrectionMode.catalogLanguage.orEmpty(),
                 ),
                 hleMetadata = HleMetadataTarget {
                     val activeModule = ModernXposedRuntime.activeModule()
@@ -97,6 +98,7 @@ internal data class TargetAdaptation(
                             module = activeModule,
                             application = application,
                             classLoader = classLoader,
+                            mode = settings.titleCorrectionMode,
                         ).install()
                     }.getOrElse { error ->
                         ModernXposedRuntime.log("HLE metadata runtime install failed", error)

--- a/app/src/main/java/dev/amenhancer/module/model/ModuleModels.kt
+++ b/app/src/main/java/dev/amenhancer/module/model/ModuleModels.kt
@@ -1,7 +1,7 @@
 package dev.amenhancer.module.model
 
 import dev.amenhancer.module.ModuleConstants
-import dev.amenhancer.module.config.CatalogLanguagePolicy
+import dev.amenhancer.module.config.TitleCorrectionMode
 
 data class ModuleSettings(
     val dualPaneEnabled: Boolean = true,
@@ -14,8 +14,8 @@ data class ModuleSettings(
     val navigationCompensationEnabled: Boolean = false,
     val lyricBlurRadiusOffsetPx: Int = 0,
     val titleCorrectionEnabled: Boolean = false,
-    /** Optional BCP-47 language for ordinary Apple Music Catalog requests. */
-    val titleCorrectionTargetLanguage: String = CatalogLanguagePolicy.DISABLED_TARGET_LANGUAGE,
+    /** Selected metadata profile; ignored while [titleCorrectionEnabled] is false. */
+    val titleCorrectionMode: TitleCorrectionMode = TitleCorrectionMode.ORIGINAL_HYPER,
     val customLyricsEnabled: Boolean = false,
     /** Enables background AMLL/Lunabeat/user-repository lyric completion. */
     val automaticLyricsEnabled: Boolean = true,

--- a/app/src/main/java/dev/amenhancer/module/ui/EmbeddedSettingsHost.kt
+++ b/app/src/main/java/dev/amenhancer/module/ui/EmbeddedSettingsHost.kt
@@ -46,8 +46,8 @@ import android.widget.Switch
 import android.widget.TextView
 import android.widget.Toast
 import dev.amenhancer.module.ModuleConstants
-import dev.amenhancer.module.config.CatalogLanguagePolicy
 import dev.amenhancer.module.config.EmbeddedConfigurationSession
+import dev.amenhancer.module.config.TitleCorrectionMode
 import dev.amenhancer.module.CurrentSongDetails
 import dev.amenhancer.module.hook.AmLyricsClient
 import dev.amenhancer.module.hook.AmllTtmlClient
@@ -2230,7 +2230,11 @@ internal class EmbeddedSettingsHost private constructor(
             addView(embeddedSettingRow(
                 activity,
                 "歌曲名显示修正",
-                "按 HLE 原地区策略修正歌曲信息，并创建持久化检索库；目标语言仅改写底层 Catalog 请求",
+                if (settings.titleCorrectionEnabled) {
+                    "${settings.titleCorrectionMode.displayName} · 重开 Apple Music 后生效"
+                } else {
+                    "关闭时跟随 Apple Music 账号 · 开启后选择修正地区"
+                },
                 settings.titleCorrectionEnabled,
                 iconTint = EmbeddedSettingsPalette.accent,
                 iconDrawable = EmbeddedGlyphDrawable(
@@ -2241,19 +2245,18 @@ internal class EmbeddedSettingsHost private constructor(
             addView(embeddedDivider(activity))
             addView(embeddedNavigationRow(
                 activity,
-                "目标语言",
-                CatalogLanguagePolicy.displayName(settings.titleCorrectionTargetLanguage),
+                "歌曲名修正模式",
+                settings.titleCorrectionMode.displayName,
                 iconDrawable = EmbeddedGlyphDrawable(
                     EmbeddedGlyphKind.Translate,
                     EmbeddedSettingsPalette.accent,
                 ),
                 inlineSummary = true,
             ) {
-                showEmbeddedTargetLanguagePicker(
+                showEmbeddedTitleCorrectionModePicker(
                     activity = activity,
-                    current = settings.titleCorrectionTargetLanguage,
-                ) { target ->
-                    onSettingsChanged(settings.copy(titleCorrectionTargetLanguage = target))
+                ) { mode ->
+                    onSettingsChanged(settings.copy(titleCorrectionMode = mode))
                     pageRefresh?.invoke()
                 }
             })
@@ -3095,52 +3098,20 @@ internal class EmbeddedSettingsHost private constructor(
         }, matchWidthWrapContent())
     }
 
-    private fun showEmbeddedTargetLanguagePicker(
+    private fun showEmbeddedTitleCorrectionModePicker(
         activity: Activity,
-        current: String,
-        onSelected: (String) -> Unit,
+        onSelected: (TitleCorrectionMode) -> Unit,
     ) {
-        val normalizedCurrent = CatalogLanguagePolicy.normalize(current)
-        val tags = listOf("", "zh-CN", "zh-TW", "ja-JP", "ko-KR", "en-US", "tr-TR")
-        val labels = tags.map { CatalogLanguagePolicy.displayName(it) }.toTypedArray()
+        val modes = TitleCorrectionMode.values()
+        val current = controller.currentSettings().titleCorrectionMode
+        val labels = modes.map(TitleCorrectionMode::displayName).toTypedArray()
         AlertDialog.Builder(activity)
-            .setTitle("目标语言")
-            .setSingleChoiceItems(labels, tags.indexOf(normalizedCurrent)) { dialog, which ->
-                tags.getOrNull(which)?.let(onSelected)
+            .setTitle("歌曲名修正模式")
+            .setSingleChoiceItems(labels, modes.indexOf(current)) { dialog, which ->
+                modes.getOrNull(which)?.let(onSelected)
                 dialog.dismiss()
             }
-            .setNeutralButton("自定义") { _, _ ->
-                showEmbeddedTargetLanguageEditor(activity, normalizedCurrent, onSelected)
-            }
             .setNegativeButton("取消", null)
-            .show()
-    }
-
-    private fun showEmbeddedTargetLanguageEditor(
-        activity: Activity,
-        current: String,
-        onSelected: (String) -> Unit,
-    ) {
-        val input = EditText(activity).apply {
-            hint = "例如 ja-JP"
-            inputType = InputType.TYPE_CLASS_TEXT
-            setText(current)
-            setSelectAllOnFocus(true)
-            setPadding(dp(activity, 24), dp(activity, 8), dp(activity, 24), 0)
-        }
-        AlertDialog.Builder(activity)
-            .setTitle("自定义目标语言")
-            .setMessage("请输入 BCP-47 语言标签（例如 zh-CN）；留空请在上一级选择“跟随 Apple Music”")
-            .setView(input)
-            .setNegativeButton("取消", null)
-            .setPositiveButton("保存") { _, _ ->
-                val raw = input.text?.toString().orEmpty()
-                if (!CatalogLanguagePolicy.isValid(raw)) {
-                    Toast.makeText(activity, "目标语言格式无效，例如 ja-JP", Toast.LENGTH_SHORT).show()
-                } else {
-                    onSelected(CatalogLanguagePolicy.normalize(raw))
-                }
-            }
             .show()
     }
 

--- a/app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt
+++ b/app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt
@@ -35,8 +35,8 @@ import android.widget.Toast
 import dev.amenhancer.module.ModuleApplication
 import dev.amenhancer.module.R
 import dev.amenhancer.module.XposedServiceSnapshot
-import dev.amenhancer.module.config.CatalogLanguagePolicy
 import dev.amenhancer.module.config.ConfigStore
+import dev.amenhancer.module.config.TitleCorrectionMode
 import dev.amenhancer.module.font.FontImportResult
 import dev.amenhancer.module.font.SafFontImporter
 import dev.amenhancer.module.hook.AmLyricsClient
@@ -419,7 +419,11 @@ class SettingsActivity : Activity() {
             addView(insetDivider())
             addView(settingRow(
                 title = "歌曲名显示修正",
-                summary = "按 HyperLyrics-Enhanced 策略恢复原地区原名，并创建持久化检索库；目标语言仅改写底层 Catalog 请求 · 修改后重开 Apple Music",
+                summary = if (settings.titleCorrectionEnabled) {
+                    "${settings.titleCorrectionMode.displayName} · 修改后重开 Apple Music"
+                } else {
+                    "关闭时跟随 Apple Music 账号 · 开启后选择修正地区"
+                },
                 checked = settings.titleCorrectionEnabled,
                 enabled = writable,
             ) { enabled ->
@@ -427,10 +431,10 @@ class SettingsActivity : Activity() {
             })
             addView(insetDivider())
             addView(actionRow(
-                title = "目标语言",
-                summary = CatalogLanguagePolicy.displayName(settings.titleCorrectionTargetLanguage),
+                title = "歌曲名修正模式",
+                summary = settings.titleCorrectionMode.displayName,
                 enabled = writable,
-            ) { showTargetLanguagePicker() })
+            ) { showTitleCorrectionModePicker() })
             addView(insetDivider())
             addView(customLyricsNavigationRow(settings.customLyricsManifest))
         }
@@ -473,57 +477,25 @@ class SettingsActivity : Activity() {
         setOnClickListener { if (enabled) onClick() }
     }
 
-    private fun showTargetLanguagePicker() {
-        val current = CatalogLanguagePolicy.normalize(store.settings().titleCorrectionTargetLanguage)
-        val tags = listOf("", "zh-CN", "zh-TW", "ja-JP", "ko-KR", "en-US", "tr-TR")
-        val labels = tags.map { CatalogLanguagePolicy.displayName(it) }.toTypedArray()
+    private fun showTitleCorrectionModePicker() {
+        val modes = TitleCorrectionMode.values()
+        val current = store.settings().titleCorrectionMode
+        val labels = modes.map(TitleCorrectionMode::displayName).toTypedArray()
         AlertDialog.Builder(this)
-            .setTitle("目标语言")
-            .setSingleChoiceItems(labels, tags.indexOf(current)) { dialog, which ->
-                tags.getOrNull(which)?.let(::saveTargetLanguage)
+            .setTitle("歌曲名修正模式")
+            .setSingleChoiceItems(labels, modes.indexOf(current)) { dialog, which ->
+                modes.getOrNull(which)?.let(::saveTitleCorrectionMode)
                 dialog.dismiss()
             }
-            .setNeutralButton("自定义") { _, _ -> showTargetLanguageEditor(current) }
             .setNegativeButton("取消", null)
             .show()
     }
 
-    private fun showTargetLanguageEditor(current: String) {
-        val input = EditText(this).apply {
-            hint = "例如 ja-JP"
-            inputType = InputType.TYPE_CLASS_TEXT
-            setText(current)
-            setSelectAllOnFocus(true)
-            setPadding(dp(24), dp(8), dp(24), 0)
-        }
-        AlertDialog.Builder(this)
-            .setTitle("自定义目标语言")
-            .setMessage("请输入 BCP-47 语言标签（例如 zh-CN）；留空请在上一级选择“跟随 Apple Music”")
-            .setView(input)
-            .setNegativeButton("取消", null)
-            .setPositiveButton("保存") { _, _ ->
-                val raw = input.text?.toString().orEmpty()
-                if (!CatalogLanguagePolicy.isValid(raw)) {
-                    toast("目标语言格式无效，例如 ja-JP")
-                } else {
-                    saveTargetLanguage(raw)
-                }
-            }
-            .show()
-    }
-
-    private fun saveTargetLanguage(raw: String) {
-        val normalized = CatalogLanguagePolicy.normalize(raw)
+    private fun saveTitleCorrectionMode(mode: TitleCorrectionMode) {
         store.saveSettings(
-            store.settings().copy(titleCorrectionTargetLanguage = normalized),
+            store.settings().copy(titleCorrectionMode = mode),
         )
-        val message = if (normalized.isBlank()) {
-            "目标语言已恢复为跟随 Apple Music；重开 Apple Music 后生效"
-        } else {
-            "目标语言已设为 " + CatalogLanguagePolicy.displayName(normalized) +
-                "；重开 Apple Music 后生效"
-        }
-        toast(message)
+        toast("歌曲名修正模式已设为${mode.displayName}；重开 Apple Music 后生效")
         render()
     }
 

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleInternalCatalogResolver.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleInternalCatalogResolver.kt
@@ -11,7 +11,6 @@ import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.lang.reflect.Proxy
-import java.util.ArrayDeque
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
@@ -105,7 +104,7 @@ internal class AppleInternalCatalogResolver(
      * Fixed-region ID misses use a two-step identity/ISRC chain.  Keep that chain behind its own
      * small queue so a 50-item localized batch cannot turn into 50 simultaneous host requests.
      */
-    private val lockedIsrcFallbackPending = ArrayDeque<LockedIsrcFallbackTask>()
+    private val lockedIsrcFallbackPending = mutableListOf<LockedIsrcFallbackTask>()
     private var lockedIsrcFallbackRunning = 0
     private val requestPriorityByMediaId =
         object : LinkedHashMap<String, RequestPriority>(256, 0.75f, true) {
@@ -1127,8 +1126,9 @@ internal class AppleInternalCatalogResolver(
         request: LocalizedRequest,
         onResolved: (resolvedLookupId: String?, alias: Alias?) -> Unit,
     ) {
-        lockedIsrcFallbackPending.addLast(
-            LockedIsrcFallbackTask(request = request, onResolved = onResolved),
+        lockedIsrcFallbackPending += LockedIsrcFallbackTask(
+            request = request,
+            onResolved = onResolved,
         )
         scheduleLockedIsrcFallbacks()
     }
@@ -1138,7 +1138,7 @@ internal class AppleInternalCatalogResolver(
             lockedIsrcFallbackRunning < MAX_LOCKED_ISRC_FALLBACK_RUNNING &&
                 lockedIsrcFallbackPending.isNotEmpty()
         ) {
-            val task = lockedIsrcFallbackPending.removeFirst()
+            val task = nextLockedIsrcFallbackTask() ?: break
             lockedIsrcFallbackRunning += 1
             resolveLocalizedRequestByLockedIsrc(task.request) { resolvedLookupId, alias ->
                 lockedIsrcFallbackRunning = (lockedIsrcFallbackRunning - 1).coerceAtLeast(0)
@@ -1146,6 +1146,20 @@ internal class AppleInternalCatalogResolver(
                 scheduleLockedIsrcFallbacks()
             }
         }
+    }
+
+    /**
+     * Selects the highest effective priority at dispatch time.  The effective value is read from
+     * [requestPriorityByMediaId], so a visible-page promotion or a request-scope update also
+     * reorders tasks that are already waiting in this fallback queue.  Equal priorities retain
+     * insertion order to avoid unnecessary churn.
+     */
+    private fun nextLockedIsrcFallbackTask(): LockedIsrcFallbackTask? {
+        val priorities = lockedIsrcFallbackPending.map { task ->
+            currentRequestPriority(task.request.mediaId, task.request.priority)
+        }
+        val index = selectNextRequestIndex(priorities) ?: return null
+        return lockedIsrcFallbackPending.removeAt(index)
     }
 
     /**
@@ -1355,6 +1369,10 @@ internal class AppleInternalCatalogResolver(
                 }
             }
         }
+        // Fallback tasks read their effective priority when a slot is selected.  Rescheduling
+        // here also wakes the queue when a completed task left capacity available during a scope
+        // update or explicit promotion.
+        scheduleLockedIsrcFallbacks()
         return changed
     }
 

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleInternalCatalogResolver.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleInternalCatalogResolver.kt
@@ -11,6 +11,7 @@ import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.lang.reflect.Proxy
+import java.util.ArrayDeque
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
@@ -18,11 +19,19 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 
+private fun sanitizeCacheNamespace(raw: String): String = raw
+    .trim()
+    .lowercase()
+    .replace(Regex("[^a-z0-9_-]"), "_")
+    .trim('_')
+    .ifBlank { "default_v1" }
+
 internal class AppleInternalCatalogResolver(
     context: Context,
     private val classLoader: ClassLoader,
     private val hookResolver: AppleMusicHookResolver,
-    private val mainHandler: Handler
+    private val mainHandler: Handler,
+    cacheNamespace: String = "original_hyper_v1",
 ) {
     /**
      * Catalog response parsing is pure CPU work once the host response has been snapshotted.
@@ -41,8 +50,19 @@ internal class AppleInternalCatalogResolver(
         backgroundExecutor = catalogBackgroundExecutor,
         isMainThread = { Looper.myLooper() == Looper.getMainLooper() },
     )
-    private val persistentLocalizedCache = AppleLocalizedMetadataCache(context, mainHandler)
-    private val persistentOriginalCache = AppleOriginalMetadataCache(context, mainHandler)
+    private val cacheNamespace = sanitizeCacheNamespace(cacheNamespace)
+    private val persistentLocalizedCache = AppleLocalizedMetadataCache(
+        context = context,
+        mainHandler = mainHandler,
+        databaseName = "hyperlyricsenhanced_apple_metadata_${this.cacheNamespace}.db",
+    )
+    private val persistentOriginalCache = AppleOriginalMetadataCache(
+        context = context,
+        mainHandler = mainHandler,
+        databaseName = "hyperlyricsenhanced_apple_original_metadata_${this.cacheNamespace}.db",
+        artistRegionPreferencesName =
+            "hyperlyricsenhanced_apple_original_artist_regions_${this.cacheNamespace}",
+    )
     private val resolvedCatalogHolder by lazy {
         hookResolver.resolveClass(AppleMusicHookPoint.MEDIA_API_REPOSITORY_HOLDER_CLASS)
     }
@@ -81,6 +101,12 @@ internal class AppleInternalCatalogResolver(
     private var localizedBatchScheduled = false
     private var localizedBatchesRunning = 0
     private var localizedBackgroundBatchesRunning = 0
+    /**
+     * Fixed-region ID misses use a two-step identity/ISRC chain.  Keep that chain behind its own
+     * small queue so a 50-item localized batch cannot turn into 50 simultaneous host requests.
+     */
+    private val lockedIsrcFallbackPending = ArrayDeque<LockedIsrcFallbackTask>()
+    private var lockedIsrcFallbackRunning = 0
     private val requestPriorityByMediaId =
         object : LinkedHashMap<String, RequestPriority>(256, 0.75f, true) {
             override fun removeEldestEntry(
@@ -95,12 +121,6 @@ internal class AppleInternalCatalogResolver(
     @Volatile
     private var persistentLocalizedCacheEnabled = true
     private var catalogAccess: CatalogAccess? = null
-    @Volatile
-    private var accountStorefront: String? = null
-    @Volatile
-    private var accountStorefrontCaptured = false
-    @Volatile
-    private var lastAppliedConfiguredStorefront: String? = null
     private val activeCatalogRequest = ThreadLocal<CatalogRequestLocalization?>()
     private val pendingCatalogRequests = ConcurrentHashMap<String, CatalogRequestLocalization>()
     private val catalogRequestSequence = AtomicLong()
@@ -110,20 +130,16 @@ internal class AppleInternalCatalogResolver(
         RootConstants.DEFAULT_HOOK_APPLE_MUSIC_CONTENT_UI_LANGUAGE
 
     /**
-     * Applies the content storefront without changing the account's original value.
-     * The MediaApi storefront is also used by Apple Music for localized content, so
-     * keeping this value in one place covers both startup and post-query recovery.
+     * Prepares the selected metadata profile without changing Apple Music's account storefront.
+     *
+     * Fixed-region requests are scoped by [CatalogRequestLocalization] inside [queryResponse]
+     * and are tagged with [CATALOG_REQUEST_TOKEN_PARAM].  Mutating MediaApi here would affect
+     * ordinary Apple Music catalog traffic, so this method intentionally only records the
+     * selection and warms the profile's display cache.
      */
     fun applyContentUiLanguage(selection: Int) {
         contentUiLanguageSelection = selection
         warmPersistentLocalizedCache(selection)
-        if (activeCatalogRequest.get() != null) return
-        runCatching {
-            val access = catalogAccess ?: createCatalogAccess().also { catalogAccess = it }
-            restoreConfiguredStorefront(access)
-        }.onFailure {
-            ProviderLogger.error("Apple 内容 UI storefront 应用失败: selection=$selection", it)
-        }
     }
 
     fun setPersistentLocalizedCacheEnabled(enabled: Boolean) {
@@ -250,46 +266,22 @@ internal class AppleInternalCatalogResolver(
     fun catalogRequestLocalization(token: String?): CatalogRequestLocalization? =
         token?.let(pendingCatalogRequests::get)
 
+    /**
+     * Returns the localization attached to the resolver's current direct-query scope.
+     *
+     * MediaApi callbacks are shared by Apple Music's ordinary traffic and by the resolver.  The
+     * request token is the durable discriminator, but a few app versions invoke the localization
+     * callback before copying the token into the parameter map.  This scope is only set around a
+     * resolver-owned direct query, so it is a safe, short-lived fallback and cannot localize an
+     * ordinary account request.
+     */
+    fun activeCatalogRequestLocalization(): CatalogRequestLocalization? =
+        activeCatalogRequest.get()
+
     fun pendingCatalogRequestCount(): Int = pendingCatalogRequests.size
 
     fun cachedCatalogGenres(mediaId: String): List<String> =
         catalogIdentityCache[mediaId]?.genres.orEmpty()
-
-    fun accountStorefrontForPlaybackRequest(): String? {
-        accountStorefront?.let { return it }
-        return runCatching {
-            val access = catalogAccess ?: createCatalogAccess().also { catalogAccess = it }
-            captureAccountStorefront(access)
-            accountStorefront
-        }.getOrNull()
-    }
-
-    private fun restoreConfiguredStorefront(access: CatalogAccess) {
-        captureAccountStorefront(access)
-        val selection = contentUiLanguageSelection
-        val configuredStorefront = storefrontForContentUiLanguage(selection)
-        if (configuredStorefront == null && !accountStorefrontCaptured) return
-        val target = configuredStorefront ?: accountStorefront
-        val previous = access.storefrontField.get(access.mediaApi) as? String
-        access.storefrontField.set(access.mediaApi, target)
-        lastAppliedConfiguredStorefront = configuredStorefront
-        if (previous != target) {
-            ProviderLogger.info(
-                "Apple 内容 UI storefront 已应用: selection=$selection, " +
-                    "previous=${previous ?: "unset"}, " +
-                    "storefront=${target ?: "account-default"}, " +
-                    "accountStorefront=${accountStorefront ?: "account-default"}"
-            )
-        }
-    }
-
-    private fun captureAccountStorefront(access: CatalogAccess) {
-        val current = access.storefrontField.get(access.mediaApi) as? String ?: return
-        if (!accountStorefrontCaptured || current != lastAppliedConfiguredStorefront) {
-            accountStorefront = current
-            accountStorefrontCaptured = true
-        }
-    }
 
     fun resolve(metadata: MediaMetadataCache.Metadata, onResolved: (Alias?) -> Unit) {
         resolveOriginalMetadata(metadata, RequestPriority.ACTIVE_PAGE) { resolution ->
@@ -333,7 +325,6 @@ internal class AppleInternalCatalogResolver(
                         alias = cachedAlias,
                         localizedTitle = metadata.title.orEmpty(),
                         localizedArtist = metadata.artist.orEmpty(),
-                        allowArtistOnly = true,
                     )
                 }?.let { cachedAlias ->
                     if (cachedAlias != alias) cache[metadata.id] = cachedAlias
@@ -344,9 +335,6 @@ internal class AppleInternalCatalogResolver(
                             originKnown = true,
                             artistIds = emptyList(),
                             album = cachedAlias.album,
-                            trustedArtistOnlyLanguages = setOf(
-                                canonicalOriginalLanguage(cachedAlias.language),
-                            ),
                         )
                     )
                     return
@@ -372,7 +360,6 @@ internal class AppleInternalCatalogResolver(
                     alias = alias,
                     localizedTitle = metadata.title.orEmpty(),
                     localizedArtist = metadata.artist.orEmpty(),
-                    allowArtistOnly = true,
                 )
             }
             if (reusableAlias != null) {
@@ -426,34 +413,18 @@ internal class AppleInternalCatalogResolver(
             }
             val results = identity.fallbackAliases.toMutableList()
             val isrc = identity.isrc
-            val singleArtistId = identity.artistIds.singleOrNull()
-                ?.trim()
-                ?.takeIf { artistId ->
-                    artistId.isNotEmpty() &&
-                        artistId.all(Char::isDigit) &&
-                        !isCollaborationArtistName(metadata.artist.orEmpty())
-                }
-            val cachedArtistLanguage = singleArtistId?.let { artistId ->
-                cachedOriginalArtistRegion(listOf("id:$artistId"))
-            }
-            val originKnownFromArtist = cachedArtistLanguage != null
-            val trustedArtistOnlyLanguages = (
-                languageTagsForIsrc(isrc) + listOfNotNull(cachedArtistLanguage)
-            ).map(::canonicalOriginalLanguage).toSet()
             val languages = languageTagsForOriginalMetadata(
                 genre = metadata.genre,
                 catalogGenres = identity.genres,
                 isrc = isrc,
-                artistLanguages = listOfNotNull(cachedArtistLanguage),
             )
             if (languages.isEmpty()) {
                 finishResolve(
                     metadata = metadata,
                     languages = languages,
                     results = results,
-                    originKnown = isrc != null || originKnownFromArtist,
+                    originKnown = isrc != null,
                     artistIds = identity.artistIds,
-                    trustedArtistOnlyLanguages = trustedArtistOnlyLanguages,
                 )
                 return@resolveCatalogIdentity
             }
@@ -463,9 +434,8 @@ internal class AppleInternalCatalogResolver(
                         metadata = metadata,
                         languages = languages,
                         results = results,
-                        originKnown = isrc != null || originKnownFromArtist,
+                        originKnown = isrc != null,
                         artistIds = identity.artistIds,
-                        trustedArtistOnlyLanguages = trustedArtistOnlyLanguages,
                     )
                     return
                 }
@@ -477,7 +447,6 @@ internal class AppleInternalCatalogResolver(
                         results = listOf(exactAlias),
                         originKnown = true,
                         artistIds = identity.artistIds,
-                        trustedArtistOnlyLanguages = trustedArtistOnlyLanguages,
                     )
                     return
                 }
@@ -494,9 +463,6 @@ internal class AppleInternalCatalogResolver(
                                 alias = alias,
                                 localizedTitle = metadata.title.orEmpty(),
                                 localizedArtist = metadata.artist.orEmpty(),
-                                allowArtistOnly =
-                                    canonicalOriginalLanguage(language) in
-                                        trustedArtistOnlyLanguages,
                             )
                     }
                     if (exactAlias != null) {
@@ -510,7 +476,6 @@ internal class AppleInternalCatalogResolver(
                             artistIds = (
                                 identity.artistIds + regionalArtistIds
                             ).distinct(),
-                            trustedArtistOnlyLanguages = trustedArtistOnlyLanguages,
                         )
                     } else {
                         if (resolvedAlias != null) {
@@ -1122,20 +1087,129 @@ internal class AppleInternalCatalogResolver(
                     batch.map { request -> Triple(request, null, null) }
                 }
                 mainHandler.post {
-                    matches.forEach { (request, resolvedLookupId, alias) ->
-                        finishLocalizedRequest(request, resolvedLookupId, alias)
+                    var remaining = matches.size
+                    fun finishBatch() {
+                        remaining -= 1
+                        if (remaining > 0) return
+                        synchronized(localizedPending) {
+                            localizedBatchesRunning -= 1
+                            if (batch.first().priority == RequestPriority.BACKGROUND) {
+                                localizedBackgroundBatchesRunning -= 1
+                            }
+                        }
+                        scheduleLocalizedBatchIfCapacity()
                     }
-                    synchronized(localizedPending) {
-                        localizedBatchesRunning -= 1
-                        if (batch.first().priority == RequestPriority.BACKGROUND) {
-                            localizedBackgroundBatchesRunning -= 1
+                    matches.forEach { (request, resolvedLookupId, alias) ->
+                        if (alias != null) {
+                            finishLocalizedRequest(request, resolvedLookupId, alias)
+                            finishBatch()
+                        } else if (request.entityType == LocalizedEntityType.SONG) {
+                            // A storefront can assign a different catalog ID to the same song.
+                            // Reuse the original HLE identity/ISRC lookup as a fallback, but keep
+                            // this second query on the fixed profile's storefront and language.
+                            enqueueLockedIsrcFallback(request) { fallbackLookupId, fallbackAlias ->
+                                finishLocalizedRequest(request, fallbackLookupId, fallbackAlias)
+                                finishBatch()
+                            }
+                        } else {
+                            finishLocalizedRequest(request, null, null)
+                            finishBatch()
                         }
                     }
-                    scheduleLocalizedBatchIfCapacity()
                 }
             }
         }
         scheduleLocalizedBatchIfCapacity()
+    }
+
+    /** Enqueues one fixed-region miss for the bounded identity/ISRC fallback scheduler. */
+    private fun enqueueLockedIsrcFallback(
+        request: LocalizedRequest,
+        onResolved: (resolvedLookupId: String?, alias: Alias?) -> Unit,
+    ) {
+        lockedIsrcFallbackPending.addLast(
+            LockedIsrcFallbackTask(request = request, onResolved = onResolved),
+        )
+        scheduleLockedIsrcFallbacks()
+    }
+
+    private fun scheduleLockedIsrcFallbacks() {
+        while (
+            lockedIsrcFallbackRunning < MAX_LOCKED_ISRC_FALLBACK_RUNNING &&
+                lockedIsrcFallbackPending.isNotEmpty()
+        ) {
+            val task = lockedIsrcFallbackPending.removeFirst()
+            lockedIsrcFallbackRunning += 1
+            resolveLocalizedRequestByLockedIsrc(task.request) { resolvedLookupId, alias ->
+                lockedIsrcFallbackRunning = (lockedIsrcFallbackRunning - 1).coerceAtLeast(0)
+                task.onResolved(resolvedLookupId, alias)
+                scheduleLockedIsrcFallbacks()
+            }
+        }
+    }
+
+    /**
+     * Resolves a fixed-region song missed by the ID batch through the same identity/ISRC fallback
+     * used by the original-region HLE path.  The identity probe is only a module-owned metadata
+     * lookup; the follow-up song query still uses [request.language]'s locked storefront.
+     */
+    private fun resolveLocalizedRequestByLockedIsrc(
+        request: LocalizedRequest,
+        onResolved: (resolvedLookupId: String?, alias: Alias?) -> Unit,
+    ) {
+        val candidateIds = (listOf(request.mediaId) + request.lookupIds)
+            .map(String::trim)
+            .filter { it.isNotEmpty() && it.all(Char::isDigit) }
+            .distinct()
+        if (candidateIds.isEmpty()) {
+            onResolved(null, null)
+            return
+        }
+
+        val attemptedIsrcs = mutableSetOf<String>()
+        fun queryNext(index: Int) {
+            if (index >= candidateIds.size) {
+                onResolved(null, null)
+                return
+            }
+            val identityId = candidateIds[index]
+            fun queryIdentity(identity: CatalogIdentity?) {
+                val isrc = identity?.isrc?.trim()?.takeIf(String::isNotEmpty)
+                if (isrc == null || !attemptedIsrcs.add(isrc)) {
+                    queryNext(index + 1)
+                    return
+                }
+                ProviderLogger.info(
+                    "Apple 固定地区歌曲启用 ISRC 备用查询: id=${request.mediaId}, " +
+                        "identityId=$identityId, isrc=$isrc, storefront=${request.storefront}, " +
+                        "language=${request.language}",
+                )
+                queryByIsrc(
+                    isrc = isrc,
+                    language = request.language,
+                    storefrontOverride = request.storefront,
+                ) { song ->
+                    val alias = song?.alias?.takeIf {
+                        it.title.isNotBlank() || it.artist.isNotBlank()
+                    }
+                    if (alias != null) {
+                        onResolved(song?.id, alias)
+                    } else {
+                        queryNext(index + 1)
+                    }
+                }
+            }
+            catalogIdentityCache[identityId]?.let { cached ->
+                queryIdentity(cached)
+                return
+            }
+            // Keep the identity probe region-neutral.  It obtains only ISRC/relationship facts;
+            // no alias from this account-region response is ever published for fixed mode.
+            resolveCatalogIdentity(identityId, emptyList()) { identity ->
+                queryIdentity(identity)
+            }
+        }
+        queryNext(0)
     }
 
     private fun scheduleLocalizedBatchIfCapacity() {
@@ -1347,7 +1421,6 @@ internal class AppleInternalCatalogResolver(
         results: List<Alias>,
         originKnown: Boolean,
         artistIds: List<String>,
-        trustedArtistOnlyLanguages: Set<String>,
     ) {
         // Canonical language filtering and alias confidence checks are pure operations over
         // immutable DTOs.  Keep cache mutation and completion publication on the host main thread,
@@ -1360,7 +1433,6 @@ internal class AppleInternalCatalogResolver(
                     results = results,
                     originKnown = originKnown,
                     artistIds = artistIds,
-                    trustedArtistOnlyLanguages = trustedArtistOnlyLanguages,
                 )
             }.onFailure { error ->
                 ProviderLogger.error(
@@ -1370,7 +1442,6 @@ internal class AppleInternalCatalogResolver(
             }.getOrElse {
                 PreparedOriginalResolution(
                     canonicalLanguages = languages.map(String::trim).filter(String::isNotEmpty),
-                    canonicalTrustedArtistOnlyLanguages = trustedArtistOnlyLanguages,
                     sourceLanguage = languages.singleOrNull(),
                     originalAlias = null,
                     resolvedAlbum = null,
@@ -1390,26 +1461,15 @@ internal class AppleInternalCatalogResolver(
         results: List<Alias>,
         originKnown: Boolean,
         artistIds: List<String>,
-        trustedArtistOnlyLanguages: Set<String>,
     ): PreparedOriginalResolution {
         val canonicalLanguages = languages.map(::canonicalOriginalLanguage).distinct()
-        val canonicalTrustedArtistOnlyLanguages = trustedArtistOnlyLanguages
-            .map(::canonicalOriginalLanguage)
-            .toSet()
         val sourceLanguage = canonicalLanguages.singleOrNull()
         val acceptableResults = regionalOriginalAliases(results, canonicalLanguages)
-        fun isTrustedArtistOnlyAlias(alias: Alias): Boolean =
-            canonicalOriginalLanguage(alias.language) in canonicalTrustedArtistOnlyLanguages &&
-                isConfidentOriginalArtistOnlyAlias(
-                    alias = alias,
-                    localizedTitle = metadata.title.orEmpty(),
-                    localizedArtist = metadata.artist.orEmpty(),
-                )
         val selected = selectOriginalAlias(
             variants = acceptableResults,
             localizedTitle = metadata.title.orEmpty(),
             localizedArtist = metadata.artist.orEmpty()
-        ) ?: acceptableResults.lastOrNull(::isTrustedArtistOnlyAlias)
+        )
         val confirmedRegionalAlias = if (originKnown) {
             acceptableResults.lastOrNull { alias ->
                 canonicalOriginalLanguage(alias.language) in canonicalLanguages &&
@@ -1417,7 +1477,6 @@ internal class AppleInternalCatalogResolver(
                         alias = alias,
                         localizedTitle = metadata.title.orEmpty(),
                         localizedArtist = metadata.artist.orEmpty(),
-                        allowArtistOnly = isTrustedArtistOnlyAlias(alias),
                     )
             }
         } else {
@@ -1430,7 +1489,6 @@ internal class AppleInternalCatalogResolver(
         )
         return PreparedOriginalResolution(
             canonicalLanguages = canonicalLanguages,
-            canonicalTrustedArtistOnlyLanguages = canonicalTrustedArtistOnlyLanguages,
             sourceLanguage = sourceLanguage,
             originalAlias = originalAlias,
             resolvedAlbum = resolvedAlbum,
@@ -1462,7 +1520,6 @@ internal class AppleInternalCatalogResolver(
             originKnown = prepared.originKnown,
             artistIds = prepared.artistIds,
             album = prepared.resolvedAlbum,
-            trustedArtistOnlyLanguages = prepared.canonicalTrustedArtistOnlyLanguages,
         )
         callbacks.forEach { callback -> callback(resolution) }
     }
@@ -1479,7 +1536,6 @@ internal class AppleInternalCatalogResolver(
             originKnown = true,
             artistIds = emptyList(),
             album = alias.album,
-            trustedArtistOnlyLanguages = setOf(canonicalOriginalLanguage(alias.language)),
         )
         callbacks.forEach { callback -> callback(resolution) }
     }
@@ -1626,7 +1682,14 @@ internal class AppleInternalCatalogResolver(
             next
         }
         val cacheable = isUsefulCatalogIdentity(merged)
-        MediaMetadataCache.updateCatalogGenres(mediaId, merged.genres)
+        // The resolver may finish after a different metadata profile has become active. Keep
+        // catalog identity facts in this resolver's namespace instead of letting a late callback
+        // mutate whichever profile happens to be globally selected at that moment.
+        MediaMetadataCache.updateCatalogGenres(
+            mediaId = mediaId,
+            genres = merged.genres,
+            profile = cacheNamespace,
+        )
         // Remove and drain the in-flight callbacks on main together with their publication. This
         // prevents a new request from observing a removed key while the background preprocessing
         // result is still waiting in the main queue.
@@ -1737,6 +1800,7 @@ internal class AppleInternalCatalogResolver(
     private fun queryByIsrc(
         isrc: String,
         language: String,
+        storefrontOverride: String? = null,
         onResult: (CatalogSong?) -> Unit
     ) {
         val queryParams = linkedMapOf(
@@ -1747,7 +1811,7 @@ internal class AppleInternalCatalogResolver(
             "limit" to "1"
         )
         query(
-            storefront = storefrontForLanguage(language),
+            storefront = storefrontOverride ?: storefrontForLanguage(language),
             language = language,
             description = "isrc=$isrc",
             path = "songs",
@@ -1942,7 +2006,6 @@ internal class AppleInternalCatalogResolver(
                     null
                 }
                 if (localization != null) {
-                    captureAccountStorefront(access)
                     requestToken = catalogRequestSequence.incrementAndGet().toString(36)
                     pendingCatalogRequests[requestToken] = localization
                 }
@@ -2106,7 +2169,7 @@ internal class AppleInternalCatalogResolver(
             directQueryMethod = directQueryMethod,
             continuationType = continuationType,
             emptyCoroutineContext = emptyCoroutineContext,
-        ).also(::captureAccountStorefront)
+        )
     }
 
     private fun findDirectCatalogQueryMethod(clazz: Class<*>, methodName: String): Method {
@@ -2467,7 +2530,6 @@ internal class AppleInternalCatalogResolver(
 
     private data class PreparedOriginalResolution(
         val canonicalLanguages: List<String>,
-        val canonicalTrustedArtistOnlyLanguages: Set<String>,
         val sourceLanguage: String?,
         val originalAlias: Alias?,
         val resolvedAlbum: String?,
@@ -2493,6 +2555,11 @@ internal class AppleInternalCatalogResolver(
         val storefront: String,
         val language: String,
         val priority: RequestPriority,
+    )
+
+    private data class LockedIsrcFallbackTask(
+        val request: LocalizedRequest,
+        val onResolved: (resolvedLookupId: String?, alias: Alias?) -> Unit,
     )
 
     private data class OriginalEntityRequest(
@@ -2525,11 +2592,6 @@ internal class AppleInternalCatalogResolver(
         val originKnown: Boolean,
         val artistIds: List<String>,
         val album: String? = null,
-        /**
-         * Original-region evidence that is strong enough to permit an alias
-         * whose title stays English while only its artist becomes CJK.
-         */
-        val trustedArtistOnlyLanguages: Set<String> = emptySet(),
     )
 
     data class LocalizedLookup(
@@ -2639,6 +2701,7 @@ internal class AppleInternalCatalogResolver(
         private const val LOCALIZED_BATCH_SIZE = 50
         private const val MAX_LOCALIZED_BATCHES_RUNNING = 4
         private const val MAX_BACKGROUND_LOCALIZED_BATCHES_RUNNING = 2
+        private const val MAX_LOCKED_ISRC_FALLBACK_RUNNING = 2
         private const val LOCALIZED_BATCH_DELAY_MS = 32L
         private const val ORIGINAL_ENTITY_BATCH_SIZE = 50
         private const val MAX_ORIGINAL_ENTITY_BATCHES_RUNNING = 3
@@ -3048,41 +3111,13 @@ internal class AppleInternalCatalogResolver(
             alias: Alias,
             localizedTitle: String,
             localizedArtist: String,
-            allowArtistOnly: Boolean = false,
         ): Boolean = isOriginalTitle(alias, localizedTitle) ||
-            nonLatinLetterCount(localizedTitle) > 0 ||
-            (
-                allowArtistOnly &&
-                    isConfidentOriginalArtistOnlyAlias(
-                        alias = alias,
-                        localizedTitle = localizedTitle,
-                        localizedArtist = localizedArtist,
-                    )
-                )
-
-        /**
-         * An English title is not by itself regional evidence. This narrow
-         * shape is only enabled by a trusted source language (ISRC or a
-         * script-confirmed single artist) at the caller.
-         */
-        internal fun isConfidentOriginalArtistOnlyAlias(
-            alias: Alias,
-            localizedTitle: String,
-            localizedArtist: String,
-        ): Boolean = normalize(alias.title) == normalize(localizedTitle) &&
-            nonLatinLetterCount(localizedTitle) == 0 &&
-            alias.artist.isNotBlank() &&
-            localizedArtist.isNotBlank() &&
-            normalize(alias.artist) != normalize(localizedArtist) &&
-            !isCollaborationArtistName(localizedArtist) &&
-            !isCollaborationArtistName(alias.artist) &&
-            hasCjkArtistScript(alias.artist, alias.language)
+            nonLatinLetterCount(localizedTitle) > 0
 
         internal fun isReusableOriginalSongAlias(
             alias: Alias,
             localizedTitle: String,
             localizedArtist: String,
-            allowArtistOnly: Boolean = false,
         ): Boolean = isAcceptableOriginalAlias(
             alias = alias,
             sourceLanguage = canonicalOriginalLanguage(alias.language),
@@ -3090,7 +3125,6 @@ internal class AppleInternalCatalogResolver(
             alias = alias,
             localizedTitle = localizedTitle,
             localizedArtist = localizedArtist,
-            allowArtistOnly = allowArtistOnly,
         )
 
         internal fun isCollaborationArtistName(artist: String): Boolean {

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleLocalizedMetadataCache.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleLocalizedMetadataCache.kt
@@ -13,8 +13,9 @@ import java.util.concurrent.Executors
 internal class AppleLocalizedMetadataCache(
     context: Context,
     private val mainHandler: Handler,
+    private val databaseName: String = "hyperlyricsenhanced_apple_metadata.db",
 ) {
-    private val helper = DatabaseHelper(context.applicationContext)
+    private val helper = DatabaseHelper(context.applicationContext, databaseName)
     private val executor: ExecutorService = Executors.newSingleThreadExecutor { task ->
         Thread(task, "HLE-AppleMetadataCache").apply { isDaemon = true }
     }
@@ -173,8 +174,10 @@ internal class AppleLocalizedMetadataCache(
     private fun Cursor.stringColumn(name: String): String =
         getString(getColumnIndexOrThrow(name)).orEmpty()
 
-    private class DatabaseHelper(context: Context) :
-        SQLiteOpenHelper(context, DATABASE_NAME, null, DATABASE_VERSION) {
+    private class DatabaseHelper(
+        context: Context,
+        databaseName: String,
+    ) : SQLiteOpenHelper(context, databaseName, null, DATABASE_VERSION) {
         override fun onCreate(db: SQLiteDatabase) {
             db.execSQL(
                 """
@@ -201,7 +204,6 @@ internal class AppleLocalizedMetadataCache(
     }
 
     private companion object {
-        const val DATABASE_NAME = "hyperlyricsenhanced_apple_metadata.db"
         const val DATABASE_VERSION = 1
         const val TABLE_NAME = "localized_metadata"
         const val COLUMN_KEY = "cache_key"

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleMetadataOverrideStore.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleMetadataOverrideStore.kt
@@ -6,6 +6,7 @@
 
 package io.github.proify.lyricon.amprovider.xposed
 
+import android.os.SystemClock
 import java.util.concurrent.ConcurrentHashMap
 
 /** Owns Apple Music metadata overrides, identity facts, and request lifecycle state. */
@@ -36,7 +37,7 @@ internal class AppleMetadataOverrideStore {
     private val nonCatalogContentItemIds = ConcurrentHashMap.newKeySet<String>()
 
     private val configuredResolveRequests = ConcurrentHashMap.newKeySet<String>()
-    private val configuredResolveMisses = ConcurrentHashMap.newKeySet<String>()
+    private val configuredResolveMisses = ConcurrentHashMap<String, Long>()
     private val originalResolveRequests = ConcurrentHashMap.newKeySet<String>()
     private val associatedArtistResolveRequests = ConcurrentHashMap.newKeySet<String>()
     private val originalResolvedIds = ConcurrentHashMap.newKeySet<String>()
@@ -83,8 +84,10 @@ internal class AppleMetadataOverrideStore {
     fun rememberConfiguredMetadataIfAbsent(
         mediaId: String,
         alias: AppleInternalCatalogResolver.Alias,
-    ): AppleInternalCatalogResolver.Alias =
-        configuredMetadataOverrides.putIfAbsent(mediaId, alias) ?: alias
+    ): AppleInternalCatalogResolver.Alias {
+        val existing = configuredMetadataOverrides.putIfAbsent(mediaId, alias)
+        return existing ?: alias
+    }
 
     fun originalMetadata(mediaId: String): AppleInternalCatalogResolver.Alias? =
         originalMetadataOverrides[mediaId]
@@ -263,10 +266,23 @@ internal class AppleMetadataOverrideStore {
         configuredResolveRequests.remove(requestKey)
     }
 
-    fun isConfiguredMiss(requestKey: String): Boolean = requestKey in configuredResolveMisses
+    fun isConfiguredMiss(
+        requestKey: String,
+        nowUptimeMillis: Long = SystemClock.uptimeMillis(),
+    ): Boolean {
+        val lastMiss = configuredResolveMisses[requestKey] ?: return false
+        if (ConfiguredMetadataRetryPolicy.shouldSkip(lastMiss, nowUptimeMillis)) {
+            return true
+        }
+        configuredResolveMisses.remove(requestKey, lastMiss)
+        return false
+    }
 
-    fun markConfiguredMiss(requestKey: String) {
-        configuredResolveMisses.add(requestKey)
+    fun markConfiguredMiss(
+        requestKey: String,
+        nowUptimeMillis: Long = SystemClock.uptimeMillis(),
+    ) {
+        configuredResolveMisses[requestKey] = nowUptimeMillis
     }
 
     fun beginOriginalRequest(requestKey: String): Boolean = originalResolveRequests.add(requestKey)

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleOriginalMetadataCache.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleOriginalMetadataCache.kt
@@ -13,10 +13,12 @@ import java.util.concurrent.Executors
 internal class AppleOriginalMetadataCache(
     context: Context,
     private val mainHandler: Handler,
+    private val databaseName: String = DEFAULT_DATABASE_NAME,
+    private val artistRegionPreferencesName: String = DEFAULT_ARTIST_REGION_PREFERENCES,
 ) {
-    private val helper = DatabaseHelper(context.applicationContext)
+    private val helper = DatabaseHelper(context.applicationContext, databaseName)
     private val artistRegionPreferences = context.applicationContext.getSharedPreferences(
-        ARTIST_REGION_PREFERENCES,
+        artistRegionPreferencesName,
         Context.MODE_PRIVATE,
     )
     private val artistRegionLock = Any()
@@ -393,8 +395,10 @@ internal class AppleOriginalMetadataCache(
     private fun Cursor.stringColumn(name: String): String =
         getString(getColumnIndexOrThrow(name)).orEmpty()
 
-    private class DatabaseHelper(context: Context) :
-        SQLiteOpenHelper(context, DATABASE_NAME, null, DATABASE_VERSION) {
+    private class DatabaseHelper(
+        context: Context,
+        databaseName: String,
+    ) : SQLiteOpenHelper(context, databaseName, null, DATABASE_VERSION) {
         override fun onCreate(db: SQLiteDatabase) {
             db.execSQL(
                 """
@@ -423,10 +427,10 @@ internal class AppleOriginalMetadataCache(
     internal companion object {
         const val MAX_ENTRIES = 20_000
         private const val MAX_ARTIST_REGION_ENTRIES = 5_000
-        private const val DATABASE_NAME =
-            "hyperlyricsenhanced_apple_original_metadata_v5.db"
-        /** Isolates v4 aliases created from storefront-localized artist display names. */
-        private const val DATABASE_VERSION = 5
+        private const val DEFAULT_DATABASE_NAME =
+            "hyperlyricsenhanced_apple_original_metadata_original_hyper_v1.db"
+        /** A new physical namespace deliberately does not read the legacy v5 database. */
+        private const val DATABASE_VERSION = 1
         private const val TABLE_NAME = "original_metadata"
         private const val COLUMN_KEY = "cache_key"
         private const val COLUMN_TITLE = "title"
@@ -434,16 +438,16 @@ internal class AppleOriginalMetadataCache(
         private const val COLUMN_ALBUM = "album"
         private const val COLUMN_LANGUAGE = "language"
         private const val COLUMN_UPDATED_AT = "updated_at"
-        private const val ARTIST_REGION_PREFERENCES =
-            "hyperlyricsenhanced_apple_original_artist_regions_v5"
+        private const val DEFAULT_ARTIST_REGION_PREFERENCES =
+            "hyperlyricsenhanced_apple_original_artist_regions_original_hyper_v1"
         private const val ARTIST_REGION_VALUE_SEPARATOR = "|"
 
         internal fun currentDatabaseVersionForTest(): Int = DATABASE_VERSION
 
-        internal fun currentDatabaseNameForTest(): String = DATABASE_NAME
+        internal fun currentDatabaseNameForTest(): String = DEFAULT_DATABASE_NAME
 
         internal fun currentArtistRegionPreferencesNameForTest(): String =
-            ARTIST_REGION_PREFERENCES
+            DEFAULT_ARTIST_REGION_PREFERENCES
 
         private val COLUMNS = arrayOf(
             COLUMN_TITLE,

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/ConfiguredMetadataRetryPolicy.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/ConfiguredMetadataRetryPolicy.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 juren233
+ * Licensed under the Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.github.proify.lyricon.amprovider.xposed
+
+/** Small, platform-free policy for retrying a transient empty fixed-region lookup. */
+internal object ConfiguredMetadataRetryPolicy {
+    const val RETRY_AFTER_MILLIS = 10_000L
+
+    fun shouldSkip(
+        lastMissUptimeMillis: Long,
+        nowUptimeMillis: Long,
+        retryAfterMillis: Long = RETRY_AFTER_MILLIS,
+    ): Boolean {
+        if (retryAfterMillis <= 0L) return false
+        val elapsed = nowUptimeMillis - lastMissUptimeMillis
+        // A monotonic clock should not move backwards; if a caller supplies a regressed value,
+        // treat the old miss as expired rather than blocking the request indefinitely.
+        return elapsed in 0 until retryAfterMillis
+    }
+}

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/MediaMetadataCache.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/MediaMetadataCache.kt
@@ -13,12 +13,33 @@ object MediaMetadataCache {
         override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Metadata>?): Boolean =
             size > 100
     }
+    @Volatile
+    private var activeProfile = DEFAULT_PROFILE
+
+    /** Selects the in-memory namespace used by the currently installed runtime. */
+    @Synchronized
+    fun setProfile(profile: String) {
+        val normalized = normalizeProfile(profile)
+        if (activeProfile == normalized) return
+        activeProfile = normalized
+        metadataCache.clear()
+    }
+
+    @Synchronized
+    fun profile(): String = activeProfile
+
+    @Synchronized
+    fun clearProfile(profile: String = activeProfile) {
+        val prefix = normalizeProfile(profile) + ":"
+        metadataCache.keys.removeIf { it.startsWith(prefix) }
+    }
 
     /** 缓存从 Apple Music 内部播放队列中提取的歌曲元数据。 */
     @Synchronized
-    fun put(metadata: Metadata) {
-        val current = metadataCache[metadata.id]
-        metadataCache[metadata.id] = metadata.copy(
+    fun put(metadata: Metadata, profile: String = activeProfile) {
+        val key = cacheKey(profile, metadata.id)
+        val current = metadataCache[key]
+        metadataCache[key] = metadata.copy(
             genre = mergeGenres(current?.genre, listOfNotNull(metadata.genre)),
             originalTitle = metadata.originalTitle ?: current?.originalTitle,
             originalArtist = metadata.originalArtist ?: current?.originalArtist,
@@ -29,7 +50,8 @@ object MediaMetadataCache {
     }
 
     @Synchronized
-    fun getMetadataById(mediaId: String): Metadata? = metadataCache[mediaId]
+    fun getMetadataById(mediaId: String, profile: String = activeProfile): Metadata? =
+        metadataCache[cacheKey(profile, mediaId)]
 
     @Synchronized
     fun updateOriginalMetadata(
@@ -38,36 +60,49 @@ object MediaMetadataCache {
         artist: String?,
         album: String? = null,
         resolved: Boolean = true,
+        profile: String = activeProfile,
     ): Metadata? {
-        val current = metadataCache[mediaId] ?: return null
+        val key = cacheKey(profile, mediaId)
+        val current = metadataCache[key] ?: return null
         val updated = current.copy(
             originalTitle = title,
             originalArtist = artist,
             originalAlbum = album,
             originalMetadataResolved = resolved,
         )
-        metadataCache[mediaId] = updated
+        metadataCache[key] = updated
         return updated
     }
 
     @Synchronized
-    fun updateDisplayMetadata(mediaId: String, title: String?, artist: String?): Metadata? {
-        val current = metadataCache[mediaId] ?: return null
+    fun updateDisplayMetadata(
+        mediaId: String,
+        title: String?,
+        artist: String?,
+        profile: String = activeProfile,
+    ): Metadata? {
+        val key = cacheKey(profile, mediaId)
+        val current = metadataCache[key] ?: return null
         val updated = current.copy(
             title = title?.takeIf(String::isNotBlank) ?: current.title,
             artist = artist?.takeIf(String::isNotBlank) ?: current.artist,
         )
-        metadataCache[mediaId] = updated
+        metadataCache[key] = updated
         return updated
     }
 
     @Synchronized
-    fun updateCatalogGenres(mediaId: String, genres: Collection<String>): Metadata? {
-        val current = metadataCache[mediaId] ?: return null
+    fun updateCatalogGenres(
+        mediaId: String,
+        genres: Collection<String>,
+        profile: String = activeProfile,
+    ): Metadata? {
+        val key = cacheKey(profile, mediaId)
+        val current = metadataCache[key] ?: return null
         val mergedGenre = mergeGenres(current.genre, genres) ?: return current
         if (mergedGenre == current.genre) return current
         val updated = current.copy(genre = mergedGenre)
-        metadataCache[mediaId] = updated
+        metadataCache[key] = updated
         return updated
     }
 
@@ -80,6 +115,18 @@ object MediaMetadataCache {
             .distinct()
             .joinToString(", ")
             .takeIf(String::isNotEmpty)
+
+    private fun cacheKey(profile: String, mediaId: String): String =
+        normalizeProfile(profile) + ":" + mediaId.trim()
+
+    private fun normalizeProfile(profile: String): String = profile
+        .trim()
+        .lowercase()
+        .replace(Regex("[^a-z0-9_-]"), "_")
+        .trim('_')
+        .ifBlank { DEFAULT_PROFILE }
+
+    private const val DEFAULT_PROFILE = "account"
 
     @Serializable
     data class Metadata(

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/hooks/AppleContentLocalizationHooks.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/hooks/AppleContentLocalizationHooks.kt
@@ -6,11 +6,10 @@
 
 package io.github.proify.lyricon.amprovider.xposed.hooks
 
-import android.content.SharedPreferences
 import android.net.Uri
 import android.os.SystemClock
 import com.juren233.hyperlyricsenhanced.BuildConfig
-import com.juren233.hyperlyricsenhanced.common.RootConstants
+import dev.amenhancer.module.config.CatalogLanguagePolicy
 import io.github.proify.lyricon.amprovider.xposed.AppleContentHttpTimingTracker
 import io.github.proify.lyricon.amprovider.xposed.AppleInternalCatalogResolver
 import io.github.proify.lyricon.amprovider.xposed.AppleMusicHookPoint
@@ -24,7 +23,6 @@ import java.util.concurrent.ConcurrentHashMap
 
 internal class AppleContentLocalizationHooks(
     private val runtime: AppleMusicProviderRuntime,
-    private val preferences: () -> SharedPreferences?,
     private val catalogResolver: () -> AppleInternalCatalogResolver,
 ) {
     @Volatile
@@ -47,27 +45,22 @@ internal class AppleContentLocalizationHooks(
             runtime.hookRegistrar.installHook(method, after = { _, result ->
                 @Suppress("UNCHECKED_CAST")
                 val params = result as? MutableMap<Any?, Any?> ?: return@installHook
-                val prefs = preferences() ?: return@installHook
-                val selection = prefs.getInt(
-                    RootConstants.KEY_HOOK_APPLE_MUSIC_CONTENT_UI_LANGUAGE,
-                    RootConstants.DEFAULT_HOOK_APPLE_MUSIC_CONTENT_UI_LANGUAGE
-                )
                 val resolver = catalogResolver()
-                resolver.applyContentUiLanguage(selection)
                 val requestToken = params[
                     AppleInternalCatalogResolver.CATALOG_REQUEST_TOKEN_PARAM
                 ]?.toString()
                 val requestLocalization = resolver.catalogRequestLocalization(requestToken)
-                val language = requestLocalization?.language
-                    ?: resolver.languageTagForCurrentRequest(selection)
-                language?.let {
-                    params["l"] = language
-                    if (lastLoggedContentLanguage != language) {
-                        lastLoggedContentLanguage = language
-                        ProviderLogger.info(
-                            "Apple Music 内容本地化参数已覆盖: language=$language"
-                        )
-                    }
+                    ?: resolver.activeCatalogRequestLocalization()
+                // This hook is shared with every native MediaApi request.  Only a resolver-owned
+                // token proves that the request belongs to the module's metadata lookup; without
+                // it, leave the account's language and storefront untouched.
+                val language = requestLocalization?.language ?: return@installHook
+                params["l"] = language
+                if (lastLoggedContentLanguage != language) {
+                    lastLoggedContentLanguage = language
+                    ProviderLogger.info(
+                        "Apple Music HLE 元数据本地化参数已覆盖: language=$language"
+                    )
                 }
                 if (
                     BuildConfig.DEBUG &&
@@ -76,9 +69,9 @@ internal class AppleContentLocalizationHooks(
                 ) {
                     ProviderLogger.diagnostic(
                         "AppleCatalogLocalizationParams: token=$requestToken, " +
-                            "resolved=${requestLocalization != null}, " +
+                            "resolved=true, " +
                             "storefront=${requestLocalization?.storefront ?: "fallback"}, " +
-                            "language=${requestLocalization?.language ?: language ?: "unset"}"
+                            "language=${requestLocalization?.language ?: language}"
                     )
                 }
             })
@@ -101,11 +94,6 @@ internal class AppleContentLocalizationHooks(
             runtime.hookRegistrar.installHook(
                 resolved.method,
                 before = { chain ->
-                    val prefs = preferences() ?: return@installHook
-                    val selection = prefs.getInt(
-                        RootConstants.KEY_HOOK_APPLE_MUSIC_CONTENT_UI_LANGUAGE,
-                        RootConstants.DEFAULT_HOOK_APPLE_MUSIC_CONTENT_UI_LANGUAGE
-                    )
                     val httpChain = chain.args.firstOrNull() ?: return@installHook
                     val request = AppleReflection.field(
                         httpChain,
@@ -117,50 +105,17 @@ internal class AppleContentLocalizationHooks(
                     )?.toString().orEmpty()
                     val requestUri = Uri.parse(requestUrl)
                     startContentHttpTiming(httpChain, requestUri)
-                    val pathSegments = requestUri.pathSegments
-                    val isLyricsRequest = isAppleLyricsRequestPath(pathSegments)
                     val resolver = catalogResolver()
-                    if (
-                        AppleInternalCatalogResolver.isAccountScopedPlaybackPath(pathSegments) ||
-                        isLyricsRequest
-                    ) {
-                        val accountStorefront = resolver.accountStorefrontForPlaybackRequest()
-                            ?: return@installHook
-                        val rewritten = rewriteContentRequestStorefrontOnly(
-                            request = request,
-                            storefront = accountStorefront,
-                        )
-                        rewritten?.let {
-                            AppleReflection.setField(
-                                httpChain,
-                                member(
-                                    AppleMusicRuntimeMember.CONTENT_HTTP_CHAIN_REQUEST_FIELD
-                                ),
-                                it,
-                            )
-                        }
-                        if (BuildConfig.DEBUG && isLyricsRequest) {
-                            val sourceStorefront =
-                                AppleInternalCatalogResolver.storefrontFromContentPath(pathSegments)
-                            ProviderLogger.info(
-                                "Apple 歌词请求使用账号 storefront: " +
-                                    "${sourceStorefront ?: "none"}->$accountStorefront"
-                            )
-                        }
-                        return@installHook
-                    }
                     val requestToken = requestUri.getQueryParameter(
                         AppleInternalCatalogResolver.CATALOG_REQUEST_TOKEN_PARAM
                     )
                     val requestLocalization = resolver.catalogRequestLocalization(requestToken)
-                    val configuredStorefront =
-                        AppleInternalCatalogResolver.storefrontForContentUiLanguage(selection)
-                    val storefront = requestLocalization?.storefront
-                        ?: configuredStorefront
-                        ?: return@installHook
-                    val language = requestLocalization?.language
-                        ?: resolver.languageTagForCurrentRequest(selection)
-                        ?: return@installHook
+                        ?: resolver.activeCatalogRequestLocalization()
+                    // Native catalog, playback, lyrics, search and playlist requests do not carry
+                    // this token and must follow the Apple Music account region unchanged.
+                    if (requestLocalization == null) return@installHook
+                    val storefront = requestLocalization.storefront
+                    val language = requestLocalization.language
                     logContentRequestLocalizationDecision(
                         uri = requestUri,
                         requestToken = requestToken,
@@ -320,6 +275,7 @@ internal class AppleContentLocalizationHooks(
         }
         builder.appendQueryParameter("l", language)
         val rewrittenUrl = builder.build().toString()
+        val headerLanguage = CatalogLanguagePolicy.headerLanguage(language)
         val sourceAcceptLanguage = requestHeader(request, "Accept-Language")
         val sourceStorefrontHeader = requestHeader(request, "X-Apple-Store-Front")
         val sourceRequestStorefrontHeader =
@@ -335,7 +291,7 @@ internal class AppleContentLocalizationHooks(
                 currentValue = sourceRequestStorefrontHeader,
             )
         val hasHeaderChanges =
-            sourceAcceptLanguage != language ||
+            sourceAcceptLanguage != headerLanguage ||
                 targetStorefrontHeader != sourceStorefrontHeader ||
                 targetRequestStorefrontHeader != sourceRequestStorefrontHeader
         if (rewrittenUrl == url && !hasHeaderChanges) return null
@@ -363,7 +319,7 @@ internal class AppleContentLocalizationHooks(
         }
         val headerMethod =
             member(AppleMusicRuntimeMember.CONTENT_HTTP_REQUEST_BUILDER_HEADER_METHOD)
-        AppleReflection.call(requestBuilder, headerMethod, "Accept-Language", language)
+        AppleReflection.call(requestBuilder, headerMethod, "Accept-Language", headerLanguage)
         targetStorefrontHeader?.let { value ->
             AppleReflection.call(requestBuilder, headerMethod, "X-Apple-Store-Front", value)
         }
@@ -378,7 +334,7 @@ internal class AppleContentLocalizationHooks(
         logContentRequestHeaders(
             requestToken = requestToken,
             sourceAcceptLanguage = sourceAcceptLanguage,
-            targetAcceptLanguage = language,
+            targetAcceptLanguage = headerLanguage,
             sourceStorefrontHeader = sourceStorefrontHeader,
             targetStorefrontHeader = targetStorefrontHeader,
             sourceRequestStorefrontHeader = sourceRequestStorefrontHeader,

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/metadata/AppleInAppMetadataResolutionCoordinator.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/metadata/AppleInAppMetadataResolutionCoordinator.kt
@@ -790,6 +790,12 @@ internal class AppleInAppMetadataResolutionCoordinator(
         preBind: Boolean,
         priority: AppleInternalCatalogResolver.RequestPriority,
     ) {
+        if (!host.isRestoreOriginalEnabled()) {
+            ProviderLogger.debug(
+                "Apple App 原地区缓存查询忽略: id=$mediaId, reason=original_mode_disabled",
+            )
+            return
+        }
         val requestKey = "original-cache:$entityType:$mediaId"
         if (!metadataStore.beginOriginalRequest(requestKey)) return
         var bindingPhase = true
@@ -891,15 +897,8 @@ internal class AppleInAppMetadataResolutionCoordinator(
                     return@resolveOriginalMetadata
                 }
                 mergePlaybackAssociatedArtistIds(mediaId, resolution.artistIds)
-                originalArtistLanguageFromSongResolution(
-                    resolution = resolution,
-                    localizedArtist = account.artist,
-                )?.let { language ->
-                    rememberOriginalLanguageForArtist(mediaId, language)
-                }
                 fun finishResolution(
                     alias: AppleInternalCatalogResolver.Alias?,
-                    allowArtistOnly: Boolean = false,
                 ) {
                     metadataStore.finishOriginalRequest(requestKey)
                     if (!host.isRestoreOriginalEnabled()) return
@@ -909,7 +908,6 @@ internal class AppleInAppMetadataResolutionCoordinator(
                         alias = alias,
                         localizedTitle = account.title,
                         localizedArtist = account.artist,
-                        allowArtistOnly = allowArtistOnly,
                     )
                     if (alias != null && safeAlias == null) {
                         catalogResolver.invalidateOriginalEntity(
@@ -962,10 +960,6 @@ internal class AppleInAppMetadataResolutionCoordinator(
                 if (retryLanguage == null) {
                     finishResolution(
                         alias = alias,
-                        allowArtistOnly = hasTrustedOriginalArtistOnlyLanguage(
-                            resolution = resolution,
-                            alias = alias,
-                        ),
                     )
                 } else {
                     ProviderLogger.info(
@@ -981,10 +975,6 @@ internal class AppleInAppMetadataResolutionCoordinator(
                         onResolved = { retryAlias ->
                             finishResolution(
                                 alias = retryAlias,
-                                allowArtistOnly = hasTrustedOriginalArtistOnlyLanguage(
-                                    resolution = resolution,
-                                    alias = retryAlias,
-                                ),
                             )
                         },
                     )

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/metadata/AppleMetadataPolicies.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/metadata/AppleMetadataPolicies.kt
@@ -320,24 +320,15 @@ internal fun confirmedOriginalSongAlias(
     resolution: AppleInternalCatalogResolver.OriginalResolution,
 ): AppleInternalCatalogResolver.Alias? = resolution.alias
 
-internal fun hasTrustedOriginalArtistOnlyLanguage(
-    resolution: AppleInternalCatalogResolver.OriginalResolution,
-    alias: AppleInternalCatalogResolver.Alias?,
-): Boolean = alias != null &&
-    AppleInternalCatalogResolver.canonicalOriginalLanguage(alias.language) in
-        resolution.trustedArtistOnlyLanguages
-
 internal fun validatedOriginalSongAlias(
     alias: AppleInternalCatalogResolver.Alias?,
     localizedTitle: String?,
     localizedArtist: String?,
-    allowArtistOnly: Boolean = false,
 ): AppleInternalCatalogResolver.Alias? = alias?.takeIf {
     AppleInternalCatalogResolver.isConfidentOriginalSongAlias(
         alias = it,
         localizedTitle = localizedTitle.orEmpty(),
         localizedArtist = localizedArtist.orEmpty(),
-        allowArtistOnly = allowArtistOnly,
     )
 }
 
@@ -345,23 +336,6 @@ internal fun originalSongRetryLanguage(
     resolution: AppleInternalCatalogResolver.OriginalResolution,
 ): String? = resolution.language?.takeIf {
     resolution.alias == null && resolution.originKnown
-}
-
-internal fun originalArtistLanguageFromSongResolution(
-    resolution: AppleInternalCatalogResolver.OriginalResolution,
-    localizedArtist: String?,
-): String? {
-    if (!resolution.originKnown ||
-        !shouldUseAssociatedArtistEntities(
-            artistIds = resolution.artistIds,
-            artistCredit = localizedArtist,
-        )
-    ) {
-        return null
-    }
-    return resolution.language?.let(
-        AppleInternalCatalogResolver::supportedOriginalLanguageOrNull
-    )
 }
 
 internal fun stableArtistCacheKeys(keys: Collection<String>): Set<String> =

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/metadata/ApplePlaybackMetadataCoordinator.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/metadata/ApplePlaybackMetadataCoordinator.kt
@@ -37,7 +37,6 @@ internal interface ApplePlaybackMetadataCoordinatorHost {
         alias: AppleInternalCatalogResolver.Alias?,
         localizedTitle: String?,
         localizedArtist: String?,
-        allowArtistOnly: Boolean = false,
     ): AppleInternalCatalogResolver.Alias?
 
     fun shouldShareOriginalSongLanguage(
@@ -207,6 +206,12 @@ internal class ApplePlaybackMetadataCoordinator(
     }
 
     fun resolveOriginalMetadataOnDemand(mediaId: String) {
+        if (!host.isRestoreOriginalMetadataEnabled()) {
+            ProviderLogger.debug(
+                "Apple 原名按需查询忽略: id=$mediaId, reason=original_mode_disabled",
+            )
+            return
+        }
         val metadata = MediaMetadataCache.getMetadataById(mediaId)
         if (metadata == null) {
             ProviderLogger.info("Apple 原名按需查询忽略: id=$mediaId, reason=metadata_missing")
@@ -372,10 +377,6 @@ internal class ApplePlaybackMetadataCoordinator(
                     alias = resolution.alias,
                     localizedTitle = metadata.title,
                     localizedArtist = metadata.artist,
-                    allowArtistOnly = hasTrustedOriginalArtistOnlyLanguage(
-                        resolution = resolution,
-                        alias = resolution.alias,
-                    ),
                 )
                 metadataStore.markOriginalResolved(metadata.id)
                 resolution.language?.takeIf {

--- a/app/src/test/java/dev/amenhancer/module/config/EmbeddedConfigurationSessionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/config/EmbeddedConfigurationSessionTest.kt
@@ -1,5 +1,6 @@
 package dev.amenhancer.module.config
 
+import dev.amenhancer.module.ModuleConstants
 import dev.amenhancer.module.font.FontImportResult
 import dev.amenhancer.module.font.FontImportTransaction
 import dev.amenhancer.module.model.LyricsFontManifest
@@ -16,6 +17,50 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class EmbeddedConfigurationSessionTest {
+    @Test
+    fun `legacy title correction mode is published before obsolete key cleanup`() {
+        listOf(
+            "zh-CN" to TitleCorrectionMode.MAINLAND_CHINA,
+            "ja-JP" to TitleCorrectionMode.JAPAN,
+        ).forEach { (legacyLanguage, expectedMode) ->
+            val storage = InMemoryEmbeddedStorage(
+                initialValues = mapOf(
+                    "schema_version" to 11,
+                    "title_correction_enabled" to true,
+                    "title_correction_target_language" to legacyLanguage,
+                ),
+            )
+
+            val session = EmbeddedConfigurationSession(storage)
+
+            assertEquals(expectedMode, session.settings().titleCorrectionMode)
+            assertEquals(expectedMode.storageValue, storage.values()["title_correction_mode"])
+            assertEquals(
+                ModuleConstants.CONFIG_SCHEMA_VERSION,
+                storage.values()["schema_version"],
+            )
+            assertFalse(storage.values().containsKey("title_correction_target_language"))
+        }
+    }
+
+    @Test
+    fun `legacy title correction key remains when new mode cannot be published`() {
+        val storage = InMemoryEmbeddedStorage(
+            initialValues = mapOf(
+                "schema_version" to 11,
+                "title_correction_enabled" to true,
+                "title_correction_target_language" to "ja-JP",
+            ),
+            failWrites = true,
+        )
+
+        val session = EmbeddedConfigurationSession(storage)
+
+        assertEquals(TitleCorrectionMode.JAPAN, session.settings().titleCorrectionMode)
+        assertTrue(storage.values().containsKey("title_correction_target_language"))
+        assertFalse(storage.values().containsKey("title_correction_mode"))
+    }
+
     @Test
     fun `ordinary settings round trip preserves file-backed metadata`() {
         val font = LyricsFontManifest(
@@ -120,6 +165,7 @@ class EmbeddedConfigurationSessionTest {
 
     private class InMemoryEmbeddedStorage(
         initialValues: Map<String, Any> = emptyMap(),
+        private val failWrites: Boolean = false,
     ) : EmbeddedConfigurationStorage {
         private val storedValues = initialValues.toMutableMap()
         private val files = mutableMapOf<String, ByteArray>()
@@ -127,7 +173,13 @@ class EmbeddedConfigurationSessionTest {
         override fun values(): Map<String, *> = storedValues.toMap()
 
         override fun writeValues(values: Map<String, Any>, synchronous: Boolean): Boolean {
+            if (failWrites) return false
             storedValues.putAll(values)
+            return true
+        }
+
+        override fun removeValues(keys: Set<String>, synchronous: Boolean): Boolean {
+            keys.forEach(storedValues::remove)
             return true
         }
 

--- a/app/src/test/java/dev/amenhancer/module/config/ModuleSettingsSchemaTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/config/ModuleSettingsSchemaTest.kt
@@ -50,7 +50,7 @@ class ModuleSettingsSchemaTest {
                 "navigation_compensation_enabled" to false,
                 "lyric_blur_radius_offset_px" to 6,
                 "title_correction_enabled" to false,
-                "title_correction_target_language" to "",
+                "title_correction_mode" to "original_hyper",
                 "custom_lyrics_enabled" to false,
                 "automatic_lyrics_enabled" to true,
                 "lyrics_font_enabled" to false,
@@ -85,7 +85,7 @@ class ModuleSettingsSchemaTest {
                 "navigation_compensation_enabled" to false,
                 "lyric_blur_radius_offset_px" to 0,
                 "title_correction_enabled" to false,
-                "title_correction_target_language" to "",
+                "title_correction_mode" to "original_hyper",
                 "custom_lyrics_enabled" to false,
                 "automatic_lyrics_enabled" to true,
                 "lyrics_font_enabled" to false,
@@ -235,31 +235,51 @@ class ModuleSettingsSchemaTest {
     }
 
     @Test
-    fun `target language is optional and round trips independently from HLE`() {
+    fun `title correction mode defaults to original and round trips`() {
         assertEquals(
-            CatalogLanguagePolicy.DISABLED_TARGET_LANGUAGE,
-            ModuleSettingsSchema.decode(emptyMap<String, Any?>()).titleCorrectionTargetLanguage,
+            TitleCorrectionMode.ORIGINAL_HYPER,
+            ModuleSettingsSchema.decode(emptyMap<String, Any?>()).titleCorrectionMode,
         )
 
         val encoded = ModuleSettingsSchema.encodeOrdinarySettings(
-            ModuleSettings(titleCorrectionTargetLanguage = "ja_jp"),
+            ModuleSettings(titleCorrectionMode = TitleCorrectionMode.JAPAN),
         )
-        assertEquals("ja-JP", encoded["title_correction_target_language"])
-        assertEquals("ja-JP", ModuleSettingsSchema.decode(encoded).titleCorrectionTargetLanguage)
+        assertEquals("japan", encoded["title_correction_mode"])
+        assertEquals(TitleCorrectionMode.JAPAN, ModuleSettingsSchema.decode(encoded).titleCorrectionMode)
     }
 
     @Test
-    fun `schema v10 target language survives the v11 reintroduction`() {
+    fun `schema v11 target language migrates to the selected profile`() {
         val upgraded = ModuleSettingsSchema.upgrade(
             storedValues = mapOf(
-                "schema_version" to 10,
-                "title_correction_target_language" to "ko_kr",
+                "schema_version" to 11,
+                "title_correction_enabled" to true,
+                "title_correction_target_language" to "ja_jp",
             ),
             legacyValues = emptyMap<String, Any?>(),
         )
 
-        assertEquals("ko-KR", upgraded?.get("title_correction_target_language"))
+        assertEquals("japan", upgraded?.get("title_correction_mode"))
+        assertFalse(upgraded?.containsKey("title_correction_target_language") == true)
         assertEquals(ModuleConstants.CONFIG_SCHEMA_VERSION, upgraded?.get("schema_version"))
+    }
+
+    @Test
+    fun `legacy mainland target maps to mainland profile and unsupported target maps to original`() {
+        val mainland = ModuleSettingsSchema.decode(
+            mapOf(
+                "title_correction_enabled" to true,
+                "title_correction_target_language" to "zh-CN",
+            ),
+        )
+        val unsupported = ModuleSettingsSchema.decode(
+            mapOf(
+                "title_correction_enabled" to true,
+                "title_correction_target_language" to "ko-KR",
+            ),
+        )
+        assertEquals(TitleCorrectionMode.MAINLAND_CHINA, mainland.titleCorrectionMode)
+        assertEquals(TitleCorrectionMode.ORIGINAL_HYPER, unsupported.titleCorrectionMode)
     }
 
     @Test
@@ -395,7 +415,7 @@ class ModuleSettingsSchemaTest {
         val encoded = ModuleSettingsSchema.encodeOrdinarySettings(decoded)
         assertFalse(encoded.containsKey("modify_locale"))
         assertFalse(encoded.containsKey("modify_locale_target_tag"))
-        assertEquals("", encoded["title_correction_target_language"])
+        assertEquals("original_hyper", encoded["title_correction_mode"])
 
         val upgraded = ModuleSettingsSchema.upgrade(
             storedValues = mapOf(
@@ -406,6 +426,6 @@ class ModuleSettingsSchemaTest {
         )
         assertFalse(upgraded!!.containsKey("modify_locale"))
         assertFalse(upgraded.containsKey("modify_locale_target_tag"))
-        assertEquals("", upgraded["title_correction_target_language"])
+        assertEquals("original_hyper", upgraded["title_correction_mode"])
     }
 }

--- a/app/src/test/java/dev/amenhancer/module/config/OrdinarySettingsWritePolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/config/OrdinarySettingsWritePolicyTest.kt
@@ -109,7 +109,7 @@ class OrdinarySettingsWritePolicyTest {
                 "navigation_compensation_enabled" to false,
                 "lyric_blur_radius_offset_px" to 6,
                 "title_correction_enabled" to false,
-                "title_correction_target_language" to "",
+                "title_correction_mode" to "original_hyper",
                 "custom_lyrics_enabled" to false,
                 "automatic_lyrics_enabled" to true,
                 "schema_version" to ModuleConstants.CONFIG_SCHEMA_VERSION,

--- a/app/src/test/java/dev/amenhancer/module/config/TitleCorrectionModeTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/config/TitleCorrectionModeTest.kt
@@ -1,0 +1,33 @@
+package dev.amenhancer.module.config
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TitleCorrectionModeTest {
+    @Test
+    fun `profiles map to their fixed storefront and language`() {
+        assertEquals("cn", TitleCorrectionMode.MAINLAND_CHINA.catalogStorefront)
+        assertEquals("zh-CN", TitleCorrectionMode.MAINLAND_CHINA.catalogLanguage)
+        assertEquals("jp", TitleCorrectionMode.JAPAN.catalogStorefront)
+        assertEquals("ja-JP", TitleCorrectionMode.JAPAN.catalogLanguage)
+        assertNull(TitleCorrectionMode.ORIGINAL_HYPER.catalogLanguage)
+    }
+
+    @Test
+    fun `legacy target language migration only recognizes mainland and japan`() {
+        assertEquals(
+            TitleCorrectionMode.MAINLAND_CHINA,
+            TitleCorrectionMode.fromLegacyTargetLanguage("zh_cn"),
+        )
+        assertEquals(
+            TitleCorrectionMode.JAPAN,
+            TitleCorrectionMode.fromLegacyTargetLanguage("ja-JP"),
+        )
+        assertEquals(
+            TitleCorrectionMode.ORIGINAL_HYPER,
+            TitleCorrectionMode.fromLegacyTargetLanguage("ko-KR"),
+        )
+    }
+
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/CatalogLanguageCompositionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/CatalogLanguageCompositionTest.kt
@@ -17,7 +17,7 @@ class CatalogLanguageCompositionTest {
         val headers = CatalogLanguageRewritePolicy.withHeaderLanguageValue(source, "ja-JP")
 
         assertEquals("ja-JP", raw["l"])
-        assertEquals("ja-JP", headers["Accept-Language"])
+        assertEquals("ja", headers["Accept-Language"])
     }
 
     @Test

--- a/app/src/test/java/dev/amenhancer/module/hook/HleArtistLanguageStructuralTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/HleArtistLanguageStructuralTest.kt
@@ -18,9 +18,11 @@ class HleArtistLanguageStructuralTest {
             "app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleInternalCatalogResolver.kt",
         )
         assertFalse(resolver.contains("probeOriginalArtistLanguage"))
-        assertTrue(resolver.contains("artistLanguages = listOfNotNull(cachedArtistLanguage)"))
-        assertTrue(resolver.contains("originKnownFromArtist"))
-        assertTrue(resolver.contains("hasCjkArtistScript"))
+        assertFalse(resolver.contains("artistLanguages = listOfNotNull(cachedArtistLanguage)"))
+        assertFalse(resolver.contains("originKnownFromArtist"))
+        assertFalse(resolver.contains("trustedArtistOnlyLanguages"))
+        assertTrue(resolver.contains("originKnown = isrc != null"))
+        assertTrue(resolver.contains("isConfidentOriginalSongAlias"))
     }
 
     @Test

--- a/app/src/test/java/dev/amenhancer/module/hook/HleMetadataIntegrationStructuralTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/HleMetadataIntegrationStructuralTest.kt
@@ -13,16 +13,13 @@ class HleMetadataIntegrationStructuralTest {
         ?: error("Missing $relative")
 
     @Test
-    fun `title switch installs HLE metadata runtime and optional catalog language target`() {
+    fun `title switch installs HLE metadata runtime without global catalog language target`() {
         val feature = source("app/src/main/java/dev/amenhancer/module/hook/TitleCorrectionFeature.kt")
         val installation = source("app/src/main/java/dev/amenhancer/module/hook/FeatureInstallation.kt")
         assertTrue(feature.contains("hleMetadata.install()"))
         assertFalse(installation.contains("LibraryRefreshFeature()"))
-        assertTrue(installation.contains("CatalogLanguageFeature()"))
-        assertTrue(
-            installation.indexOf("CatalogLanguageFeature()") <
-                installation.indexOf("TitleCorrectionFeature()"),
-        )
+        assertFalse(installation.contains("CatalogLanguageFeature()"))
+        assertTrue(installation.contains("TitleCorrectionFeature()"))
     }
 
     @Test
@@ -60,15 +57,43 @@ class HleMetadataIntegrationStructuralTest {
     }
 
     @Test
-    fun `new metadata lookups install HLE storefront and language request rewriting`() {
+    fun `new metadata lookups scope storefront and language rewriting to HLE tokens`() {
         val runtime = source("app/src/main/java/dev/amenhancer/module/hook/HleMetadataRuntime.kt")
+        val localization = source(
+            "app/src/main/java/io/github/proify/lyricon/amprovider/xposed/hooks/AppleContentLocalizationHooks.kt",
+        )
+        val resolver = source(
+            "app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleInternalCatalogResolver.kt",
+        )
+        assertTrue(runtime.contains("mode.contentUiLanguageSelection"))
+        assertTrue(runtime.contains("cacheNamespace = mode.cacheNamespace"))
         assertTrue(runtime.contains("contentLocalizationHooks.installMediaApiLocalization()"))
         assertTrue(runtime.contains("contentLocalizationHooks.installContentHttpLocalization()"))
-        assertTrue(
-            source(
-                "app/src/main/java/io/github/proify/lyricon/amprovider/xposed/hooks/AppleContentLocalizationHooks.kt",
-            ).contains("Accept-Language"),
+        assertTrue(localization.contains("resolver.catalogRequestLocalization(requestToken)"))
+        assertTrue(localization.contains("resolver.activeCatalogRequestLocalization()"))
+        assertTrue(localization.contains("if (requestLocalization == null) return@installHook"))
+        assertFalse(localization.contains("resolver.applyContentUiLanguage(selection)"))
+        assertTrue(localization.contains("Accept-Language"))
+        assertFalse(resolver.contains("restoreConfiguredStorefront(access)"))
+    }
+
+    @Test
+    fun `fixed region lookups retain HLE identity and ISRC fallback`() {
+        val resolver = source(
+            "app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleInternalCatalogResolver.kt",
         )
+        assertTrue(resolver.contains("resolveLocalizedRequestByLockedIsrc"))
+        assertTrue(resolver.contains("enqueueLockedIsrcFallback"))
+        assertTrue(resolver.contains("lockedIsrcFallbackPending"))
+        assertTrue(resolver.contains("MAX_LOCKED_ISRC_FALLBACK_RUNNING"))
+        assertTrue(resolver.contains("resolveCatalogIdentity(identityId, emptyList())"))
+        assertTrue(resolver.contains("queryByIsrc("))
+        assertTrue(resolver.contains("storefrontOverride = request.storefront"))
+        val batchCompletion = resolver
+            .substringAfter("matches.forEach")
+            .substringBefore("private fun enqueueLockedIsrcFallback")
+        assertTrue(batchCompletion.contains("enqueueLockedIsrcFallback(request)"))
+        assertFalse(batchCompletion.contains("resolveLocalizedRequestByLockedIsrc(request)"))
     }
 
     @Test
@@ -268,25 +293,34 @@ class HleMetadataIntegrationStructuralTest {
     }
 
     @Test
-    fun `settings expose target language without restoring refresh action`() {
+    fun `settings expose profile selector without restoring refresh action`() {
         val standalone = source("app/src/main/java/dev/amenhancer/module/ui/SettingsActivity.kt")
         val embedded = source("app/src/main/java/dev/amenhancer/module/ui/EmbeddedSettingsHost.kt")
         assertTrue(standalone.contains("歌曲名显示修正"))
         assertTrue(embedded.contains("歌曲名显示修正"))
-        assertTrue(standalone.contains("目标语言"))
-        assertTrue(embedded.contains("目标语言"))
+        assertTrue(standalone.contains("歌曲名修正模式"))
+        assertTrue(embedded.contains("歌曲名修正模式"))
+        assertTrue(standalone.contains("titleCorrectionMode"))
+        assertTrue(embedded.contains("titleCorrectionMode"))
         assertFalse(standalone.contains("刷新资料库"))
         assertFalse(embedded.contains("刷新资料库"))
     }
 
     @Test
-    fun `schema owns optional target language and HLE token requests bypass it`() {
+    fun `schema owns the profile selector and HLE token requests remain isolated`() {
         val schema = source("app/src/main/java/dev/amenhancer/module/config/ModuleSettingsSchema.kt")
         val target = source(
             "app/src/main/java/dev/amenhancer/module/hook/AppleMusicCatalogLanguageTarget.kt",
         )
+        val bridge = source("app/src/main/java/dev/amenhancer/module/hook/HleMetadataSurfaceBridge.kt")
+        assertTrue(schema.contains("KEY_TITLE_CORRECTION_MODE"))
         assertTrue(schema.contains("KEY_TITLE_CORRECTION_TARGET_LANGUAGE"))
         assertTrue(target.contains("isHleResolverRequest"))
         assertTrue(target.contains("CATALOG_REQUEST_TOKEN_PARAM"))
+        assertTrue(target.contains("Global Catalog locale hooks disabled"))
+        assertFalse(target.contains("ModernXposedRuntime.hookMethod"))
+        assertTrue(bridge.contains("MediaMetadataCache.setProfile(profileId)"))
+        assertTrue(bridge.contains("if (MediaMetadataCache.profile() != profileId)"))
+        assertTrue(bridge.contains("restoreOriginalMetadata"))
     }
 }

--- a/app/src/test/java/dev/amenhancer/module/hook/HleMetadataIntegrationStructuralTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/HleMetadataIntegrationStructuralTest.kt
@@ -94,6 +94,15 @@ class HleMetadataIntegrationStructuralTest {
             .substringBefore("private fun enqueueLockedIsrcFallback")
         assertTrue(batchCompletion.contains("enqueueLockedIsrcFallback(request)"))
         assertFalse(batchCompletion.contains("resolveLocalizedRequestByLockedIsrc(request)"))
+        val fallbackScheduler = resolver
+            .substringAfter("private fun scheduleLockedIsrcFallbacks")
+            .substringBefore("private fun resolveLocalizedRequestByLockedIsrc")
+        assertTrue(fallbackScheduler.contains("currentRequestPriority(task.request.mediaId"))
+        assertTrue(fallbackScheduler.contains("selectNextRequestIndex(priorities)"))
+        val priorityUpdate = resolver
+            .substringAfter("private fun updatePendingRequestPriorities")
+            .substringBefore("private fun currentScopedPriority")
+        assertTrue(priorityUpdate.contains("scheduleLockedIsrcFallbacks()"))
     }
 
     @Test

--- a/app/src/test/java/io/github/proify/lyricon/amprovider/xposed/AppleInternalCatalogResolverPriorityTest.kt
+++ b/app/src/test/java/io/github/proify/lyricon/amprovider/xposed/AppleInternalCatalogResolverPriorityTest.kt
@@ -1,0 +1,33 @@
+package io.github.proify.lyricon.amprovider.xposed
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AppleInternalCatalogResolverPriorityTest {
+    @Test
+    fun `fallback selector favors visible requests over FIFO order`() {
+        assertEquals(
+            1,
+            AppleInternalCatalogResolver.selectNextRequestIndex(
+                listOf(
+                    AppleInternalCatalogResolver.RequestPriority.BACKGROUND,
+                    AppleInternalCatalogResolver.RequestPriority.VISIBLE,
+                    AppleInternalCatalogResolver.RequestPriority.ACTIVE_PAGE,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `fallback selector keeps FIFO order for equal priorities`() {
+        assertEquals(
+            0,
+            AppleInternalCatalogResolver.selectNextRequestIndex(
+                listOf(
+                    AppleInternalCatalogResolver.RequestPriority.ACTIVE_PAGE,
+                    AppleInternalCatalogResolver.RequestPriority.ACTIVE_PAGE,
+                ),
+            ),
+        )
+    }
+}

--- a/app/src/test/java/io/github/proify/lyricon/amprovider/xposed/ConfiguredMetadataRetryPolicyTest.kt
+++ b/app/src/test/java/io/github/proify/lyricon/amprovider/xposed/ConfiguredMetadataRetryPolicyTest.kt
@@ -1,0 +1,42 @@
+package io.github.proify.lyricon.amprovider.xposed
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ConfiguredMetadataRetryPolicyTest {
+    @Test
+    fun `override store expires configured misses instead of keeping a permanent tombstone`() {
+        val store = AppleMetadataOverrideStore()
+        store.markConfiguredMiss("cn:SONG:42:42", nowUptimeMillis = 1_000L)
+
+        assertTrue(store.isConfiguredMiss("cn:SONG:42:42", nowUptimeMillis = 1_001L))
+        assertFalse(store.isConfiguredMiss("cn:SONG:42:42", nowUptimeMillis = 11_000L))
+    }
+
+    @Test
+    fun `recent configured miss is suppressed but expires`() {
+        assertTrue(
+            ConfiguredMetadataRetryPolicy.shouldSkip(
+                lastMissUptimeMillis = 1_000L,
+                nowUptimeMillis = 1_001L,
+            ),
+        )
+        assertFalse(
+            ConfiguredMetadataRetryPolicy.shouldSkip(
+                lastMissUptimeMillis = 1_000L,
+                nowUptimeMillis = 11_000L,
+            ),
+        )
+    }
+
+    @Test
+    fun `clock rollback does not suppress forever`() {
+        assertFalse(
+            ConfiguredMetadataRetryPolicy.shouldSkip(
+                lastMissUptimeMillis = 2_000L,
+                nowUptimeMillis = 1_999L,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/io/github/proify/lyricon/amprovider/xposed/MediaMetadataCacheProfileTest.kt
+++ b/app/src/test/java/io/github/proify/lyricon/amprovider/xposed/MediaMetadataCacheProfileTest.kt
@@ -1,0 +1,35 @@
+package io.github.proify.lyricon.amprovider.xposed
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class MediaMetadataCacheProfileTest {
+    @After
+    fun restoreDefaultProfile() {
+        MediaMetadataCache.setProfile("account")
+        MediaMetadataCache.clearProfile()
+    }
+
+    @Test
+    fun `metadata is namespaced by the active profile`() {
+        val metadata = MediaMetadataCache.Metadata(
+            id = "42",
+            title = "Song",
+            artist = "Artist",
+            genre = null,
+            duration = 0L,
+            queueId = 0L,
+        )
+
+        MediaMetadataCache.setProfile("cn_v1")
+        MediaMetadataCache.put(metadata)
+        assertEquals("Song", MediaMetadataCache.getMetadataById("42")?.title)
+
+        MediaMetadataCache.setProfile("jp_v1")
+        assertNull(MediaMetadataCache.getMetadataById("42"))
+        MediaMetadataCache.put(metadata.copy(title = "曲"))
+        assertEquals("曲", MediaMetadataCache.getMetadataById("42")?.title)
+    }
+}

--- a/app/src/test/java/io/github/proify/lyricon/amprovider/xposed/OriginalArtistLanguageEvidenceTest.kt
+++ b/app/src/test/java/io/github/proify/lyricon/amprovider/xposed/OriginalArtistLanguageEvidenceTest.kt
@@ -52,21 +52,13 @@ class OriginalArtistLanguageEvidenceTest {
     }
 
     @Test
-    fun sameEnglishTitleCanApplyConfirmedJapaneseArtistAlias() {
+    fun sameEnglishTitleDoesNotApplyJapaneseArtistOnlyAlias() {
         val alias = AppleInternalCatalogResolver.Alias(
             title = "Let Me Know",
             artist = "當山 みれい",
             language = "ja-JP",
         )
 
-        assertTrue(
-            AppleInternalCatalogResolver.isConfidentOriginalSongAlias(
-                alias = alias,
-                localizedTitle = "Let Me Know",
-                localizedArtist = "MIREI",
-                allowArtistOnly = true,
-            ),
-        )
         assertFalse(
             AppleInternalCatalogResolver.isConfidentOriginalSongAlias(
                 alias = alias,
@@ -89,7 +81,23 @@ class OriginalArtistLanguageEvidenceTest {
                 alias = alias,
                 localizedTitle = "Let Me Know",
                 localizedArtist = "MIREI",
-                allowArtistOnly = true,
+            ),
+        )
+    }
+
+    @Test
+    fun oneRepublicJapaneseStorefrontArtistAliasIsNotAnOriginalSongAlias() {
+        val alias = AppleInternalCatalogResolver.Alias(
+            title = "I Ain't Worried",
+            artist = "ワンリパブリック",
+            language = "ja-JP",
+        )
+
+        assertFalse(
+            AppleInternalCatalogResolver.isConfidentOriginalSongAlias(
+                alias = alias,
+                localizedTitle = "I Ain't Worried",
+                localizedArtist = "OneRepublic",
             ),
         )
     }
@@ -102,26 +110,4 @@ class OriginalArtistLanguageEvidenceTest {
         )
     }
 
-    @Test
-    fun trustedArtistOnlyLanguageMustMatchTheAliasLanguage() {
-        val japaneseAlias = AppleInternalCatalogResolver.Alias(
-            title = "Let Me Know",
-            artist = "當山 みれい",
-            language = "ja-JP",
-        )
-        val koreanAlias = japaneseAlias.copy(
-            artist = "방탄소년단",
-            language = "ko-KR",
-        )
-        val resolution = AppleInternalCatalogResolver.OriginalResolution(
-            alias = japaneseAlias,
-            language = "ja-JP",
-            originKnown = true,
-            artistIds = listOf("882739606"),
-            trustedArtistOnlyLanguages = setOf("ja-JP"),
-        )
-
-        assertTrue(hasTrustedOriginalArtistOnlyLanguage(resolution, japaneseAlias))
-        assertFalse(hasTrustedOriginalArtistOnlyLanguage(resolution, koreanAlias))
-    }
 }

--- a/app/src/test/java/io/github/proify/lyricon/amprovider/xposed/OriginalMetadataCacheGenerationTest.kt
+++ b/app/src/test/java/io/github/proify/lyricon/amprovider/xposed/OriginalMetadataCacheGenerationTest.kt
@@ -7,15 +7,15 @@ class OriginalMetadataCacheGenerationTest {
     @Test
     fun storefrontArtistLocalizationCachesUseASeparateGeneration() {
         assertEquals(
-            5,
+            1,
             AppleOriginalMetadataCache.currentDatabaseVersionForTest(),
         )
         assertEquals(
-            "hyperlyricsenhanced_apple_original_metadata_v5.db",
+            "hyperlyricsenhanced_apple_original_metadata_original_hyper_v1.db",
             AppleOriginalMetadataCache.currentDatabaseNameForTest(),
         )
         assertEquals(
-            "hyperlyricsenhanced_apple_original_artist_regions_v5",
+            "hyperlyricsenhanced_apple_original_artist_regions_original_hyper_v1",
             AppleOriginalMetadataCache.currentArtistRegionPreferencesNameForTest(),
         )
     }


### PR DESCRIPTION
## Summary
- keep the original HLE metadata resolution flow for fixed China/Japan profiles
- fall back from locked-storefront ID misses through neutral Catalog identity and ISRC lookup, while keeping the follow-up request locked to the selected storefront/language
- keep locale rewriting scoped to resolver tokens/active request scope so ordinary Apple Music traffic follows the account region
- make configured misses retryable after a short TTL
- bound fixed-region identity/ISRC fallback work with a dedicated queue (at most 2 chains in flight), preventing a 50-item miss batch from fanning out into 50 simultaneous requests
- dispatch queued fallbacks by the latest effective request priority, preserving visible-page responsiveness while retaining FIFO order for equal priorities
- migrate embedded v11 legacy title-correction language to the new profile before removing the obsolete key; retain the legacy key if the write fails
- release as version 1.5.4 while retaining versionCode 103

## Validation
- :app:testDebugUnitTest (721 tests)
- :app:assembleDebug
- :app:assembleRelease
- APK manifest reports versionName 1.5.4 / versionCode 103
- APK Signature Scheme v2 verification
- git diff --check

Release APK SHA-256: 1E1C2C59BB54EF00AE3558EC050B154CD5C2980EE46AC3DA35FD78FCCFF20FD6
Debug APK SHA-256: 6DD857779D4DA2CB16F0F9278C566F5919C7C31587A492F43ED61C8DC25E5BD1