### PR TITLE
Improve tablet dual-pane player layout

### DIFF
--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
@@ -80,7 +80,7 @@ private object RightLyricsPaneLayout {
     private const val CONTROLS_TAP_TARGET = "controls_tap_target"
     private const val ALPHA_GRADIENT_FRAME_LAYOUT =
         "com.apple.android.music.common.views.AlphaGradientFrameLayout"
-    private const val TOP_EDGE_FRACTION = 0.30f
+    private const val TOP_EDGE_FRACTION = 0.15f
     private const val TOP_CLEAR_FRACTION = 0.075f
     private const val TOP_CLEAR_WITHIN_FADE_FRACTION = 0.25f
     private const val BOTTOM_EDGE_FRACTION = 0.15f
@@ -158,6 +158,22 @@ private object RightLyricsPaneLayout {
                 ?: error("AlphaGradientFrameLayout.e was unavailable")
             topFadeColorsField.set(gradients, topFadeColors)
             topFadePositionsField.set(gradients, topFadePositions)
+            val bottomFadeColors = intArrayOf(
+                Color.BLACK,
+                Color.TRANSPARENT,
+                Color.TRANSPARENT,
+            )
+            val bottomFadePositions = floatArrayOf(
+                0f,
+                1f - TOP_CLEAR_WITHIN_FADE_FRACTION,
+                1f,
+            )
+            val bottomFadeColorsField = findField(gradients.javaClass, "b")
+                ?: error("AlphaGradientFrameLayout.b was unavailable")
+            val bottomFadePositionsField = findField(gradients.javaClass, "f")
+                ?: error("AlphaGradientFrameLayout.f was unavailable")
+            bottomFadeColorsField.set(gradients, bottomFadeColors)
+            bottomFadePositionsField.set(gradients, bottomFadePositions)
             val topEdgeSize = (gradients.height * TOP_EDGE_FRACTION)
                 .roundToInt()
                 .coerceAtLeast(1)
@@ -479,7 +495,8 @@ internal class AppleMusicDualPaneTarget(
             return TargetCapabilityInstall.Degraded(
                 "Installed controller=$controllerHooks navigationMeasure=$navigationMenuMeasureHooks " +
                     "chrome=$chromeHooks lyricsChrome=$lyricsChromeHooks " +
-                    "lyricsMetrics=$lyricsMetricsHooks lyricsTypography=$lyricsTypographyHooks " +
+                    "lyricsMetrics=$lyricsMetricsHooks " +
+                    "lyricsTypography=$lyricsTypographyHooks " +
                     "staticIntercept=$staticInterceptStatus hook(s)" +
                     failureSummary,
             )
@@ -1154,6 +1171,8 @@ private object ConstraintLayoutPane {
     private const val PLAYER_CONTAINER = "player_container"
     private const val PLAYER_SHEET_CONTAINER = "player_sheet_container"
     private const val PLAYER_CONTAINER_ELEVATION = "player_container_elevation"
+    private const val ARTWORK_CONTAINER = "artwork_container"
+    private const val METADATA_BARRIER_TOP = "metadata_barrier_top"
     private const val PLAYER_ROOT = "player_root"
     private const val PLAYER_FRAGMENTS_HOST = "player_fragments_host"
     private const val PARENT_ID = 0
@@ -1349,7 +1368,97 @@ private object ConstraintLayoutPane {
             },
         )
 
-        return DualPaneState(root, playerHost, lyricsHost)
+        val state = DualPaneState(root, playerHost, lyricsHost)
+        installTabletArtworkLayout(playerRoot, playerHost)
+        return state
+    }
+
+    /**
+     * Keep Apple's native cover size, but center it in the vertical interval
+     * from the left pane top to Apple's metadata barrier (the title row).
+     */
+    private fun installTabletArtworkLayout(
+        playerRoot: ViewGroup,
+        playerHost: View,
+    ) {
+        val artworkId = playerRoot.resources.getIdentifier(
+            ARTWORK_CONTAINER,
+            "id",
+            ModuleConstants.TARGET_PACKAGE,
+        )
+        if (artworkId == 0) return
+        val barrierId = playerRoot.resources.getIdentifier(
+            METADATA_BARRIER_TOP,
+            "id",
+            ModuleConstants.TARGET_PACKAGE,
+        )
+        if (barrierId == 0) return
+        val nativeSizeByArtwork = WeakHashMap<View, Int>()
+        fun apply() {
+            if (!TabletModeQualifier.isEligible(playerRoot.context)) return
+            val artwork = playerHost.findViewById<View>(artworkId) ?: return
+            val barrier = playerHost.findViewById<View>(barrierId) ?: return
+            val parent = artwork.parent as? ViewGroup ?: return
+            if (parent.width <= 0 || parent.height <= 0 || artwork.width <= 0) return
+            val nativeSizePx = nativeSizeByArtwork[artwork]
+                ?: artwork.width.takeIf { it > 0 }?.also { nativeSizeByArtwork[artwork] = it }
+                ?: return
+            val hostLocation = IntArray(2)
+            val windowRootLocation = IntArray(2)
+            val artworkLocation = IntArray(2)
+            val barrierLocation = IntArray(2)
+            playerHost.getLocationInWindow(hostLocation)
+            playerRoot.rootView.getLocationInWindow(windowRootLocation)
+            artwork.getLocationInWindow(artworkLocation)
+            barrier.getLocationInWindow(barrierLocation)
+            val statusBarInsetTopPx = playerRoot.rootWindowInsets?.systemWindowInsetTop
+                ?: playerRoot.resources.getIdentifier("status_bar_height", "dimen", "android")
+                    .takeIf { it != 0 }
+                    ?.let(playerRoot.resources::getDimensionPixelSize)
+                ?: 0
+            val intervalTopPx = maxOf(
+                hostLocation[1],
+                windowRootLocation[1] + statusBarInsetTopPx,
+            )
+            val availableHeightPx = (barrierLocation[1] - intervalTopPx).toFloat()
+            val layout = TabletArtworkLayoutPolicy.resolve(
+                availableHeightPx = availableHeightPx,
+                nativeSizePx = nativeSizePx.toFloat(),
+            ) ?: return
+            val params = artwork.layoutParams as? ViewGroup.MarginLayoutParams ?: return
+            if (constraintField(params.javaClass, "startToStart") == null) return
+            val sizePx = (layout.sizePx + 0.5f).toInt().coerceAtLeast(1)
+            val desiredArtworkTopPx = intervalTopPx + layout.edgeGapPx
+            val artworkDeltaPx = desiredArtworkTopPx - artworkLocation[1]
+            if (kotlin.math.abs(artworkDeltaPx) > 0.5f) {
+                artwork.translationY += artworkDeltaPx
+            }
+            val alreadyApplied =
+                params.width == sizePx &&
+                    params.height == sizePx &&
+                    params.topMargin == 0 &&
+                    params.bottomMargin == 0 &&
+                    constraintField(params.javaClass, "topToTop")?.getInt(params) == PARENT_ID &&
+                    constraintField(params.javaClass, "topToBottom")?.getInt(params) == -1
+            if (alreadyApplied) return
+            params.width = sizePx
+            params.height = sizePx
+            params.topMargin = 0
+            params.bottomMargin = 0
+            params.setObject("dimensionRatio", null)
+            params.setInt("topToTop", PARENT_ID)
+            params.setInt("topToBottom", -1)
+            artwork.layoutParams = params
+            artwork.requestLayout()
+        }
+        val listener = View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ -> apply() }
+        playerRoot.addOnLayoutChangeListener(listener)
+        (playerHost.parent as? View)
+            ?.takeUnless { it === playerRoot }
+            ?.addOnLayoutChangeListener(listener)
+        playerHost.addOnLayoutChangeListener(listener)
+        playerRoot.post { apply() }
+        playerHost.post { apply() }
     }
 
     private fun configureTabsFrame(

--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
@@ -937,13 +937,11 @@ internal class AppleMusicDualPaneTarget(
         invokeCompatible(transaction, listOf("e", "replace"), state.playerHost.id, songFragment, songTag)
         invokeCompatible(transaction, listOf("e", "replace"), state.lyricsHost.id, lyricsFragment, lyricsTag)
         invokeCompatible(transaction, listOf("h", "commit"), false)
-        state.artworkLayoutReapply?.let { reapply ->
-            // FragmentManager executes the commit on the main queue. Enqueue
-            // after it so the song fragment's artwork view exists before the
-            // first centering pass is attempted.
-            state.playerHost.post {
-                reapply()
-            }
+        // FragmentManager executes the commit on the main queue. Keep this
+        // post so the callback is requested after that transaction, while the
+        // callback itself waits for a measured pre-draw before applying layout.
+        state.playerHost.post {
+            state.artworkLayoutReapply?.invoke()
         }
         return true
     }
@@ -1181,6 +1179,7 @@ private object ConstraintLayoutPane {
     private const val PLAYER_CONTAINER_ELEVATION = "player_container_elevation"
     private const val ARTWORK_CONTAINER = "artwork_container"
     private const val METADATA_BARRIER_TOP = "metadata_barrier_top"
+    private const val ARTWORK_LAYOUT_REAPPLY_MAX_PRE_DRAWS = 8
     private const val PLAYER_ROOT = "player_root"
     private const val PLAYER_FRAGMENTS_HOST = "player_fragments_host"
     private const val PARENT_ID = 0
@@ -1401,15 +1400,15 @@ private object ConstraintLayoutPane {
         )
         if (barrierId == 0) return null
         val nativeSizeByArtwork = WeakHashMap<View, Int>()
-        fun apply() {
-            if (!TabletModeQualifier.isEligible(playerRoot.context)) return
-            val artwork = playerHost.findViewById<View>(artworkId) ?: return
-            val barrier = playerHost.findViewById<View>(barrierId) ?: return
-            val parent = artwork.parent as? ViewGroup ?: return
-            if (parent.width <= 0 || parent.height <= 0 || artwork.width <= 0) return
+        fun apply(): Boolean {
+            if (!TabletModeQualifier.isEligible(playerRoot.context)) return true
+            val artwork = playerHost.findViewById<View>(artworkId) ?: return false
+            val barrier = playerHost.findViewById<View>(barrierId) ?: return false
+            val parent = artwork.parent as? ViewGroup ?: return false
+            if (parent.width <= 0 || parent.height <= 0 || artwork.width <= 0) return false
             val nativeSizePx = nativeSizeByArtwork[artwork]
                 ?: artwork.width.takeIf { it > 0 }?.also { nativeSizeByArtwork[artwork] = it }
-                ?: return
+                ?: return false
             val hostLocation = IntArray(2)
             val windowRootLocation = IntArray(2)
             val artworkLocation = IntArray(2)
@@ -1431,9 +1430,9 @@ private object ConstraintLayoutPane {
             val layout = TabletArtworkLayoutPolicy.resolve(
                 availableHeightPx = availableHeightPx,
                 nativeSizePx = nativeSizePx.toFloat(),
-            ) ?: return
-            val params = artwork.layoutParams as? ViewGroup.MarginLayoutParams ?: return
-            if (constraintField(params.javaClass, "startToStart") == null) return
+            ) ?: return false
+            val params = artwork.layoutParams as? ViewGroup.MarginLayoutParams ?: return true
+            if (constraintField(params.javaClass, "startToStart") == null) return true
             val sizePx = (layout.sizePx + 0.5f).toInt().coerceAtLeast(1)
             val desiredArtworkTopPx = intervalTopPx + layout.edgeGapPx
             val artworkDeltaPx = desiredArtworkTopPx - artworkLocation[1]
@@ -1447,7 +1446,7 @@ private object ConstraintLayoutPane {
                     params.bottomMargin == 0 &&
                     constraintField(params.javaClass, "topToTop")?.getInt(params) == PARENT_ID &&
                     constraintField(params.javaClass, "topToBottom")?.getInt(params) == -1
-            if (alreadyApplied) return
+            if (alreadyApplied) return true
             params.width = sizePx
             params.height = sizePx
             params.topMargin = 0
@@ -1457,6 +1456,7 @@ private object ConstraintLayoutPane {
             params.setInt("topToBottom", -1)
             artwork.layoutParams = params
             artwork.requestLayout()
+            return true
         }
         val listener = View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ -> apply() }
         playerRoot.addOnLayoutChangeListener(listener)
@@ -1466,7 +1466,70 @@ private object ConstraintLayoutPane {
         playerHost.addOnLayoutChangeListener(listener)
         playerRoot.post { apply() }
         playerHost.post { apply() }
-        return { apply() }
+        fun scheduleArtworkLayoutReapplyAfterMeasure() {
+            var attemptsRemaining = ARTWORK_LAYOUT_REAPPLY_MAX_PRE_DRAWS
+            var observedTree: ViewTreeObserver? = null
+            var attachListener: View.OnAttachStateChangeListener? = null
+            lateinit var preDrawListener: ViewTreeObserver.OnPreDrawListener
+
+            fun removePreDrawListener() {
+                observedTree?.takeIf(ViewTreeObserver::isAlive)
+                    ?.removeOnPreDrawListener(preDrawListener)
+                observedTree = null
+            }
+
+            fun finish() {
+                removePreDrawListener()
+                attachListener?.let(playerHost::removeOnAttachStateChangeListener)
+                attachListener = null
+            }
+
+            fun registerPreDraw() {
+                if (!playerHost.isAttachedToWindow) return
+                val tree = playerHost.viewTreeObserver
+                if (!tree.isAlive) {
+                    playerHost.post { registerPreDraw() }
+                    return
+                }
+                removePreDrawListener()
+                observedTree = tree
+                playerHost.viewTreeObserver.addOnPreDrawListener(preDrawListener)
+            }
+
+            preDrawListener = ViewTreeObserver.OnPreDrawListener {
+                val applied = apply()
+                attemptsRemaining -= 1
+                if (applied || attemptsRemaining <= 0 || !playerHost.isAttachedToWindow) {
+                    finish()
+                } else {
+                    // A failed pre-draw may not itself cause another traversal
+                    // (for example while FragmentManager is still adding the
+                    // child). Keep the bounded retry observable to ViewRoot.
+                    playerHost.requestLayout()
+                }
+                true
+            }
+
+            val newAttachListener = object : View.OnAttachStateChangeListener {
+                override fun onViewAttachedToWindow(view: View) {
+                    view.removeOnAttachStateChangeListener(this)
+                    attachListener = null
+                    registerPreDraw()
+                }
+
+                override fun onViewDetachedFromWindow(view: View) {
+                    removePreDrawListener()
+                }
+            }
+            attachListener = newAttachListener
+            playerHost.addOnAttachStateChangeListener(newAttachListener)
+            if (playerHost.isAttachedToWindow) {
+                playerHost.removeOnAttachStateChangeListener(newAttachListener)
+                attachListener = null
+                registerPreDraw()
+            }
+        }
+        return ::scheduleArtworkLayoutReapplyAfterMeasure
     }
 
     private fun configureTabsFrame(

--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
@@ -937,6 +937,14 @@ internal class AppleMusicDualPaneTarget(
         invokeCompatible(transaction, listOf("e", "replace"), state.playerHost.id, songFragment, songTag)
         invokeCompatible(transaction, listOf("e", "replace"), state.lyricsHost.id, lyricsFragment, lyricsTag)
         invokeCompatible(transaction, listOf("h", "commit"), false)
+        state.artworkLayoutReapply?.let { reapply ->
+            // FragmentManager executes the commit on the main queue. Enqueue
+            // after it so the song fragment's artwork view exists before the
+            // first centering pass is attempted.
+            state.playerHost.post {
+                reapply()
+            }
+        }
         return true
     }
 
@@ -1368,9 +1376,8 @@ private object ConstraintLayoutPane {
             },
         )
 
-        val state = DualPaneState(root, playerHost, lyricsHost)
-        installTabletArtworkLayout(playerRoot, playerHost)
-        return state
+        val artworkLayoutReapply = installTabletArtworkLayout(playerRoot, playerHost)
+        return DualPaneState(root, playerHost, lyricsHost, artworkLayoutReapply)
     }
 
     /**
@@ -1380,19 +1387,19 @@ private object ConstraintLayoutPane {
     private fun installTabletArtworkLayout(
         playerRoot: ViewGroup,
         playerHost: View,
-    ) {
+    ): (() -> Unit)? {
         val artworkId = playerRoot.resources.getIdentifier(
             ARTWORK_CONTAINER,
             "id",
             ModuleConstants.TARGET_PACKAGE,
         )
-        if (artworkId == 0) return
+        if (artworkId == 0) return null
         val barrierId = playerRoot.resources.getIdentifier(
             METADATA_BARRIER_TOP,
             "id",
             ModuleConstants.TARGET_PACKAGE,
         )
-        if (barrierId == 0) return
+        if (barrierId == 0) return null
         val nativeSizeByArtwork = WeakHashMap<View, Int>()
         fun apply() {
             if (!TabletModeQualifier.isEligible(playerRoot.context)) return
@@ -1459,6 +1466,7 @@ private object ConstraintLayoutPane {
         playerHost.addOnLayoutChangeListener(listener)
         playerRoot.post { apply() }
         playerHost.post { apply() }
+        return { apply() }
     }
 
     private fun configureTabsFrame(
@@ -1772,6 +1780,7 @@ internal class DualPaneState(
     val root: ViewGroup,
     val playerHost: View,
     val lyricsHost: FrameLayout,
+    val artworkLayoutReapply: (() -> Unit)? = null,
 ) {
     var lyricsAttachRequested: Boolean = false
     var lyricsAttached: Boolean = false

--- a/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/AppleMusicDualPaneTarget.kt
@@ -1480,7 +1480,9 @@ private object ConstraintLayoutPane {
 
             fun finish() {
                 removePreDrawListener()
-                attachListener?.let(playerHost::removeOnAttachStateChangeListener)
+                attachListener?.let { listener ->
+                    playerHost.removeOnAttachStateChangeListener(listener)
+                }
                 attachListener = null
             }
 
@@ -1512,8 +1514,6 @@ private object ConstraintLayoutPane {
 
             val newAttachListener = object : View.OnAttachStateChangeListener {
                 override fun onViewAttachedToWindow(view: View) {
-                    view.removeOnAttachStateChangeListener(this)
-                    attachListener = null
                     registerPreDraw()
                 }
 
@@ -1524,8 +1524,6 @@ private object ConstraintLayoutPane {
             attachListener = newAttachListener
             playerHost.addOnAttachStateChangeListener(newAttachListener)
             if (playerHost.isAttachedToWindow) {
-                playerHost.removeOnAttachStateChangeListener(newAttachListener)
-                attachListener = null
                 registerPreDraw()
             }
         }

--- a/app/src/main/java/dev/amenhancer/module/hook/TabletArtworkLayoutPolicy.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/TabletArtworkLayoutPolicy.kt
@@ -1,0 +1,25 @@
+package dev.amenhancer.module.hook
+
+internal data class TabletArtworkLayout(
+    val sizePx: Float,
+    val edgeGapPx: Float,
+)
+
+/**
+ * Center the unchanged native cover inside the vertical interval between the
+ * player top and Apple's metadata barrier, leaving equal edge gaps whenever
+ * the native cover fits in that interval.
+ */
+internal object TabletArtworkLayoutPolicy {
+    fun resolve(
+        availableHeightPx: Float,
+        nativeSizePx: Float,
+    ): TabletArtworkLayout? {
+        if (availableHeightPx <= 0f || nativeSizePx <= 0f) return null
+        val edgeGapPx = ((availableHeightPx - nativeSizePx) / 2f).coerceAtLeast(0f)
+        return TabletArtworkLayout(
+            sizePx = nativeSizePx,
+            edgeGapPx = edgeGapPx,
+        )
+    }
+}

--- a/app/src/main/java/dev/amenhancer/module/hook/TabletLyricAnchorPolicy.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/TabletLyricAnchorPolicy.kt
@@ -10,5 +10,5 @@ internal object TabletLyricAnchorPolicy {
     }
 
     private const val STOCK_ANCHOR_FRACTION = 0.08f
-    private const val TARGET_ANCHOR_FRACTION = 0.33f
+    private const val TARGET_ANCHOR_FRACTION = 0.30f
 }

--- a/app/src/main/java/dev/amenhancer/module/hook/TabletLyricVisualPolicy.kt
+++ b/app/src/main/java/dev/amenhancer/module/hook/TabletLyricVisualPolicy.kt
@@ -28,10 +28,7 @@ internal object TabletLyricVisualPolicy {
         scaledDensity: Float,
     ): Float {
         if (scaledDensity <= 0f) return MIN_FONT_PX
-        val targetPx = max(
-            max(viewportHeightPx * FONT_HEIGHT_FRACTION, viewportWidthPx * FONT_WIDTH_FRACTION),
-            MIN_FONT_PX,
-        )
+        val targetPx = textSizePx(viewportWidthPx, viewportHeightPx)
         return targetPx / scaledDensity
     }
 
@@ -41,4 +38,8 @@ internal object TabletLyricVisualPolicy {
         isHighlighted: Boolean = false,
     ): Float = if (isHighlighted) 0f else max(focusBlurRadius, edgeBlurRadius)
     private const val EDGE_MAX_BLUR_PX = 5f
+    private fun textSizePx(viewportWidthPx: Float, viewportHeightPx: Float): Float = max(
+        max(viewportHeightPx * FONT_HEIGHT_FRACTION, viewportWidthPx * FONT_WIDTH_FRACTION),
+        MIN_FONT_PX,
+    )
 }

--- a/app/src/test/java/dev/amenhancer/module/hook/DualPaneStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/DualPaneStructuralRegressionTest.kt
@@ -115,6 +115,26 @@ class DualPaneStructuralRegressionTest {
     }
 
     @Test
+    fun `applies AMLL artwork size and title gap to the native left pane`() {
+        assertTrue(source.contains("private const val ARTWORK_CONTAINER = \"artwork_container\""))
+        assertTrue(source.contains("private const val METADATA_BARRIER_TOP = \"metadata_barrier_top\""))
+        assertTrue(source.contains("installTabletArtworkLayout(playerRoot, playerHost)"))
+        assertTrue(source.contains("TabletArtworkLayoutPolicy.resolve("))
+        assertTrue(source.contains("nativeSizeByArtwork[artwork]"))
+        assertTrue(source.contains("val statusBarInsetTopPx = playerRoot.rootWindowInsets?.systemWindowInsetTop"))
+        assertTrue(source.contains("windowRootLocation[1] + statusBarInsetTopPx"))
+        assertTrue(source.contains("val availableHeightPx = (barrierLocation[1] - intervalTopPx).toFloat()"))
+        assertTrue(source.contains("val desiredArtworkTopPx = intervalTopPx + layout.edgeGapPx"))
+        assertTrue(source.contains("artwork.translationY += artworkDeltaPx"))
+        assertTrue(source.contains("params.topMargin = 0"))
+        assertTrue(source.contains("params.bottomMargin = 0"))
+        assertTrue(source.contains("params.setObject(\"dimensionRatio\", null)"))
+        assertTrue(source.contains("params.setInt(\"topToTop\", PARENT_ID)"))
+        assertTrue(source.contains("params.setInt(\"topToBottom\", -1)"))
+        assertTrue(source.contains("nativeSizePx = nativeSizePx.toFloat()"))
+    }
+
+    @Test
     fun `reapplies bottom navigation params after target layout initialization`() {
         assertTrue(source.contains("bottomNavigation.post {"))
     }

--- a/app/src/test/java/dev/amenhancer/module/hook/DualPaneStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/DualPaneStructuralRegressionTest.kt
@@ -135,6 +135,20 @@ class DualPaneStructuralRegressionTest {
     }
 
     @Test
+    fun `reapplies artwork after paired fragments are committed`() {
+        val commitIndex = source.indexOf(
+            "invokeCompatible(transaction, listOf(\"h\", \"commit\"), false)",
+        )
+        val reapplyIndex = source.indexOf("state.artworkLayoutReapply?.let", commitIndex)
+        assertTrue(commitIndex >= 0)
+        assertTrue(reapplyIndex > commitIndex)
+        assertTrue(source.contains("val artworkLayoutReapply = installTabletArtworkLayout(playerRoot, playerHost)"))
+        assertTrue(source.contains("DualPaneState(root, playerHost, lyricsHost, artworkLayoutReapply)"))
+        assertTrue(source.contains("state.playerHost.post {"))
+        assertTrue(source.contains("reapply()"))
+    }
+
+    @Test
     fun `reapplies bottom navigation params after target layout initialization`() {
         assertTrue(source.contains("bottomNavigation.post {"))
     }

--- a/app/src/test/java/dev/amenhancer/module/hook/DualPaneStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/DualPaneStructuralRegressionTest.kt
@@ -135,17 +135,22 @@ class DualPaneStructuralRegressionTest {
     }
 
     @Test
-    fun `reapplies artwork after paired fragments are committed`() {
+    fun `waits for measured artwork after paired fragments are committed`() {
         val commitIndex = source.indexOf(
             "invokeCompatible(transaction, listOf(\"h\", \"commit\"), false)",
         )
-        val reapplyIndex = source.indexOf("state.artworkLayoutReapply?.let", commitIndex)
+        val reapplyIndex = source.indexOf("state.artworkLayoutReapply?.invoke()", commitIndex)
         assertTrue(commitIndex >= 0)
         assertTrue(reapplyIndex > commitIndex)
         assertTrue(source.contains("val artworkLayoutReapply = installTabletArtworkLayout(playerRoot, playerHost)"))
         assertTrue(source.contains("DualPaneState(root, playerHost, lyricsHost, artworkLayoutReapply)"))
-        assertTrue(source.contains("state.playerHost.post {"))
-        assertTrue(source.contains("reapply()"))
+        assertTrue(source.contains("ARTWORK_LAYOUT_REAPPLY_MAX_PRE_DRAWS"))
+        assertTrue(source.contains("scheduleArtworkLayoutReapplyAfterMeasure"))
+        assertTrue(source.contains("playerHost.viewTreeObserver.addOnPreDrawListener"))
+        assertTrue(source.contains("playerHost.addOnAttachStateChangeListener"))
+        assertTrue(source.contains("playerHost.removeOnAttachStateChangeListener"))
+        assertTrue(source.contains("playerHost.requestLayout()"))
+        assertTrue(source.contains("removeOnPreDrawListener"))
     }
 
     @Test
@@ -277,7 +282,7 @@ class DualPaneStructuralRegressionTest {
         assertTrue(source.contains("DualPaneShell.installImmediately(root)"))
         assertTrue(source.contains("installForControllerRoot(controllerInstance, param.result as? View, \"onCreateView\")"))
         assertFalse(source.contains("PendingDualPaneState"))
-        val synchronousInstallSource = source.substringBefore("private fun installFlatPlayerBoundarySync")
+        val synchronousInstallSource = source.substringBefore("private fun installTabletArtworkLayout")
         assertFalse(synchronousInstallSource.contains("addOnAttachStateChangeListener"))
         assertFalse(synchronousInstallSource.contains("onViewAttachedToWindow"))
         assertTrue(source.contains("[AMENH-2]"))

--- a/app/src/test/java/dev/amenhancer/module/hook/RightLyricsPaneStructuralRegressionTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/RightLyricsPaneStructuralRegressionTest.kt
@@ -36,10 +36,17 @@ class RightLyricsPaneStructuralRegressionTest {
         assertTrue(source.contains("rootParams.topMargin = 0"))
         assertTrue(source.contains("anchorTopToParent"))
         assertTrue(source.contains("configureVerticalGradientEdges"))
-        assertTrue(source.contains("TOP_EDGE_FRACTION = 0.30f"))
+        assertTrue(source.contains("TOP_EDGE_FRACTION = 0.15f"))
         assertTrue(source.contains("TOP_CLEAR_FRACTION = 0.075f"))
         assertTrue(source.contains("TOP_CLEAR_WITHIN_FADE_FRACTION = 0.25f"))
         assertTrue(source.contains("BOTTOM_EDGE_FRACTION = 0.15f"))
+        assertTrue(source.contains("val bottomFadeColors = intArrayOf("))
+        assertTrue(source.contains("val bottomFadePositions = floatArrayOf("))
+        assertTrue(source.contains("1f - TOP_CLEAR_WITHIN_FADE_FRACTION"))
+        assertTrue(source.contains("findField(gradients.javaClass, \"b\")"))
+        assertTrue(source.contains("findField(gradients.javaClass, \"f\")"))
+        assertTrue(source.contains("bottomFadeColorsField.set(gradients, bottomFadeColors)"))
+        assertTrue(source.contains("bottomFadePositionsField.set(gradients, bottomFadePositions)"))
         assertTrue(source.contains("topFadeColorsField.set(gradients, topFadeColors)"))
         assertTrue(source.contains("topFadePositionsField.set(gradients, topFadePositions)"))
         assertTrue(source.contains("setVerticalFadeSizes.invoke(gradients, topEdgeSize, bottomEdgeSize)"))
@@ -67,10 +74,9 @@ class RightLyricsPaneStructuralRegressionTest {
     }
 
     @Test
-    fun `reapplies the tablet highlight anchor after delayed sheet expansion`() {
+    fun `keeps the tablet highlight anchor fixed at thirty percent`() {
         assertTrue(source.contains("installHighlightAnchorResizeSync(fragment)"))
-        assertTrue(source.contains("container.addOnLayoutChangeListener"))
-        assertTrue(source.contains("bottom - top == oldBottom - oldTop"))
+        assertTrue(source.contains("container.addOnLayoutChangeListener(listener)"))
         assertTrue(source.contains("refreshHighlightAnchor(container, fragmentReference)"))
         assertTrue(compactSource.contains(
             "installHighlightAnchorResizeSync(fragment) TabletLyricTypography.attach(fragment)",
@@ -79,6 +85,13 @@ class RightLyricsPaneStructuralRegressionTest {
         assertTrue(source.contains("WeakReference(fragment)"))
         assertTrue(source.contains("LyricsLayoutFieldProfiles.resolve(fragment.javaClass)"))
         assertTrue(source.contains("profile.synchronizedMetrics.first()"))
+        assertTrue(compactSource.contains(
+            "currentOffset = highlightOffset.getInt(metrics), containerHeight = container.height",
+        ))
+        assertFalse(source.contains("LyricsViewModelSetCurrentHighlightedLine"))
+        assertFalse(source.contains("measuredHighlightedRowCenterOffset"))
+        assertFalse(source.contains("artworkCenterInContainerPx"))
+        assertFalse(source.contains("container.postDelayed("))
         assertTrue(source.contains("RightLyricsPaneLayout.reapplyVerticalGradientEdges(gradients)"))
     }
 

--- a/app/src/test/java/dev/amenhancer/module/hook/TabletArtworkLayoutPolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/TabletArtworkLayoutPolicyTest.kt
@@ -1,0 +1,53 @@
+package dev.amenhancer.module.hook
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TabletArtworkLayoutPolicyTest {
+    @Test
+    fun centersNativeCoverWithEqualTopAndTitleGaps() {
+        val layout = TabletArtworkLayoutPolicy.resolve(
+            availableHeightPx = 1_200f,
+            nativeSizePx = 600f,
+        )
+
+        requireNotNull(layout)
+        assertEquals(600f, layout.sizePx, 0.001f)
+        assertEquals(300f, layout.edgeGapPx, 0.001f)
+    }
+
+    @Test
+    fun keepsNativeSizeWhenAvailableIntervalIsTight() {
+        val layout = TabletArtworkLayoutPolicy.resolve(
+            availableHeightPx = 800f,
+            nativeSizePx = 800f,
+        )
+
+        requireNotNull(layout)
+        assertEquals(800f, layout.sizePx, 0.001f)
+        assertEquals(0f, layout.edgeGapPx, 0.001f)
+    }
+
+    @Test
+    fun doesNotShrinkNativeCoverWhenItExceedsAvailableInterval() {
+        val layout = TabletArtworkLayoutPolicy.resolve(
+            availableHeightPx = 600f,
+            nativeSizePx = 800f,
+        )
+
+        requireNotNull(layout)
+        assertEquals(800f, layout.sizePx, 0.001f)
+        assertEquals(0f, layout.edgeGapPx, 0.001f)
+    }
+
+    @Test
+    fun rejectsNonPositiveViewport() {
+        assertNull(
+            TabletArtworkLayoutPolicy.resolve(
+                availableHeightPx = 0f,
+                nativeSizePx = 400f,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/dev/amenhancer/module/hook/TabletLyricAnchorPolicyTest.kt
+++ b/app/src/test/java/dev/amenhancer/module/hook/TabletLyricAnchorPolicyTest.kt
@@ -5,9 +5,9 @@ import org.junit.Test
 
 class TabletLyricAnchorPolicyTest {
     @Test
-    fun `moves the synchronized highlight anchor from stock eight percent to thirty three percent`() {
+    fun `moves the synchronized highlight anchor from stock eight percent to fixed thirty percent`() {
         assertEquals(
-            787,
+            715,
             TabletLyricAnchorPolicy.highlightOffset(
                 currentOffset = 187,
                 containerHeight = 2_400,


### PR DESCRIPTION
## Summary
- keep the native tablet artwork size and center it between the status-bar bottom and the metadata title barrier
- use a stable synchronized-lyrics anchor at 30% of the lyrics container
- make top and bottom lyric fades symmetric at 15% while preserving the existing tablet typography and controls layout
- add policy and structural regression coverage for the artwork and lyrics geometry

## Testing
- .\gradlew :app:testDebugUnitTest :app:assembleRelease --no-daemon
- manually verified the release APK on emulator-5554 with Apple Music 6.5.x tablet dual-pane playback